### PR TITLE
Changes previous to new server feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,106 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Type --help to get a list of all the possible options of the script.
 
 ## Dependencies  
 * The scripts rely on [Biopython](www.biopython.org) to validate the PDB structures and calculate interatomic distances.
-* [freesasa](https://github.com/mittinatten/freesasa), with the parameter set used in NACCESS ([Chothia,1976](http://www.ncbi.nlm.nih.gov/pubmed/994183)), is also required for calculating the buried surface area.
+* [freesasa](https://github.com/mittinatten/freesasa), with the parameter set used in NACCESS ([Chothia,1976](http://www.ncbi.nlm.nih.gov/pubmed/994183)), is also required for calculating the buried surface area. Both 2.x and 1.x version series are supported.
 * [scikit-learn](https://github.com/scikit-learn/scikit-learn) for Python 3 is necessary to load and use the classifier.
 
 To install and use the scripts, just clone the git repository or download the tarball zip
@@ -42,3 +42,4 @@ through the appropriate environment variables ($PYTHONPATH).
 ## License  
 These utilities are open-source and licensed under the Apache License 2.0. For more information
 read the LICENSE file.
+

--- a/classify.py
+++ b/classify.py
@@ -15,8 +15,11 @@ __author__ = ["Katarina Elez", "Anna Vangone"]
 
 import sys
 import pickle
+import warnings
 
-features = sys.argv[1:]
 
-model = pickle.load(open('classifier.sav', 'rb'))
-print(model.predict([features])[0])
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    features = sys.argv[1:]
+    model = pickle.load(open('classifier.sav', 'rb'))
+    print(model.predict([features])[0])

--- a/classify.py
+++ b/classify.py
@@ -11,8 +11,9 @@ Interface classification methods developed by the Bonvin Lab.
 Classifier loader.
 """
 
-__author__ = ["Katarina Elez", "Anna Vangone"]
+__author__ = ["Katarina Elez", "Anna Vangone", "Brian Jimenez"]
 
+import os
 import sys
 import pickle
 import warnings
@@ -21,5 +22,6 @@ import warnings
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     features = sys.argv[1:]
-    model = pickle.load(open('classifier.sav', 'rb'))
+    base_path = os.path.dirname(os.path.realpath(__file__))
+    model = pickle.load(open(os.path.join(base_path, 'classifier.sav'), 'rb'))
     print(model.predict([features])[0])

--- a/interface_classifier.py
+++ b/interface_classifier.py
@@ -11,7 +11,7 @@ Biological/crystallographic interface classifier based on Intermolecular Contact
 
 from __future__ import print_function, division
 
-__author__ = ["Katarina Elez", "Anna Vangone", "Joao Rodrigues"]
+__author__ = ["Katarina Elez", "Anna Vangone", "Joao Rodrigues", "Brian Jimenez"]
 
 import os
 import sys
@@ -26,6 +26,7 @@ from lib.freesasa import execute_freesasa
 from lib.utils import _check_path
 from lib.parsers import parse_structure
 from lib import aa_properties
+
 
 def calculate_ic(structure, d_cutoff=5.0, selection=None):
     """
@@ -47,6 +48,7 @@ def calculate_ic(structure, d_cutoff=5.0, selection=None):
         raise ValueError('No contacts found for selection')
 
     return ic_list
+
 
 def analyse_contacts(contact_list):
     """
@@ -71,6 +73,7 @@ def analyse_contacts(contact_list):
         bins[res_j.resname] += 1
 
     return bins
+
 
 if __name__ == "__main__":
 

--- a/interface_classifier.py
+++ b/interface_classifier.py
@@ -168,7 +168,8 @@ if __name__ == "__main__":
     features = [str(bins[x]) for x in ['CP', 'AC', 'AP', 'AA', 
         'ALA', 'CYS', 'GLU', 'ASP', 'GLY', 'PHE', 'ILE', 'HIS', 'MET', 'LEU', 'GLN', 'PRO', 'SER', 'ARG', 'THR', 'VAL', 'TYR']]
     features.append(str(len(ic_network)/max_contacts))
-    prediction = os.popen('./classify.py '+' '.join(features)).read()
+    base_path = os.path.dirname(os.path.realpath(__file__))
+    prediction = os.popen(os.path.join(base_path, 'classify.py') + ' ' + ' '.join(features)).read()
     print('[+] Class: '+prediction)
 
     if cmd.quiet:

--- a/lib/freesasa.py
+++ b/lib/freesasa.py
@@ -34,7 +34,11 @@ def freesasa_version():
     cmd = '{0} -v'.format(FREESASA_BIN)
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
-    version_raw = (str(stdout, 'utf-8')).split(os.linesep)[0]
+    try:
+        version_raw = (str(stdout, 'utf-8')).split(os.linesep)[0]
+    except:
+        # Python 2.7
+        version_raw = str(stdout).split(os.linesep)[0]
     version = version_raw.replace("FreeSASA ", "")
     major, minor = version.split(".")[:2]
     return int(major), int(minor)
@@ -57,8 +61,7 @@ def execute_freesasa(structure, selection=None):
     try:
         major, minor = freesasa_version()
     except:
-        print('[!] error retrieving freesasa version', file=sys.stderr)
-        raise Exception()
+        raise IOError('[!] error retrieving freesasa version from {0}'.format(freesasa))
 
     if major < 2 and not os.path.isfile(param_f):
         raise IOError('[!] Atomic radii file not found at `{0}`'.format(param_f))

--- a/lib/freesasa.py
+++ b/lib/freesasa.py
@@ -60,7 +60,7 @@ def execute_freesasa(structure, selection=None):
     # Run freesasa
     # Save atomic asa output to another temp file
     _outf = tempfile.NamedTemporaryFile()
-    cmd = '{0} --B-value-file={1} -c {2} {3}'.format(freesasa, _outf.name, param_f, _pdbf.name)
+    cmd = '{0} {1} --format=pdb --radii=naccess -o {2}'.format(freesasa, _pdbf.name, _outf.name)
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
 

--- a/lib/freesasa.py
+++ b/lib/freesasa.py
@@ -26,6 +26,20 @@ except ImportError as e:
 from config import FREESASA_BIN, FREESASA_PAR
 from lib.aa_properties import rel_asa
 
+
+def freesasa_version():
+    """
+    Parses freesasa version and return two integers corresponding to major and minor
+    """
+    cmd = '{0} -v'.format(FREESASA_BIN)
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    version_raw = (str(stdout, 'utf-8')).split(os.linesep)[0]
+    version = version_raw.replace("FreeSASA ", "")
+    major, minor = version.split(".")[:2]
+    return int(major), int(minor)
+
+
 def execute_freesasa(structure, selection=None):
     """
     Runs the freesasa executable on a PDB file.
@@ -35,10 +49,18 @@ def execute_freesasa(structure, selection=None):
     """
     io = PDBIO()
 
+    # Check FreeSASA installation
     freesasa, param_f= FREESASA_BIN, FREESASA_PAR
+
     if not os.path.isfile(freesasa):
         raise IOError('[!] freesasa binary not found at `{0}`'.format(freesasa))
-    if not os.path.isfile(param_f):
+    try:
+        major, minor = freesasa_version()
+    except:
+        print('[!] error retrieving freesasa version', file=sys.stderr)
+        raise Exception()
+
+    if major < 2 and not os.path.isfile(param_f):
         raise IOError('[!] Atomic radii file not found at `{0}`'.format(param_f))
 
     # Rewrite PDB using Biopython to have a proper format
@@ -60,7 +82,11 @@ def execute_freesasa(structure, selection=None):
     # Run freesasa
     # Save atomic asa output to another temp file
     _outf = tempfile.NamedTemporaryFile()
-    cmd = '{0} {1} --format=pdb --radii=naccess -o {2}'.format(freesasa, _pdbf.name, _outf.name)
+
+    if major >= 2:
+        cmd = '{0} {1} --format=pdb --radii=naccess -o {2}'.format(freesasa, _pdbf.name, _outf.name)
+    else:
+        cmd = '{0} --B-value-file={1} -c {2} {3}'.format(freesasa, _outf.name, param_f, _pdbf.name)
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
 

--- a/test/1ppe/golden/1ppe.pdb
+++ b/test/1ppe/golden/1ppe.pdb
@@ -1,0 +1,2520 @@
+HEADER    HYDROLASE(SERINE PROTEINASE)            24-OCT-91   1PPE              
+TITLE     THE REFINED 2.0 ANGSTROMS X-RAY CRYSTAL STRUCTURE OF THE              
+TITLE    2 COMPLEX FORMED BETWEEN BOVINE BETA-TRYPSIN AND CMTI-I, A             
+TITLE    3 TRYPSIN INHIBITOR FROM SQUASH SEEDS (CUCURBITA MAXIMA):              
+TITLE    4 TOPOLOGICAL SIMILARITY OF THE SQUASH SEED INHIBITORS WITH            
+TITLE    5 THE CARBOXYPEPTIDASE A INHIBITOR FROM POTATOES                       
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: TRYPSIN;                                                   
+COMPND   3 CHAIN: E;                                                            
+COMPND   4 EC: 3.4.21.4;                                                        
+COMPND   5 ENGINEERED: YES;                                                     
+COMPND   6 MOL_ID: 2;                                                           
+COMPND   7 MOLECULE: TRYPSIN INHIBITOR CMTI-I;                                  
+COMPND   8 CHAIN: I;                                                            
+COMPND   9 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: BOS TAURUS;                                     
+SOURCE   3 ORGANISM_COMMON: CATTLE;                                             
+SOURCE   4 ORGANISM_TAXID: 9913;                                                
+SOURCE   5 ORGAN: SEED;                                                         
+SOURCE   6 MOL_ID: 2                                                            
+KEYWDS    HYDROLASE(SERINE PROTEINASE)                                          
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    W.BODE,R.HUBER                                                        
+REVDAT   3   24-FEB-09 1PPE    1       VERSN                                    
+REVDAT   2   01-APR-03 1PPE    1       JRNL                                     
+REVDAT   1   31-JAN-94 1PPE    0                                                
+JRNL        AUTH   W.BODE,H.J.GREYLING,R.HUBER,J.OTLEWSKI,T.WILUSZ              
+JRNL        TITL   THE REFINED 2.0 A X-RAY CRYSTAL STRUCTURE OF THE             
+JRNL        TITL 2 COMPLEX FORMED BETWEEN BOVINE BETA-TRYPSIN AND               
+JRNL        TITL 3 CMTI-I, A TRYPSIN INHIBITOR FROM SQUASH SEEDS                
+JRNL        TITL 4 (CUCURBITA MAXIMA). TOPOLOGICAL SIMILARITY OF THE            
+JRNL        TITL 5 SQUASH SEED INHIBITORS WITH THE CARBOXYPEPTIDASE A           
+JRNL        TITL 6 INHIBITOR FROM POTATOES                                      
+JRNL        REF    FEBS LETT.                    V. 242   285 1989              
+JRNL        REFN                   ISSN 0014-5793                               
+JRNL        PMID   2914611                                                      
+JRNL        DOI    10.1016/0014-5793(89)80486-7                                 
+REMARK   1                                                                      
+REMARK   1 REFERENCE 1                                                          
+REMARK   1  AUTH   W.BODE,R.HUBER                                               
+REMARK   1  TITL   LIGAND BINDING: PROTEINASE-PROTEIN INHIBITOR                 
+REMARK   1  TITL 2 INTERACTIONS                                                 
+REMARK   1  REF    CURR.OPIN.STRUCT.BIOL.        V.   1    45 1991              
+REMARK   1  REFN                   ISSN 0959-440X                               
+REMARK   1 REFERENCE 2                                                          
+REMARK   1  AUTH   T.A.HOLAK,W.BODE,R.HUBER,J.OTLEWSKI,T.WILUSZ                 
+REMARK   1  TITL   NUCLEAR MAGNETIC RESONANCE SOLUTION AND X-RAY                
+REMARK   1  TITL 2 STRUCTURES OF SQUASH TRYPSIN INHIBITOR EXHIBIT THE           
+REMARK   1  TITL 3 SAME CONFORMATION OF THE PROTEINASE BINDING LOOP             
+REMARK   1  REF    J.MOL.BIOL.                   V. 210   649 1989              
+REMARK   1  REFN                   ISSN 0022-2836                               
+REMARK   1 REFERENCE 3                                                          
+REMARK   1  AUTH   M.WIECZOREK,J.OTLEWSKI,J.COOK,K.PARKS,J.LELUK,               
+REMARK   1  AUTH 2 A.WILIMOWSKA-PELC,A.POLANOWSKI,T.WILUSZ,                     
+REMARK   1  AUTH 3 M.LASKOWSKI JUNIOR                                           
+REMARK   1  TITL   THE SQUASH FAMILY OF SERINE PROTEINASE INHIBITORS.           
+REMARK   1  TITL 2 AMINO ACID SEQUENCES AND ASSOCIATION EQUILIBRIUM             
+REMARK   1  TITL 3 CONSTANTS OF INHIBITORS FROM SQUASH, SUMMER                  
+REMARK   1  TITL 4 SQUASH, ZUCCHINI, AND CUCUMBER SEEDS                         
+REMARK   1  REF    BIOCHEM.BIOPHYS.RES.COMMUN.   V. 126   646 1985              
+REMARK   1  REFN                   ISSN 0006-291X                               
+REMARK   1 REFERENCE 4                                                          
+REMARK   1  AUTH   T.WILUSZ,M.WIECZOREK,A.POLANOWSKI,A.DENTON,J.COOK,           
+REMARK   1  AUTH 2 M.LASKOWSKI JUNIOR                                           
+REMARK   1  TITL   AMINO-ACID SEQUENCE OF TWO TRYPSIN ISOINHIBITORS,            
+REMARK   1  TITL 2 ITD I AND ITD III FROM SQUASH SEEDS (CUCURBITA               
+REMARK   1  TITL 3 MAXIMA)                                                      
+REMARK   1  REF    HOPPE-SEYLER'S                V. 364    93 1983              
+REMARK   1  REF  2 Z.PHYSIOL.CHEM.                                              
+REMARK   1  REFN                   ISSN 0018-4888                               
+REMARK   1 REFERENCE 5                                                          
+REMARK   1  AUTH   W.BODE,P.SCHWAGER                                            
+REMARK   1  TITL   THE REFINED CRYSTAL STRUCTURE OF BOVINE                      
+REMARK   1  TITL 2 BETA-TRYPSIN AT 1.8 ANGSTROMS RESOLUTION.                    
+REMARK   1  TITL 3 CRYSTALLOGRAPHIC REFINEMENT, CALCIUM BINDING SITE,           
+REMARK   1  TITL 4 BENZAMIDINE BINDING SITE AND ACTIVE SITE AT PH 7.0           
+REMARK   1  REF    J.MOL.BIOL.                   V.  98   693 1975              
+REMARK   1  REFN                   ISSN 0022-2836                               
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.00 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : EREF                                                 
+REMARK   3   AUTHORS     : JACK,LEVITT                                          
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.00                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 6.00                           
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : NULL                           
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : NULL                           
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : NULL                           
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : NULL                           
+REMARK   3   NUMBER OF REFLECTIONS             : NULL                           
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : NULL                            
+REMARK   3   FREE R VALUE TEST SET SELECTION  : NULL                            
+REMARK   3   R VALUE            (WORKING SET) : 0.151                           
+REMARK   3   FREE R VALUE                     : NULL                            
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : NULL                            
+REMARK   3   FREE R VALUE TEST SET COUNT      : NULL                            
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : NULL                            
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : NULL                         
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : NULL                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : NULL                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : NULL                         
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : NULL                         
+REMARK   3   BIN R VALUE           (WORKING SET) : NULL                         
+REMARK   3   BIN FREE R VALUE                    : NULL                         
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : NULL                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : NULL                         
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : NULL                         
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 1851                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 0                                       
+REMARK   3   SOLVENT ATOMS            : 140                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : NULL                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : NULL                           
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : NULL                            
+REMARK   3   ESD FROM SIGMAA              (A) : NULL                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : NULL                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : NULL                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : NULL                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.020                           
+REMARK   3   BOND ANGLES            (DEGREES) : 2.70                            
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : NULL                            
+REMARK   3   IMPROPER ANGLES        (DEGREES) : NULL                            
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : NULL                                      
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1PPE COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY BNL.                                
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : NULL                               
+REMARK 200  TEMPERATURE           (KELVIN) : NULL                               
+REMARK 200  PH                             : NULL                               
+REMARK 200  NUMBER OF CRYSTALS USED        : NULL                               
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : NULL                               
+REMARK 200  RADIATION SOURCE               : NULL                               
+REMARK 200  BEAMLINE                       : NULL                               
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : NULL                               
+REMARK 200  WAVELENGTH OR RANGE        (A) : NULL                               
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : NULL                               
+REMARK 200  DETECTOR MANUFACTURER          : NULL                               
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : NULL                               
+REMARK 200  DATA SCALING SOFTWARE          : NULL                               
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : NULL                               
+REMARK 200  RESOLUTION RANGE HIGH      (A) : NULL                               
+REMARK 200  RESOLUTION RANGE LOW       (A) : NULL                               
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : NULL                               
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY                : NULL                               
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : NULL                               
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : NULL                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : NULL                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : NULL                               
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: NULL                                           
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: NULL                         
+REMARK 200 SOFTWARE USED: SQUASH                                                
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 46.62                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.30                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: NULL                                     
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 21 21 21                       
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X+1/2,-Y,Z+1/2                                         
+REMARK 290       3555   -X,Y+1/2,-Z+1/2                                         
+REMARK 290       4555   X+1/2,-Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000       29.64000            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       37.29500            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       27.73500            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       37.29500            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       29.64000            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000       27.73500            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: DIMERIC                    
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 1680 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 9920 ANGSTROM**2                        
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -7.0 KCAL/MOL                         
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: E, I                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 480                                                                      
+REMARK 480 ZERO OCCUPANCY ATOM                                                  
+REMARK 480 THE FOLLOWING RESIDUES HAVE ATOMS MODELED WITH ZERO                  
+REMARK 480 OCCUPANCY. THE LOCATION AND PROPERTIES OF THESE ATOMS                
+REMARK 480 MAY NOT BE RELIABLE. (M=MODEL NUMBER; RES=RESIDUE NAME;              
+REMARK 480 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):         
+REMARK 480   M RES C SSEQI ATOMS                                                
+REMARK 480     VAL E   76   N                                                   
+REMARK 480     LYS E   87   CD                                                  
+REMARK 480     LYS E  145   CE    NZ                                            
+REMARK 480     SER E  147   OG                                                  
+REMARK 480     ASP E  165   OD1   OD2                                           
+REMARK 480     LYS E  169   NZ                                                  
+REMARK 480     GLU E  186   CG    CD    OE1   OE2                               
+REMARK 480     LYS E  188   NZ                                                  
+REMARK 480     LYS I   11   CD                                                  
+REMARK 480     GLU I   24   CD    OE1   OE2                                     
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS                                             
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS THAT ARE RELATED BY CRYSTALLOGRAPHIC             
+REMARK 500 SYMMETRY ARE IN CLOSE CONTACT.  AN ATOM LOCATED WITHIN 0.15          
+REMARK 500 ANGSTROMS OF A SYMMETRY RELATED ATOM IS ASSUMED TO BE ON A           
+REMARK 500 SPECIAL POSITION AND IS, THEREFORE, LISTED IN REMARK 375             
+REMARK 500 INSTEAD OF REMARK 500.  ATOMS WITH NON-BLANK ALTERNATE               
+REMARK 500 LOCATION INDICATORS ARE NOT INCLUDED IN THE CALCULATIONS.            
+REMARK 500                                                                      
+REMARK 500 DISTANCE CUTOFF:                                                     
+REMARK 500 2.2 ANGSTROMS FOR CONTACTS NOT INVOLVING HYDROGEN ATOMS              
+REMARK 500 1.6 ANGSTROMS FOR CONTACTS INVOLVING HYDROGEN ATOMS                  
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI  SSYMOP   DISTANCE          
+REMARK 500   O    HOH E   968     O    HOH E   970     3555     0.15            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND LENGTHS                                      
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,2(A3,1X,A1,I4,A1,1X,A4,3X),1X,F6.3)               
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   RES CSSEQI ATM2   DEVIATION                     
+REMARK 500    TRP E 141   NE1   TRP E 141   CE2    -0.083                       
+REMARK 500    TRP E 215   NE1   TRP E 215   CE2    -0.107                       
+REMARK 500    TRP E 237   NE1   TRP E 237   CE2    -0.094                       
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    SER E  61   N   -  CA  -  CB  ANGL. DEV. =  -9.1 DEGREES          
+REMARK 500    ARG E 117   NE  -  CZ  -  NH1 ANGL. DEV. =   3.1 DEGREES          
+REMARK 500    TYR E 151   CB  -  CG  -  CD1 ANGL. DEV. =  -4.4 DEGREES          
+REMARK 500    GLY E 174   C   -  N   -  CA  ANGL. DEV. = -13.3 DEGREES          
+REMARK 500    ARG I   1   NE  -  CZ  -  NH1 ANGL. DEV. =   7.5 DEGREES          
+REMARK 500    ARG I   1   NE  -  CZ  -  NH2 ANGL. DEV. =  -9.3 DEGREES          
+REMARK 500    GLU I   9   OE1 -  CD  -  OE2 ANGL. DEV. =  -7.5 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ASN E 115     -157.34   -149.00                                   
+REMARK 500    SER E 195      140.24    -37.55                                   
+REMARK 500    SER E 214      -65.57   -123.99                                   
+REMARK 500    ALA I  18     -127.27     55.88                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: NON-CIS, NON-TRANS                                         
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING PEPTIDE BONDS DEVIATE SIGNIFICANTLY FROM BOTH          
+REMARK 500 CIS AND TRANS CONFORMATION.  CIS BONDS, IF ANY, ARE LISTED           
+REMARK 500 ON CISPEP RECORDS.  TRANS IS DEFINED AS 180 +/- 30 AND               
+REMARK 500 CIS IS DEFINED AS 0 +/- 30 DEGREES.                                  
+REMARK 500                                 MODEL     OMEGA                      
+REMARK 500 GLU E   70     ASP E   71                  149.88                    
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: PLANAR GROUPS                                              
+REMARK 500                                                                      
+REMARK 500 PLANAR GROUPS IN THE FOLLOWING RESIDUES HAVE A TOTAL                 
+REMARK 500 RMS DISTANCE OF ALL ATOMS FROM THE BEST-FIT PLANE                    
+REMARK 500 BY MORE THAN AN EXPECTED VALUE OF 6*RMSD, WITH AN                    
+REMARK 500 RMSD 0.02 ANGSTROMS, OR AT LEAST ONE ATOM HAS                        
+REMARK 500 AN RMSD GREATER THAN THIS VALUE                                      
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        RMS     TYPE                                    
+REMARK 500    TYR E  39         0.10    SIDE_CHAIN                              
+REMARK 500    TYR E  59         0.07    SIDE_CHAIN                              
+REMARK 500    TYR E 228         0.06    SIDE_CHAIN                              
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: MAIN CHAIN PLANARITY                                       
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING RESIDUES HAVE A PSEUDO PLANARITY                       
+REMARK 500 TORSION, C(I) - CA(I) - N(I+1) - O(I), GREATER                       
+REMARK 500 10.0 DEGREES. (M=MODEL NUMBER; RES=RESIDUE NAME;                     
+REMARK 500 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;                            
+REMARK 500 I=INSERTION CODE).                                                   
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        ANGLE                                           
+REMARK 500    THR E  21         11.37                                           
+REMARK 500    LEU E  33         10.94                                           
+REMARK 500    SER E  37         12.96                                           
+REMARK 500    ILE E  47        -11.21                                           
+REMARK 500    CYS E  58         11.28                                           
+REMARK 500    GLU E  70        -10.21                                           
+REMARK 500    VAL E  76         10.18                                           
+REMARK 500    GLY E  78        -10.03                                           
+REMARK 500    LYS E 109        -11.04                                           
+REMARK 500    ALA E 111        -10.06                                           
+REMARK 500    SER E 120         12.62                                           
+REMARK 500    SER E 167        -10.36                                           
+REMARK 500    MET E 180        -10.99                                           
+REMARK 500    PRO E 198        -13.59                                           
+REMARK 500    LEU I  17        -10.45                                           
+REMARK 500    GLU I  19        -11.24                                           
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+DBREF  1PPE E   16   245  UNP    P00760   TRY1_BOVIN      21    243             
+DBREF  1PPE I    1    29  UNP    P01074   ITR1_CUCMA       1     29             
+SEQRES   1 E  223  ILE VAL GLY GLY TYR THR CYS GLY ALA ASN THR VAL PRO          
+SEQRES   2 E  223  TYR GLN VAL SER LEU ASN SER GLY TYR HIS PHE CYS GLY          
+SEQRES   3 E  223  GLY SER LEU ILE ASN SER GLN TRP VAL VAL SER ALA ALA          
+SEQRES   4 E  223  HIS CYS TYR LYS SER GLY ILE GLN VAL ARG LEU GLY GLU          
+SEQRES   5 E  223  ASP ASN ILE ASN VAL VAL GLU GLY ASN GLU GLN PHE ILE          
+SEQRES   6 E  223  SER ALA SER LYS SER ILE VAL HIS PRO SER TYR ASN SER          
+SEQRES   7 E  223  ASN THR LEU ASN ASN ASP ILE MET LEU ILE LYS LEU LYS          
+SEQRES   8 E  223  SER ALA ALA SER LEU ASN SER ARG VAL ALA SER ILE SER          
+SEQRES   9 E  223  LEU PRO THR SER CYS ALA SER ALA GLY THR GLN CYS LEU          
+SEQRES  10 E  223  ILE SER GLY TRP GLY ASN THR LYS SER SER GLY THR SER          
+SEQRES  11 E  223  TYR PRO ASP VAL LEU LYS CYS LEU LYS ALA PRO ILE LEU          
+SEQRES  12 E  223  SER ASP SER SER CYS LYS SER ALA TYR PRO GLY GLN ILE          
+SEQRES  13 E  223  THR SER ASN MET PHE CYS ALA GLY TYR LEU GLU GLY GLY          
+SEQRES  14 E  223  LYS ASP SER CYS GLN GLY ASP SER GLY GLY PRO VAL VAL          
+SEQRES  15 E  223  CYS SER GLY LYS LEU GLN GLY ILE VAL SER TRP GLY SER          
+SEQRES  16 E  223  GLY CYS ALA GLN LYS ASN LYS PRO GLY VAL TYR THR LYS          
+SEQRES  17 E  223  VAL CYS ASN TYR VAL SER TRP ILE LYS GLN THR ILE ALA          
+SEQRES  18 E  223  SER ASN                                                      
+SEQRES   1 I   29  ARG VAL CYS PRO ARG ILE LEU MET GLU CYS LYS LYS ASP          
+SEQRES   2 I   29  SER ASP CYS LEU ALA GLU CYS VAL CYS LEU GLU HIS GLY          
+SEQRES   3 I   29  TYR CYS GLY                                                  
+FORMUL   3  HOH   *140(H2 O)                                                    
+HELIX    1   1 ALA E   55  TYR E   59  5                                   5    
+HELIX    2   2 SER E  164  TYR E  172  1                                   9    
+HELIX    3   3 TYR E  234  SER E  244  1                                  11    
+HELIX    4   4 LYS I   12  CYS I   16  5                                   5    
+SHEET    1   A 7 MET E 180  ALA E 183  0                                        
+SHEET    2   A 7 GLY E 226  LYS E 230 -1  O  GLY E 226   N  ALA E 183           
+SHEET    3   A 7 LYS E 204  GLY E 216 -1  O  ILE E 212   N  THR E 229           
+SHEET    4   A 7 PRO E 198  CYS E 201 -1  N  VAL E 199   O  GLY E 211           
+SHEET    5   A 7 GLN E 135  GLY E 140 -1  N  LEU E 137   O  VAL E 200           
+SHEET    6   A 7 LYS E 156  PRO E 161 -1  O  LYS E 156   N  GLY E 140           
+SHEET    7   A 7 TYR E  20  THR E  21 -1  O  TYR E  20   N  CYS E 157           
+SHEET    1   B 4 MET E 180  ALA E 183  0                                        
+SHEET    2   B 4 GLY E 226  LYS E 230 -1  O  GLY E 226   N  ALA E 183           
+SHEET    3   B 4 LYS E 204  GLY E 216 -1  O  ILE E 212   N  THR E 229           
+SHEET    4   B 4 CYS I   3  PRO I   4 -1  N  CYS I   3   O  GLY E 216           
+SHEET    1   C 7 GLN E  30  ASN E  34  0                                        
+SHEET    2   C 7 HIS E  40  LEU E  46 -1  N  PHE E  41   O  LEU E  33           
+SHEET    3   C 7 TRP E  51  SER E  54 -1  N  VAL E  53   O  SER E  45           
+SHEET    4   C 7 MET E 104  LEU E 108 -1  N  MET E 104   O  SER E  54           
+SHEET    5   C 7 GLN E  81  VAL E  90 -1  N  SER E  86   O  LYS E 107           
+SHEET    6   C 7 GLN E  64  LEU E  67 -1  O  VAL E  65   N  ILE E  83           
+SHEET    7   C 7 GLN E  30  ASN E  34 -1  O  SER E  32   N  ARG E  66           
+SHEET    1   D 2 VAL I  21  CYS I  22  0                                        
+SHEET    2   D 2 CYS I  28  GLY I  29 -1  O  GLY I  29   N  VAL I  21           
+SSBOND   1 CYS E   22    CYS E  157                          1555   1555  2.00  
+SSBOND   2 CYS E   42    CYS E   58                          1555   1555  1.99  
+SSBOND   3 CYS E  128    CYS E  232                          1555   1555  2.05  
+SSBOND   4 CYS E  136    CYS E  201                          1555   1555  2.05  
+SSBOND   5 CYS E  168    CYS E  182                          1555   1555  2.00  
+SSBOND   6 CYS E  191    CYS E  220                          1555   1555  2.01  
+SSBOND   7 CYS I    3    CYS I   20                          1555   1555  2.01  
+SSBOND   8 CYS I   10    CYS I   22                          1555   1555  2.09  
+SSBOND   9 CYS I   16    CYS I   28                          1555   1555  2.07  
+CRYST1   59.280   55.470   74.590  90.00  90.00  90.00 P 21 21 21    4          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.016869  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.018028  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.013407        0.00000                         
+ATOM      1  N   ILE E  16      16.792  12.871   4.991  1.00  3.00           N  
+ATOM      2  CA  ILE E  16      17.415  14.067   5.486  1.00  3.00           C  
+ATOM      3  C   ILE E  16      17.370  15.207   4.480  1.00 11.29           C  
+ATOM      4  O   ILE E  16      18.040  15.120   3.445  1.00  3.00           O  
+ATOM      5  CB  ILE E  16      18.878  13.807   5.993  1.00  3.00           C  
+ATOM      6  CG1 ILE E  16      18.976  12.643   6.989  1.00  3.97           C  
+ATOM      7  CG2 ILE E  16      19.566  15.056   6.546  1.00  3.00           C  
+ATOM      8  CD1 ILE E  16      18.413  13.065   8.374  1.00  3.00           C  
+ATOM      9  N   VAL E  17      16.723  16.321   4.866  1.00  5.39           N  
+ATOM     10  CA  VAL E  17      16.732  17.608   4.076  1.00  5.62           C  
+ATOM     11  C   VAL E  17      17.820  18.575   4.601  1.00 10.26           C  
+ATOM     12  O   VAL E  17      17.908  18.931   5.774  1.00  5.92           O  
+ATOM     13  CB  VAL E  17      15.333  18.307   4.062  1.00  3.00           C  
+ATOM     14  CG1 VAL E  17      15.400  19.511   3.139  1.00  3.00           C  
+ATOM     15  CG2 VAL E  17      14.147  17.352   3.760  1.00  3.00           C  
+ATOM     16  N   GLY E  18      18.681  19.030   3.737  1.00  7.30           N  
+ATOM     17  CA  GLY E  18      19.574  20.103   4.153  1.00  3.00           C  
+ATOM     18  C   GLY E  18      20.879  19.538   4.650  1.00  3.00           C  
+ATOM     19  O   GLY E  18      21.505  20.190   5.470  1.00  9.38           O  
+ATOM     20  N   GLY E  19      21.113  18.305   4.421  1.00  3.00           N  
+ATOM     21  CA  GLY E  19      22.222  17.735   5.167  1.00  3.05           C  
+ATOM     22  C   GLY E  19      23.450  17.490   4.274  1.00  3.00           C  
+ATOM     23  O   GLY E  19      23.560  18.038   3.198  1.00  8.66           O  
+ATOM     24  N   TYR E  20      24.386  16.754   4.772  1.00  7.53           N  
+ATOM     25  CA  TYR E  20      25.610  16.442   4.055  1.00  3.97           C  
+ATOM     26  C   TYR E  20      25.788  14.913   4.069  1.00 19.80           C  
+ATOM     27  O   TYR E  20      24.973  14.142   4.560  1.00  4.96           O  
+ATOM     28  CB  TYR E  20      26.756  17.249   4.716  1.00  3.00           C  
+ATOM     29  CG  TYR E  20      27.093  16.767   6.145  1.00  5.92           C  
+ATOM     30  CD1 TYR E  20      27.993  15.705   6.378  1.00 15.27           C  
+ATOM     31  CD2 TYR E  20      26.423  17.320   7.210  1.00  7.76           C  
+ATOM     32  CE1 TYR E  20      28.223  15.208   7.683  1.00  6.86           C  
+ATOM     33  CE2 TYR E  20      26.637  16.835   8.508  1.00  3.91           C  
+ATOM     34  CZ  TYR E  20      27.527  15.801   8.743  1.00 14.47           C  
+ATOM     35  OH  TYR E  20      27.747  15.454  10.016  1.00  3.00           O  
+ATOM     36  N   THR E  21      26.768  14.446   3.403  1.00  3.73           N  
+ATOM     37  CA  THR E  21      26.992  13.011   3.250  1.00  4.27           C  
+ATOM     38  C   THR E  21      27.951  12.439   4.299  1.00  7.27           C  
+ATOM     39  O   THR E  21      28.944  13.068   4.640  1.00 14.62           O  
+ATOM     40  CB  THR E  21      27.633  12.835   1.854  1.00  3.00           C  
+ATOM     41  OG1 THR E  21      26.575  13.154   0.899  1.00  3.61           O  
+ATOM     42  CG2 THR E  21      28.083  11.399   1.747  1.00  4.15           C  
+ATOM     43  N   CYS E  22      27.464  11.530   5.079  1.00  3.94           N  
+ATOM     44  CA  CYS E  22      28.145  11.229   6.334  1.00  6.63           C  
+ATOM     45  C   CYS E  22      29.533  10.687   5.996  1.00 27.08           C  
+ATOM     46  O   CYS E  22      30.482  10.896   6.737  1.00 16.79           O  
+ATOM     47  CB  CYS E  22      27.424  10.112   7.119  1.00  3.00           C  
+ATOM     48  SG  CYS E  22      25.727  10.430   7.588  1.00  3.00           S  
+ATOM     49  N   GLY E  23      29.567   9.954   4.925  1.00 17.18           N  
+ATOM     50  CA  GLY E  23      30.711   9.158   4.490  1.00  6.72           C  
+ATOM     51  C   GLY E  23      30.477   7.731   4.972  1.00 29.82           C  
+ATOM     52  O   GLY E  23      29.943   7.492   6.072  1.00 12.89           O  
+ATOM     53  N   ALA E  24      30.992   6.857   4.153  1.00 19.66           N  
+ATOM     54  CA  ALA E  24      30.803   5.414   4.381  1.00 27.03           C  
+ATOM     55  C   ALA E  24      31.227   4.887   5.732  1.00 22.52           C  
+ATOM     56  O   ALA E  24      32.345   5.125   6.171  1.00 12.04           O  
+ATOM     57  CB  ALA E  24      31.399   4.539   3.272  1.00 22.29           C  
+ATOM     58  N   ASN E  25      30.272   4.211   6.378  1.00 17.58           N  
+ATOM     59  CA  ASN E  25      30.510   3.615   7.692  1.00 12.10           C  
+ATOM     60  C   ASN E  25      31.046   4.554   8.781  1.00 18.31           C  
+ATOM     61  O   ASN E  25      31.644   4.054   9.728  1.00 22.39           O  
+ATOM     62  CB  ASN E  25      31.547   2.472   7.501  1.00 36.91           C  
+ATOM     63  CG  ASN E  25      31.121   1.585   6.335  1.00 26.68           C  
+ATOM     64  OD1 ASN E  25      30.001   1.073   6.311  1.00 27.68           O  
+ATOM     65  ND2 ASN E  25      32.024   1.461   5.398  1.00 25.24           N  
+ATOM     66  N   THR E  26      30.849   5.854   8.696  1.00 21.16           N  
+ATOM     67  CA  THR E  26      31.251   6.810   9.780  1.00  8.77           C  
+ATOM     68  C   THR E  26      30.117   6.890  10.816  1.00 25.67           C  
+ATOM     69  O   THR E  26      30.191   7.583  11.822  1.00 12.87           O  
+ATOM     70  CB  THR E  26      31.483   8.199   9.110  1.00 35.31           C  
+ATOM     71  OG1 THR E  26      30.222   8.682   8.583  1.00 19.19           O  
+ATOM     72  CG2 THR E  26      32.549   8.188   7.936  1.00 10.32           C  
+ATOM     73  N   VAL E  27      29.018   6.198  10.581  1.00 18.65           N  
+ATOM     74  CA  VAL E  27      27.911   6.167  11.616  1.00  5.48           C  
+ATOM     75  C   VAL E  27      27.547   4.692  11.819  1.00  3.00           C  
+ATOM     76  O   VAL E  27      26.630   4.178  11.175  1.00  8.44           O  
+ATOM     77  CB  VAL E  27      26.636   6.960  11.122  1.00  3.00           C  
+ATOM     78  CG1 VAL E  27      25.454   6.837  12.090  1.00  3.00           C  
+ATOM     79  CG2 VAL E  27      26.942   8.420  10.865  1.00  3.00           C  
+ATOM     80  N   PRO E  28      28.465   3.999  12.469  1.00  5.09           N  
+ATOM     81  CA  PRO E  28      28.506   2.523  12.451  1.00  3.00           C  
+ATOM     82  C   PRO E  28      27.344   1.816  13.182  1.00  5.17           C  
+ATOM     83  O   PRO E  28      27.210   0.597  13.101  1.00  3.17           O  
+ATOM     84  CB  PRO E  28      29.910   2.230  13.101  1.00  8.33           C  
+ATOM     85  CG  PRO E  28      30.170   3.418  14.025  1.00  3.00           C  
+ATOM     86  CD  PRO E  28      29.558   4.636  13.309  1.00  3.00           C  
+ATOM     87  N   TYR E  29      26.508   2.541  13.928  1.00  3.35           N  
+ATOM     88  CA  TYR E  29      25.401   2.034  14.692  1.00  3.00           C  
+ATOM     89  C   TYR E  29      24.138   2.270  13.879  1.00 10.89           C  
+ATOM     90  O   TYR E  29      23.108   1.790  14.300  1.00  6.82           O  
+ATOM     91  CB  TYR E  29      25.264   2.835  15.992  1.00  3.00           C  
+ATOM     92  CG  TYR E  29      25.283   4.386  15.885  1.00  3.00           C  
+ATOM     93  CD1 TYR E  29      24.150   5.109  15.619  1.00  3.00           C  
+ATOM     94  CD2 TYR E  29      26.469   5.049  16.043  1.00  3.00           C  
+ATOM     95  CE1 TYR E  29      24.259   6.463  15.463  1.00  3.00           C  
+ATOM     96  CE2 TYR E  29      26.571   6.421  15.900  1.00  3.00           C  
+ATOM     97  CZ  TYR E  29      25.479   7.133  15.570  1.00 10.75           C  
+ATOM     98  OH  TYR E  29      25.610   8.527  15.275  1.00  3.27           O  
+ATOM     99  N   GLN E  30      24.235   2.942  12.765  1.00  3.00           N  
+ATOM    100  CA  GLN E  30      23.071   3.104  11.877  1.00  8.38           C  
+ATOM    101  C   GLN E  30      22.748   1.807  11.135  1.00  3.00           C  
+ATOM    102  O   GLN E  30      23.614   1.252  10.518  1.00  5.02           O  
+ATOM    103  CB  GLN E  30      23.390   4.228  10.871  1.00  6.84           C  
+ATOM    104  CG  GLN E  30      22.326   4.449   9.751  1.00  3.00           C  
+ATOM    105  CD  GLN E  30      21.146   5.313  10.223  1.00  3.00           C  
+ATOM    106  OE1 GLN E  30      19.990   4.907  10.065  1.00 10.76           O  
+ATOM    107  NE2 GLN E  30      21.405   6.447  10.716  1.00  3.00           N  
+ATOM    108  N   VAL E  31      21.538   1.330  11.153  1.00  3.00           N  
+ATOM    109  CA  VAL E  31      21.061   0.214  10.386  1.00  8.40           C  
+ATOM    110  C   VAL E  31      19.852   0.616   9.506  1.00  4.83           C  
+ATOM    111  O   VAL E  31      19.219   1.667   9.694  1.00  3.00           O  
+ATOM    112  CB  VAL E  31      20.692  -1.016  11.288  1.00  4.45           C  
+ATOM    113  CG1 VAL E  31      21.695  -1.392  12.345  1.00  3.00           C  
+ATOM    114  CG2 VAL E  31      19.337  -0.924  11.944  1.00  3.00           C  
+ATOM    115  N   SER E  32      19.576  -0.217   8.533  1.00  8.67           N  
+ATOM    116  CA  SER E  32      18.399  -0.029   7.661  1.00  3.00           C  
+ATOM    117  C   SER E  32      17.428  -1.206   7.873  1.00  6.06           C  
+ATOM    118  O   SER E  32      17.863  -2.362   8.041  1.00  3.00           O  
+ATOM    119  CB  SER E  32      19.005  -0.053   6.252  1.00  3.00           C  
+ATOM    120  OG  SER E  32      17.924  -0.079   5.373  1.00 15.07           O  
+ATOM    121  N   LEU E  33      16.152  -0.907   8.094  1.00  3.00           N  
+ATOM    122  CA  LEU E  33      15.052  -1.947   8.134  1.00 20.08           C  
+ATOM    123  C   LEU E  33      14.385  -2.155   6.767  1.00  5.72           C  
+ATOM    124  O   LEU E  33      14.215  -1.159   6.051  1.00  5.96           O  
+ATOM    125  CB  LEU E  33      13.875  -1.620   9.075  1.00  4.28           C  
+ATOM    126  CG  LEU E  33      14.362  -1.249  10.502  1.00 12.26           C  
+ATOM    127  CD1 LEU E  33      13.221  -1.013  11.463  1.00 10.05           C  
+ATOM    128  CD2 LEU E  33      15.407  -2.188  11.098  1.00 14.29           C  
+ATOM    129  N   ASN E  34      14.432  -3.435   6.290  1.00  5.39           N  
+ATOM    130  CA  ASN E  34      14.181  -3.641   4.865  1.00  6.57           C  
+ATOM    131  C   ASN E  34      13.078  -4.676   4.767  1.00  3.11           C  
+ATOM    132  O   ASN E  34      13.155  -5.669   5.460  1.00 15.76           O  
+ATOM    133  CB  ASN E  34      15.498  -4.100   4.123  1.00  3.98           C  
+ATOM    134  CG  ASN E  34      15.278  -4.454   2.627  1.00 42.67           C  
+ATOM    135  OD1 ASN E  34      14.709  -5.497   2.294  1.00 26.76           O  
+ATOM    136  ND2 ASN E  34      15.749  -3.596   1.697  1.00 22.31           N  
+ATOM    137  N   SER E  37      12.035  -4.410   4.000  1.00 12.48           N  
+ATOM    138  CA  SER E  37      11.006  -5.466   3.715  1.00  8.90           C  
+ATOM    139  C   SER E  37      10.812  -5.556   2.190  1.00 28.18           C  
+ATOM    140  O   SER E  37       9.869  -5.010   1.639  1.00 20.93           O  
+ATOM    141  CB  SER E  37       9.650  -5.075   4.283  1.00  6.06           C  
+ATOM    142  OG  SER E  37       9.386  -3.722   3.824  1.00 27.88           O  
+ATOM    143  N   GLY E  38      11.839  -5.787   1.441  1.00 24.67           N  
+ATOM    144  CA  GLY E  38      11.609  -5.552   0.006  1.00 24.50           C  
+ATOM    145  C   GLY E  38      12.398  -4.332  -0.389  1.00 22.68           C  
+ATOM    146  O   GLY E  38      13.217  -4.387  -1.282  1.00 33.32           O  
+ATOM    147  N   TYR E  39      12.270  -3.333   0.396  1.00 15.67           N  
+ATOM    148  CA  TYR E  39      13.038  -2.138   0.130  1.00  9.33           C  
+ATOM    149  C   TYR E  39      13.373  -1.435   1.467  1.00 17.74           C  
+ATOM    150  O   TYR E  39      12.813  -1.792   2.504  1.00  7.63           O  
+ATOM    151  CB  TYR E  39      12.047  -1.343  -0.744  1.00 12.81           C  
+ATOM    152  CG  TYR E  39      10.659  -1.047  -0.098  1.00 13.07           C  
+ATOM    153  CD1 TYR E  39       9.598  -1.928  -0.184  1.00 25.12           C  
+ATOM    154  CD2 TYR E  39      10.434   0.197   0.431  1.00 20.45           C  
+ATOM    155  CE1 TYR E  39       8.300  -1.547   0.219  1.00 36.31           C  
+ATOM    156  CE2 TYR E  39       9.133   0.598   0.801  1.00 47.34           C  
+ATOM    157  CZ  TYR E  39       8.046  -0.262   0.664  1.00 52.52           C  
+ATOM    158  OH  TYR E  39       6.712   0.187   0.952  1.00 35.20           O  
+ATOM    159  N   HIS E  40      14.203  -0.410   1.452  1.00  3.40           N  
+ATOM    160  CA  HIS E  40      14.469   0.341   2.713  1.00  4.16           C  
+ATOM    161  C   HIS E  40      13.248   1.135   3.185  1.00  9.22           C  
+ATOM    162  O   HIS E  40      12.706   1.899   2.414  1.00  5.01           O  
+ATOM    163  CB  HIS E  40      15.647   1.323   2.501  1.00  3.00           C  
+ATOM    164  CG  HIS E  40      15.717   2.358   3.629  1.00 19.89           C  
+ATOM    165  ND1 HIS E  40      16.416   2.074   4.846  1.00  9.27           N  
+ATOM    166  CD2 HIS E  40      15.154   3.590   3.687  1.00  7.54           C  
+ATOM    167  CE1 HIS E  40      16.257   3.213   5.667  1.00 13.71           C  
+ATOM    168  NE2 HIS E  40      15.476   4.172   4.939  1.00 17.66           N  
+ATOM    169  N   PHE E  41      12.794   1.008   4.429  1.00  7.60           N  
+ATOM    170  CA  PHE E  41      11.627   1.858   4.776  1.00  3.00           C  
+ATOM    171  C   PHE E  41      11.765   2.616   6.105  1.00  3.73           C  
+ATOM    172  O   PHE E  41      11.087   3.630   6.276  1.00  5.06           O  
+ATOM    173  CB  PHE E  41      10.346   0.985   4.786  1.00  5.48           C  
+ATOM    174  CG  PHE E  41      10.318  -0.079   5.923  1.00 11.70           C  
+ATOM    175  CD1 PHE E  41      10.857  -1.324   5.695  1.00  4.62           C  
+ATOM    176  CD2 PHE E  41       9.747   0.197   7.160  1.00  3.21           C  
+ATOM    177  CE1 PHE E  41      10.862  -2.296   6.681  1.00  7.39           C  
+ATOM    178  CE2 PHE E  41       9.738  -0.767   8.157  1.00  3.00           C  
+ATOM    179  CZ  PHE E  41      10.305  -2.015   7.927  1.00  4.74           C  
+ATOM    180  N   CYS E  42      12.656   2.161   7.011  1.00  3.00           N  
+ATOM    181  CA  CYS E  42      12.958   2.918   8.216  1.00  3.00           C  
+ATOM    182  C   CYS E  42      14.433   2.762   8.504  1.00  3.00           C  
+ATOM    183  O   CYS E  42      14.988   1.746   8.056  1.00  3.00           O  
+ATOM    184  CB  CYS E  42      12.169   2.367   9.381  1.00  3.00           C  
+ATOM    185  SG  CYS E  42      10.431   2.975   9.519  1.00  3.83           S  
+ATOM    186  N   GLY E  43      14.953   3.662   9.400  1.00  3.00           N  
+ATOM    187  CA  GLY E  43      16.226   3.301  10.073  1.00  3.21           C  
+ATOM    188  C   GLY E  43      16.096   2.545  11.411  1.00  3.00           C  
+ATOM    189  O   GLY E  43      14.998   2.219  11.870  1.00  3.00           O  
+ATOM    190  N   GLY E  44      17.204   2.486  12.150  1.00  3.00           N  
+ATOM    191  CA  GLY E  44      17.262   2.028  13.542  1.00  3.00           C  
+ATOM    192  C   GLY E  44      18.690   2.145  14.044  1.00  3.00           C  
+ATOM    193  O   GLY E  44      19.543   2.631  13.311  1.00  5.06           O  
+ATOM    194  N   SER E  45      18.915   1.850  15.279  1.00  3.00           N  
+ATOM    195  CA  SER E  45      20.271   1.972  15.920  1.00  6.15           C  
+ATOM    196  C   SER E  45      20.658   0.698  16.641  1.00  3.25           C  
+ATOM    197  O   SER E  45      19.763   0.128  17.253  1.00  3.36           O  
+ATOM    198  CB  SER E  45      20.278   2.994  17.027  1.00  3.00           C  
+ATOM    199  OG  SER E  45      19.786   4.241  16.529  1.00 13.76           O  
+ATOM    200  N   LEU E  46      21.858   0.192  16.368  1.00  3.90           N  
+ATOM    201  CA  LEU E  46      22.316  -1.067  16.939  1.00  3.00           C  
+ATOM    202  C   LEU E  46      22.802  -0.747  18.360  1.00 16.04           C  
+ATOM    203  O   LEU E  46      23.511   0.238  18.576  1.00  4.53           O  
+ATOM    204  CB  LEU E  46      23.454  -1.556  16.070  1.00  3.00           C  
+ATOM    205  CG  LEU E  46      24.053  -2.925  16.499  1.00  4.65           C  
+ATOM    206  CD1 LEU E  46      23.138  -4.142  16.213  1.00  6.73           C  
+ATOM    207  CD2 LEU E  46      25.391  -3.200  15.771  1.00 10.72           C  
+ATOM    208  N   ILE E  47      22.186  -1.355  19.343  1.00  8.87           N  
+ATOM    209  CA  ILE E  47      22.548  -0.964  20.735  1.00 16.19           C  
+ATOM    210  C   ILE E  47      23.220  -2.120  21.508  1.00 10.81           C  
+ATOM    211  O   ILE E  47      23.957  -1.916  22.465  1.00 20.87           O  
+ATOM    212  CB  ILE E  47      21.291  -0.501  21.486  1.00 14.73           C  
+ATOM    213  CG1 ILE E  47      20.349  -1.675  21.633  1.00 14.34           C  
+ATOM    214  CG2 ILE E  47      20.600   0.827  21.034  1.00  3.17           C  
+ATOM    215  CD1 ILE E  47      19.218  -1.363  22.642  1.00 32.68           C  
+ATOM    216  N   ASN E  48      23.319  -3.228  20.868  1.00 10.74           N  
+ATOM    217  CA  ASN E  48      24.307  -4.256  21.076  1.00  9.60           C  
+ATOM    218  C   ASN E  48      24.256  -5.268  19.930  1.00 35.10           C  
+ATOM    219  O   ASN E  48      23.661  -4.944  18.901  1.00 16.56           O  
+ATOM    220  CB  ASN E  48      24.225  -4.929  22.451  1.00 23.72           C  
+ATOM    221  CG  ASN E  48      22.890  -5.610  22.670  1.00  5.84           C  
+ATOM    222  OD1 ASN E  48      22.332  -5.485  23.743  1.00 33.34           O  
+ATOM    223  ND2 ASN E  48      22.430  -6.346  21.725  1.00  7.38           N  
+ATOM    224  N   SER E  49      24.985  -6.384  20.033  1.00 13.54           N  
+ATOM    225  CA  SER E  49      25.207  -7.212  18.826  1.00 14.84           C  
+ATOM    226  C   SER E  49      23.955  -7.966  18.424  1.00  8.84           C  
+ATOM    227  O   SER E  49      23.938  -8.561  17.342  1.00 12.82           O  
+ATOM    228  CB  SER E  49      26.334  -8.270  18.996  1.00 26.98           C  
+ATOM    229  OG  SER E  49      26.030  -9.116  20.101  1.00 19.90           O  
+ATOM    230  N   GLN E  50      23.005  -8.006  19.338  1.00 11.81           N  
+ATOM    231  CA  GLN E  50      21.726  -8.704  19.112  1.00 23.11           C  
+ATOM    232  C   GLN E  50      20.457  -7.824  19.007  1.00 13.10           C  
+ATOM    233  O   GLN E  50      19.368  -8.352  18.794  1.00 15.64           O  
+ATOM    234  CB  GLN E  50      21.585  -9.951  20.038  1.00 16.08           C  
+ATOM    235  CG  GLN E  50      21.915 -11.105  19.088  1.00 47.72           C  
+ATOM    236  CD  GLN E  50      21.389 -12.412  19.646  1.00 62.58           C  
+ATOM    237  OE1 GLN E  50      20.647 -13.139  18.939  1.00 31.43           O  
+ATOM    238  NE2 GLN E  50      21.833 -12.552  20.906  1.00 33.83           N  
+ATOM    239  N   TRP E  51      20.512  -6.535  19.420  1.00  5.11           N  
+ATOM    240  CA  TRP E  51      19.299  -5.668  19.482  1.00  7.07           C  
+ATOM    241  C   TRP E  51      19.480  -4.316  18.818  1.00  3.00           C  
+ATOM    242  O   TRP E  51      20.524  -3.666  18.927  1.00  9.99           O  
+ATOM    243  CB  TRP E  51      18.941  -5.320  20.918  1.00  3.00           C  
+ATOM    244  CG  TRP E  51      18.562  -6.620  21.596  1.00  7.87           C  
+ATOM    245  CD1 TRP E  51      19.382  -7.607  22.143  1.00 14.24           C  
+ATOM    246  CD2 TRP E  51      17.238  -7.028  21.836  1.00  5.90           C  
+ATOM    247  NE1 TRP E  51      18.550  -8.599  22.691  1.00 20.07           N  
+ATOM    248  CE2 TRP E  51      17.306  -8.240  22.572  1.00 13.33           C  
+ATOM    249  CE3 TRP E  51      16.032  -6.423  21.509  1.00 15.81           C  
+ATOM    250  CZ2 TRP E  51      16.173  -8.864  23.095  1.00  5.48           C  
+ATOM    251  CZ3 TRP E  51      14.885  -7.064  21.997  1.00 27.73           C  
+ATOM    252  CH2 TRP E  51      14.956  -8.237  22.786  1.00 14.48           C  
+ATOM    253  N   VAL E  52      18.438  -3.958  18.174  1.00  5.56           N  
+ATOM    254  CA  VAL E  52      18.355  -2.642  17.486  1.00  5.33           C  
+ATOM    255  C   VAL E  52      17.175  -1.873  18.093  1.00  7.30           C  
+ATOM    256  O   VAL E  52      16.146  -2.514  18.279  1.00 13.93           O  
+ATOM    257  CB  VAL E  52      18.020  -3.057  16.014  1.00 10.80           C  
+ATOM    258  CG1 VAL E  52      17.396  -1.896  15.183  1.00  4.63           C  
+ATOM    259  CG2 VAL E  52      19.277  -3.654  15.326  1.00  3.00           C  
+ATOM    260  N   VAL E  53      17.235  -0.551  18.209  1.00  3.00           N  
+ATOM    261  CA  VAL E  53      16.056   0.233  18.544  1.00  3.00           C  
+ATOM    262  C   VAL E  53      15.525   1.022  17.341  1.00  3.00           C  
+ATOM    263  O   VAL E  53      16.330   1.531  16.558  1.00  6.41           O  
+ATOM    264  CB  VAL E  53      16.300   1.160  19.788  1.00 11.15           C  
+ATOM    265  CG1 VAL E  53      17.330   2.235  19.514  1.00 17.19           C  
+ATOM    266  CG2 VAL E  53      15.026   1.820  20.339  1.00 16.76           C  
+ATOM    267  N   SER E  54      14.200   1.123  17.249  1.00  5.03           N  
+ATOM    268  CA  SER E  54      13.486   1.816  16.134  1.00  6.25           C  
+ATOM    269  C   SER E  54      12.156   2.361  16.636  1.00  4.75           C  
+ATOM    270  O   SER E  54      11.910   2.386  17.852  1.00 11.24           O  
+ATOM    271  CB  SER E  54      13.408   0.937  14.832  1.00  3.00           C  
+ATOM    272  OG  SER E  54      12.994   1.675  13.621  1.00  3.00           O  
+ATOM    273  N   ALA E  55      11.429   2.964  15.728  1.00  8.51           N  
+ATOM    274  CA  ALA E  55      10.124   3.554  15.942  1.00  3.00           C  
+ATOM    275  C   ALA E  55       9.086   2.429  15.900  1.00 12.10           C  
+ATOM    276  O   ALA E  55       9.120   1.605  14.982  1.00  5.35           O  
+ATOM    277  CB  ALA E  55       9.819   4.642  14.917  1.00  3.00           C  
+ATOM    278  N   ALA E  56       8.133   2.432  16.854  1.00 12.70           N  
+ATOM    279  CA  ALA E  56       7.037   1.445  16.794  1.00  8.36           C  
+ATOM    280  C   ALA E  56       6.182   1.539  15.509  1.00  3.00           C  
+ATOM    281  O   ALA E  56       5.795   0.474  15.085  1.00  3.58           O  
+ATOM    282  CB  ALA E  56       6.141   1.584  18.060  1.00  3.34           C  
+ATOM    283  N   HIS E  57       5.914   2.696  14.928  1.00  3.00           N  
+ATOM    284  CA  HIS E  57       5.258   2.734  13.660  1.00  3.00           C  
+ATOM    285  C   HIS E  57       6.099   2.109  12.530  1.00  6.44           C  
+ATOM    286  O   HIS E  57       5.510   1.877  11.462  1.00  7.93           O  
+ATOM    287  CB  HIS E  57       4.880   4.130  13.351  1.00  3.00           C  
+ATOM    288  CG  HIS E  57       6.041   5.000  12.842  1.00  6.82           C  
+ATOM    289  ND1 HIS E  57       6.523   6.014  13.593  1.00  3.45           N  
+ATOM    290  CD2 HIS E  57       6.641   5.057  11.633  1.00 15.72           C  
+ATOM    291  CE1 HIS E  57       7.496   6.678  12.840  1.00 19.29           C  
+ATOM    292  NE2 HIS E  57       7.586   6.088  11.603  1.00 10.13           N  
+ATOM    293  N   CYS E  58       7.380   1.661  12.815  1.00  6.01           N  
+ATOM    294  CA  CYS E  58       8.092   0.919  11.765  1.00  3.48           C  
+ATOM    295  C   CYS E  58       7.778  -0.566  11.730  1.00  3.80           C  
+ATOM    296  O   CYS E  58       8.476  -1.308  11.032  1.00  3.00           O  
+ATOM    297  CB  CYS E  58       9.606   1.146  11.812  1.00  3.00           C  
+ATOM    298  SG  CYS E  58      10.076   2.826  11.469  1.00  4.62           S  
+ATOM    299  N   TYR E  59       7.068  -1.016  12.769  1.00  3.96           N  
+ATOM    300  CA  TYR E  59       6.766  -2.462  12.857  1.00 10.65           C  
+ATOM    301  C   TYR E  59       6.186  -2.983  11.530  1.00 22.06           C  
+ATOM    302  O   TYR E  59       5.220  -2.457  10.957  1.00  6.56           O  
+ATOM    303  CB  TYR E  59       5.750  -2.726  14.019  1.00 15.93           C  
+ATOM    304  CG  TYR E  59       5.318  -4.210  13.999  1.00  4.07           C  
+ATOM    305  CD1 TYR E  59       6.128  -5.182  14.525  1.00 14.23           C  
+ATOM    306  CD2 TYR E  59       4.205  -4.564  13.272  1.00 18.15           C  
+ATOM    307  CE1 TYR E  59       5.810  -6.504  14.324  1.00 23.07           C  
+ATOM    308  CE2 TYR E  59       3.896  -5.876  13.040  1.00 12.29           C  
+ATOM    309  CZ  TYR E  59       4.694  -6.845  13.577  1.00 23.30           C  
+ATOM    310  OH  TYR E  59       4.427  -8.133  13.284  1.00 31.71           O  
+ATOM    311  N   LYS E  60       6.727  -4.110  11.144  1.00 11.91           N  
+ATOM    312  CA  LYS E  60       6.235  -4.918  10.004  1.00 21.05           C  
+ATOM    313  C   LYS E  60       6.596  -6.364  10.331  1.00 16.43           C  
+ATOM    314  O   LYS E  60       7.595  -6.681  10.951  1.00 14.90           O  
+ATOM    315  CB  LYS E  60       6.902  -4.640   8.622  1.00  3.72           C  
+ATOM    316  CG  LYS E  60       6.574  -3.320   7.926  1.00  9.02           C  
+ATOM    317  CD  LYS E  60       7.062  -3.392   6.455  1.00 27.26           C  
+ATOM    318  CE  LYS E  60       7.257  -1.984   5.822  1.00 16.23           C  
+ATOM    319  NZ  LYS E  60       6.017  -1.245   5.811  1.00 26.44           N  
+ATOM    320  N   SER E  61       5.869  -7.286   9.836  1.00 20.24           N  
+ATOM    321  CA  SER E  61       6.387  -8.617  10.084  1.00 15.52           C  
+ATOM    322  C   SER E  61       7.419  -8.877   8.972  1.00 20.08           C  
+ATOM    323  O   SER E  61       7.349  -8.263   7.917  1.00 36.45           O  
+ATOM    324  CB  SER E  61       5.113  -9.473   9.929  1.00 35.56           C  
+ATOM    325  OG  SER E  61       5.380 -10.620   9.164  1.00 43.38           O  
+ATOM    326  N   GLY E  62       8.358  -9.747   9.171  1.00 17.00           N  
+ATOM    327  CA  GLY E  62       9.332 -10.077   8.154  1.00 21.68           C  
+ATOM    328  C   GLY E  62      10.371  -8.976   7.868  1.00 36.12           C  
+ATOM    329  O   GLY E  62      10.959  -9.052   6.796  1.00 34.43           O  
+ATOM    330  N   ILE E  63      10.748  -8.163   8.854  1.00 15.49           N  
+ATOM    331  CA  ILE E  63      11.948  -7.233   8.752  1.00  6.97           C  
+ATOM    332  C   ILE E  63      13.239  -8.016   8.514  1.00 19.48           C  
+ATOM    333  O   ILE E  63      13.631  -8.938   9.250  1.00  8.30           O  
+ATOM    334  CB  ILE E  63      12.040  -6.295  10.001  1.00  8.61           C  
+ATOM    335  CG1 ILE E  63      10.806  -5.385  10.050  1.00 19.88           C  
+ATOM    336  CG2 ILE E  63      13.312  -5.405   9.988  1.00 11.30           C  
+ATOM    337  CD1 ILE E  63      10.671  -4.566  11.366  1.00 10.82           C  
+ATOM    338  N   GLN E  64      13.966  -7.523   7.550  1.00 16.10           N  
+ATOM    339  CA  GLN E  64      15.421  -7.826   7.506  1.00  8.29           C  
+ATOM    340  C   GLN E  64      16.234  -6.580   7.864  1.00 16.87           C  
+ATOM    341  O   GLN E  64      16.005  -5.482   7.357  1.00 12.46           O  
+ATOM    342  CB  GLN E  64      15.859  -8.340   6.134  1.00  6.07           C  
+ATOM    343  CG  GLN E  64      17.348  -8.698   5.995  1.00 11.78           C  
+ATOM    344  CD  GLN E  64      17.658  -8.934   4.515  1.00 35.01           C  
+ATOM    345  OE1 GLN E  64      18.121 -10.009   4.126  1.00 35.09           O  
+ATOM    346  NE2 GLN E  64      17.389  -7.905   3.735  1.00 19.58           N  
+ATOM    347  N   VAL E  65      17.159  -6.771   8.789  1.00  8.42           N  
+ATOM    348  CA  VAL E  65      17.982  -5.704   9.202  1.00  4.23           C  
+ATOM    349  C   VAL E  65      19.336  -5.675   8.484  1.00  3.00           C  
+ATOM    350  O   VAL E  65      19.969  -6.713   8.418  1.00  8.12           O  
+ATOM    351  CB  VAL E  65      18.211  -5.930  10.672  1.00  3.92           C  
+ATOM    352  CG1 VAL E  65      19.130  -4.758  11.107  1.00  3.00           C  
+ATOM    353  CG2 VAL E  65      16.845  -5.963  11.381  1.00 12.00           C  
+ATOM    354  N   ARG E  66      19.731  -4.533   7.927  1.00  8.72           N  
+ATOM    355  CA  ARG E  66      21.015  -4.416   7.228  1.00 10.76           C  
+ATOM    356  C   ARG E  66      22.017  -3.515   7.930  1.00 19.38           C  
+ATOM    357  O   ARG E  66      21.699  -2.347   8.171  1.00  7.64           O  
+ATOM    358  CB  ARG E  66      20.948  -4.085   5.731  1.00  3.00           C  
+ATOM    359  CG  ARG E  66      19.832  -4.901   5.111  1.00 10.25           C  
+ATOM    360  CD  ARG E  66      19.659  -4.547   3.615  1.00 14.73           C  
+ATOM    361  NE  ARG E  66      18.886  -5.640   2.971  1.00 12.07           N  
+ATOM    362  CZ  ARG E  66      18.753  -5.705   1.627  1.00 28.10           C  
+ATOM    363  NH1 ARG E  66      19.269  -4.816   0.827  1.00 17.16           N  
+ATOM    364  NH2 ARG E  66      18.055  -6.619   1.050  1.00 22.27           N  
+ATOM    365  N   LEU E  67      23.212  -4.126   8.222  1.00  8.75           N  
+ATOM    366  CA  LEU E  67      24.240  -3.416   8.995  1.00 15.63           C  
+ATOM    367  C   LEU E  67      25.446  -3.168   8.112  1.00 13.01           C  
+ATOM    368  O   LEU E  67      25.604  -3.913   7.158  1.00  4.48           O  
+ATOM    369  CB  LEU E  67      24.749  -4.120  10.246  1.00 13.54           C  
+ATOM    370  CG  LEU E  67      23.730  -4.392  11.421  1.00 11.17           C  
+ATOM    371  CD1 LEU E  67      22.775  -5.511  10.997  1.00 24.71           C  
+ATOM    372  CD2 LEU E  67      24.584  -5.159  12.469  1.00 34.44           C  
+ATOM    373  N   GLY E  69      26.216  -2.159   8.437  1.00  8.10           N  
+ATOM    374  CA  GLY E  69      27.455  -1.887   7.665  1.00  4.67           C  
+ATOM    375  C   GLY E  69      27.157  -1.363   6.265  1.00 14.34           C  
+ATOM    376  O   GLY E  69      28.046  -1.398   5.420  1.00 23.18           O  
+ATOM    377  N   GLU E  70      26.019  -0.749   6.050  1.00 13.89           N  
+ATOM    378  CA  GLU E  70      25.636  -0.112   4.724  1.00 18.47           C  
+ATOM    379  C   GLU E  70      26.225   1.304   4.596  1.00 11.13           C  
+ATOM    380  O   GLU E  70      26.006   2.135   5.470  1.00  6.44           O  
+ATOM    381  CB  GLU E  70      24.118   0.169   4.674  1.00 14.82           C  
+ATOM    382  CG  GLU E  70      23.055  -0.973   4.685  1.00  8.90           C  
+ATOM    383  CD  GLU E  70      23.094  -1.529   3.270  1.00 45.93           C  
+ATOM    384  OE1 GLU E  70      23.940  -1.065   2.451  1.00 44.93           O  
+ATOM    385  OE2 GLU E  70      22.312  -2.444   2.902  1.00 24.49           O  
+ATOM    386  N   ASP E  71      26.605   1.669   3.404  1.00  6.98           N  
+ATOM    387  CA  ASP E  71      26.550   3.083   3.007  1.00  7.93           C  
+ATOM    388  C   ASP E  71      25.627   3.311   1.783  1.00  8.79           C  
+ATOM    389  O   ASP E  71      24.504   3.848   1.802  1.00 10.11           O  
+ATOM    390  CB  ASP E  71      28.012   3.507   2.688  1.00 18.21           C  
+ATOM    391  CG  ASP E  71      27.912   5.011   2.436  1.00 29.46           C  
+ATOM    392  OD1 ASP E  71      27.324   5.733   3.285  1.00 18.35           O  
+ATOM    393  OD2 ASP E  71      28.375   5.532   1.392  1.00 27.81           O  
+ATOM    394  N   ASN E  72      26.060   2.739   0.683  1.00 18.84           N  
+ATOM    395  CA  ASN E  72      25.228   2.799  -0.514  1.00  8.26           C  
+ATOM    396  C   ASN E  72      24.229   1.667  -0.480  1.00  9.28           C  
+ATOM    397  O   ASN E  72      24.610   0.558  -0.812  1.00 18.39           O  
+ATOM    398  CB  ASN E  72      26.086   2.604  -1.775  1.00  3.00           C  
+ATOM    399  CG  ASN E  72      25.227   2.955  -2.993  1.00 21.72           C  
+ATOM    400  OD1 ASN E  72      24.112   2.445  -3.250  1.00 15.43           O  
+ATOM    401  ND2 ASN E  72      25.801   3.877  -3.694  1.00 13.01           N  
+ATOM    402  N   ILE E  73      23.005   1.957  -0.185  1.00  3.15           N  
+ATOM    403  CA  ILE E  73      21.976   0.938  -0.111  1.00 16.76           C  
+ATOM    404  C   ILE E  73      21.683   0.178  -1.406  1.00 28.24           C  
+ATOM    405  O   ILE E  73      20.890  -0.751  -1.280  1.00 22.02           O  
+ATOM    406  CB  ILE E  73      20.644   1.535   0.398  1.00 23.13           C  
+ATOM    407  CG1 ILE E  73      20.148   2.769  -0.399  1.00 16.55           C  
+ATOM    408  CG2 ILE E  73      20.470   1.642   1.935  1.00 17.21           C  
+ATOM    409  CD1 ILE E  73      18.779   3.237   0.129  1.00 27.53           C  
+ATOM    410  N   ASN E  74      22.206   0.557  -2.592  1.00 20.05           N  
+ATOM    411  CA  ASN E  74      21.805  -0.133  -3.844  1.00 33.59           C  
+ATOM    412  C   ASN E  74      22.880  -1.052  -4.363  1.00 40.87           C  
+ATOM    413  O   ASN E  74      22.682  -1.734  -5.372  1.00 40.82           O  
+ATOM    414  CB  ASN E  74      21.395   0.832  -4.981  1.00 24.75           C  
+ATOM    415  CG  ASN E  74      20.062   1.433  -4.565  1.00 29.55           C  
+ATOM    416  OD1 ASN E  74      19.165   0.736  -4.050  1.00 31.30           O  
+ATOM    417  ND2 ASN E  74      20.015   2.728  -4.738  1.00 20.22           N  
+ATOM    418  N   VAL E  75      24.011  -0.805  -3.775  1.00 36.97           N  
+ATOM    419  CA  VAL E  75      25.283  -1.305  -4.288  1.00 30.59           C  
+ATOM    420  C   VAL E  75      26.043  -2.003  -3.162  1.00 27.48           C  
+ATOM    421  O   VAL E  75      26.341  -1.347  -2.176  1.00 39.84           O  
+ATOM    422  CB  VAL E  75      26.047  -0.066  -4.848  1.00 37.28           C  
+ATOM    423  CG1 VAL E  75      27.247  -0.494  -5.665  1.00 36.96           C  
+ATOM    424  CG2 VAL E  75      25.192   0.863  -5.754  1.00 41.71           C  
+ATOM    425  N   VAL E  76      26.397  -3.268  -3.320  0.00 39.56           N  
+ATOM    426  CA  VAL E  76      27.135  -4.055  -2.300  1.00 25.67           C  
+ATOM    427  C   VAL E  76      28.617  -3.674  -2.203  1.00 20.93           C  
+ATOM    428  O   VAL E  76      29.273  -3.500  -3.227  1.00 46.19           O  
+ATOM    429  CB  VAL E  76      27.039  -5.534  -2.696  1.00 28.24           C  
+ATOM    430  CG1 VAL E  76      28.299  -6.332  -2.380  1.00 42.24           C  
+ATOM    431  CG2 VAL E  76      25.823  -6.168  -2.026  1.00 28.58           C  
+ATOM    432  N   GLU E  77      29.054  -3.185  -1.072  1.00 29.14           N  
+ATOM    433  CA  GLU E  77      30.411  -2.639  -1.019  1.00 40.09           C  
+ATOM    434  C   GLU E  77      31.305  -3.518  -0.151  1.00 51.43           C  
+ATOM    435  O   GLU E  77      32.530  -3.312  -0.049  1.00 35.43           O  
+ATOM    436  CB  GLU E  77      30.294  -1.213  -0.505  1.00 30.51           C  
+ATOM    437  CG  GLU E  77      29.621  -0.379  -1.614  1.00 38.55           C  
+ATOM    438  CD  GLU E  77      29.364   1.046  -1.131  1.00 43.15           C  
+ATOM    439  OE1 GLU E  77      28.808   1.261  -0.029  1.00 36.13           O  
+ATOM    440  OE2 GLU E  77      29.684   2.026  -1.845  1.00 46.69           O  
+ATOM    441  N   GLY E  78      30.587  -4.563   0.226  1.00 32.64           N  
+ATOM    442  CA  GLY E  78      31.023  -5.711   1.024  1.00 24.37           C  
+ATOM    443  C   GLY E  78      31.413  -5.325   2.446  1.00 35.13           C  
+ATOM    444  O   GLY E  78      31.973  -6.173   3.139  1.00 48.24           O  
+ATOM    445  N   ASN E  79      30.869  -4.285   3.026  1.00 30.18           N  
+ATOM    446  CA  ASN E  79      31.002  -4.400   4.511  1.00 45.63           C  
+ATOM    447  C   ASN E  79      29.689  -4.859   5.200  1.00 46.31           C  
+ATOM    448  O   ASN E  79      29.458  -4.693   6.413  1.00 26.80           O  
+ATOM    449  CB  ASN E  79      31.511  -3.049   5.092  1.00 39.33           C  
+ATOM    450  CG  ASN E  79      32.906  -2.689   4.574  1.00 58.71           C  
+ATOM    451  OD1 ASN E  79      33.868  -3.406   4.849  1.00 48.74           O  
+ATOM    452  ND2 ASN E  79      33.006  -1.573   3.860  1.00 51.17           N  
+ATOM    453  N   GLU E  80      28.692  -5.094   4.377  1.00 22.32           N  
+ATOM    454  CA  GLU E  80      27.339  -5.196   4.928  1.00  9.58           C  
+ATOM    455  C   GLU E  80      27.121  -6.518   5.652  1.00 17.21           C  
+ATOM    456  O   GLU E  80      27.631  -7.534   5.213  1.00 23.33           O  
+ATOM    457  CB  GLU E  80      26.227  -5.068   3.878  1.00  8.63           C  
+ATOM    458  CG  GLU E  80      26.365  -3.786   3.064  1.00 17.25           C  
+ATOM    459  CD  GLU E  80      27.264  -3.979   1.827  1.00 48.55           C  
+ATOM    460  OE1 GLU E  80      28.059  -4.940   1.678  1.00 35.91           O  
+ATOM    461  OE2 GLU E  80      27.219  -3.137   0.901  1.00 27.87           O  
+ATOM    462  N   GLN E  81      26.223  -6.517   6.629  1.00 15.24           N  
+ATOM    463  CA  GLN E  81      25.630  -7.748   7.186  1.00 24.94           C  
+ATOM    464  C   GLN E  81      24.118  -7.654   7.237  1.00 17.41           C  
+ATOM    465  O   GLN E  81      23.647  -6.531   7.481  1.00 10.72           O  
+ATOM    466  CB  GLN E  81      26.064  -8.011   8.627  1.00 14.17           C  
+ATOM    467  CG  GLN E  81      27.558  -7.758   8.767  1.00  8.69           C  
+ATOM    468  CD  GLN E  81      27.923  -7.840  10.245  1.00 25.40           C  
+ATOM    469  OE1 GLN E  81      27.318  -8.654  10.950  1.00 15.55           O  
+ATOM    470  NE2 GLN E  81      28.919  -7.010  10.646  1.00 10.90           N  
+ATOM    471  N   PHE E  82      23.477  -8.738   6.712  1.00 12.40           N  
+ATOM    472  CA  PHE E  82      22.005  -8.820   6.545  1.00 18.05           C  
+ATOM    473  C   PHE E  82      21.475  -9.905   7.471  1.00 16.69           C  
+ATOM    474  O   PHE E  82      21.854 -11.079   7.354  1.00 14.62           O  
+ATOM    475  CB  PHE E  82      21.554  -9.234   5.132  1.00 12.32           C  
+ATOM    476  CG  PHE E  82      21.767  -8.225   4.008  1.00 14.10           C  
+ATOM    477  CD1 PHE E  82      22.674  -7.218   4.165  1.00 39.01           C  
+ATOM    478  CD2 PHE E  82      21.160  -8.437   2.797  1.00 27.52           C  
+ATOM    479  CE1 PHE E  82      23.004  -6.436   3.109  1.00 31.73           C  
+ATOM    480  CE2 PHE E  82      21.512  -7.666   1.724  1.00 29.88           C  
+ATOM    481  CZ  PHE E  82      22.446  -6.674   1.885  1.00 19.05           C  
+ATOM    482  N   ILE E  83      20.677  -9.488   8.407  1.00  9.61           N  
+ATOM    483  CA  ILE E  83      20.240 -10.429   9.433  1.00 12.74           C  
+ATOM    484  C   ILE E  83      18.747 -10.226   9.611  1.00  6.32           C  
+ATOM    485  O   ILE E  83      18.378  -9.089   9.864  1.00  9.98           O  
+ATOM    486  CB  ILE E  83      20.989 -10.182  10.756  1.00 13.75           C  
+ATOM    487  CG1 ILE E  83      22.516 -10.165  10.556  1.00 12.93           C  
+ATOM    488  CG2 ILE E  83      20.543 -11.200  11.837  1.00  3.00           C  
+ATOM    489  CD1 ILE E  83      23.307  -9.558  11.757  1.00 11.40           C  
+ATOM    490  N   SER E  84      17.954 -11.296   9.563  1.00  8.08           N  
+ATOM    491  CA  SER E  84      16.515 -11.155   9.907  1.00  9.51           C  
+ATOM    492  C   SER E  84      16.234 -10.853  11.377  1.00 14.06           C  
+ATOM    493  O   SER E  84      16.904 -11.375  12.280  1.00 11.04           O  
+ATOM    494  CB  SER E  84      15.855 -12.529   9.689  1.00 23.90           C  
+ATOM    495  OG  SER E  84      15.757 -12.735   8.291  1.00 41.22           O  
+ATOM    496  N   ALA E  85      15.134 -10.173  11.558  1.00  7.33           N  
+ATOM    497  CA  ALA E  85      14.607  -9.986  12.888  1.00 17.07           C  
+ATOM    498  C   ALA E  85      13.993 -11.310  13.355  1.00 22.09           C  
+ATOM    499  O   ALA E  85      13.052 -11.806  12.758  1.00 27.73           O  
+ATOM    500  CB  ALA E  85      13.532  -8.842  12.885  1.00  9.76           C  
+ATOM    501  N   SER E  86      14.351 -11.724  14.510  1.00  9.29           N  
+ATOM    502  CA  SER E  86      13.709 -12.841  15.159  1.00  3.37           C  
+ATOM    503  C   SER E  86      12.497 -12.379  15.973  1.00 15.13           C  
+ATOM    504  O   SER E  86      11.520 -13.110  16.109  1.00 25.63           O  
+ATOM    505  CB  SER E  86      14.749 -13.380  16.100  1.00  5.69           C  
+ATOM    506  OG  SER E  86      14.076 -14.239  16.974  1.00 39.12           O  
+ATOM    507  N   LYS E  87      12.579 -11.223  16.543  1.00 14.63           N  
+ATOM    508  CA  LYS E  87      11.480 -10.801  17.433  1.00  7.07           C  
+ATOM    509  C   LYS E  87      11.386  -9.276  17.448  1.00 13.15           C  
+ATOM    510  O   LYS E  87      12.389  -8.583  17.630  1.00 12.34           O  
+ATOM    511  CB  LYS E  87      11.991 -11.290  18.819  1.00 24.04           C  
+ATOM    512  CG  LYS E  87      10.882 -11.476  19.873  1.00 35.57           C  
+ATOM    513  CD  LYS E  87      11.106 -12.699  20.808  0.00 33.84           C  
+ATOM    514  CE  LYS E  87      12.363 -12.616  21.708  1.00 56.72           C  
+ATOM    515  NZ  LYS E  87      12.516 -13.813  22.592  1.00 39.53           N  
+ATOM    516  N   SER E  88      10.189  -8.751  17.515  1.00 11.15           N  
+ATOM    517  CA  SER E  88       9.995  -7.281  17.587  1.00 19.72           C  
+ATOM    518  C   SER E  88       9.090  -6.941  18.762  1.00 38.23           C  
+ATOM    519  O   SER E  88       8.123  -7.653  18.968  1.00 32.81           O  
+ATOM    520  CB  SER E  88       9.306  -6.747  16.313  1.00 13.19           C  
+ATOM    521  OG  SER E  88      10.121  -7.010  15.111  1.00 39.71           O  
+ATOM    522  N   ILE E  89       9.491  -6.021  19.612  1.00  8.67           N  
+ATOM    523  CA  ILE E  89       8.718  -5.840  20.809  1.00  3.00           C  
+ATOM    524  C   ILE E  89       8.297  -4.386  20.846  1.00  6.16           C  
+ATOM    525  O   ILE E  89       9.152  -3.539  21.053  1.00 10.62           O  
+ATOM    526  CB  ILE E  89       9.675  -6.119  21.966  1.00  6.65           C  
+ATOM    527  CG1 ILE E  89      10.188  -7.553  21.874  1.00  9.33           C  
+ATOM    528  CG2 ILE E  89       8.937  -5.862  23.288  1.00 13.68           C  
+ATOM    529  CD1 ILE E  89      10.942  -8.079  23.121  1.00 13.46           C  
+ATOM    530  N   VAL E  90       7.084  -4.115  20.418  1.00 12.73           N  
+ATOM    531  CA  VAL E  90       6.526  -2.748  20.389  1.00  6.04           C  
+ATOM    532  C   VAL E  90       6.251  -2.244  21.834  1.00 20.66           C  
+ATOM    533  O   VAL E  90       5.981  -3.073  22.708  1.00 20.27           O  
+ATOM    534  CB  VAL E  90       5.252  -2.769  19.484  1.00  8.53           C  
+ATOM    535  CG1 VAL E  90       4.473  -1.436  19.484  1.00  5.90           C  
+ATOM    536  CG2 VAL E  90       5.556  -3.152  18.018  1.00 14.15           C  
+ATOM    537  N   HIS E  91       6.622  -0.988  22.191  1.00 12.88           N  
+ATOM    538  CA  HIS E  91       6.387  -0.519  23.599  1.00 13.00           C  
+ATOM    539  C   HIS E  91       4.892  -0.739  24.016  1.00 31.18           C  
+ATOM    540  O   HIS E  91       4.008  -0.446  23.211  1.00 15.39           O  
+ATOM    541  CB  HIS E  91       6.593   1.015  23.671  1.00  4.41           C  
+ATOM    542  CG  HIS E  91       6.662   1.389  25.151  1.00 14.72           C  
+ATOM    543  ND1 HIS E  91       5.539   1.798  25.822  1.00 13.82           N  
+ATOM    544  CD2 HIS E  91       7.695   1.385  26.002  1.00 10.01           C  
+ATOM    545  CE1 HIS E  91       5.880   2.058  27.155  1.00 14.03           C  
+ATOM    546  NE2 HIS E  91       7.237   1.810  27.264  1.00 12.17           N  
+ATOM    547  N   PRO E  92       4.589  -1.319  25.194  1.00 10.13           N  
+ATOM    548  CA  PRO E  92       3.230  -1.570  25.699  1.00 13.14           C  
+ATOM    549  C   PRO E  92       2.346  -0.354  25.654  1.00 11.90           C  
+ATOM    550  O   PRO E  92       1.153  -0.551  25.528  1.00 19.23           O  
+ATOM    551  CB  PRO E  92       3.413  -1.843  27.204  1.00 17.64           C  
+ATOM    552  CG  PRO E  92       4.894  -1.651  27.487  1.00 23.38           C  
+ATOM    553  CD  PRO E  92       5.550  -1.927  26.149  1.00 18.43           C  
+ATOM    554  N   SER E  93       2.891   0.857  25.705  1.00 10.91           N  
+ATOM    555  CA  SER E  93       1.957   1.979  25.704  1.00  7.06           C  
+ATOM    556  C   SER E  93       1.957   2.713  24.399  1.00 18.51           C  
+ATOM    557  O   SER E  93       1.461   3.862  24.353  1.00 15.09           O  
+ATOM    558  CB  SER E  93       2.146   2.910  26.930  1.00 25.42           C  
+ATOM    559  OG  SER E  93       2.396   2.098  28.110  1.00 24.14           O  
+ATOM    560  N   TYR E  94       2.457   1.971  23.406  1.00 10.13           N  
+ATOM    561  CA  TYR E  94       2.432   2.652  22.042  1.00  6.60           C  
+ATOM    562  C   TYR E  94       1.019   3.062  21.628  1.00  6.60           C  
+ATOM    563  O   TYR E  94       0.112   2.249  21.645  1.00 21.64           O  
+ATOM    564  CB  TYR E  94       3.104   1.765  20.963  1.00  3.00           C  
+ATOM    565  CG  TYR E  94       3.008   2.351  19.524  1.00 15.63           C  
+ATOM    566  CD1 TYR E  94       3.465   3.609  19.226  1.00  6.19           C  
+ATOM    567  CD2 TYR E  94       2.434   1.604  18.528  1.00 16.80           C  
+ATOM    568  CE1 TYR E  94       3.349   4.152  17.949  1.00  4.32           C  
+ATOM    569  CE2 TYR E  94       2.305   2.125  17.262  1.00  7.12           C  
+ATOM    570  CZ  TYR E  94       2.747   3.387  16.967  1.00 17.01           C  
+ATOM    571  OH  TYR E  94       2.642   3.820  15.674  1.00 12.41           O  
+ATOM    572  N   ASN E  95       0.856   4.245  21.097  1.00 18.54           N  
+ATOM    573  CA  ASN E  95      -0.406   4.705  20.567  1.00  9.54           C  
+ATOM    574  C   ASN E  95      -0.235   5.126  19.134  1.00  5.69           C  
+ATOM    575  O   ASN E  95       0.397   6.154  18.894  1.00 17.56           O  
+ATOM    576  CB  ASN E  95      -0.892   6.026  21.221  1.00 22.21           C  
+ATOM    577  CG  ASN E  95      -2.349   6.291  20.779  1.00 10.61           C  
+ATOM    578  OD1 ASN E  95      -2.672   6.806  19.722  1.00 27.73           O  
+ATOM    579  ND2 ASN E  95      -3.244   5.958  21.616  1.00 38.22           N  
+ATOM    580  N   SER E  96      -0.842   4.393  18.224  1.00  9.85           N  
+ATOM    581  CA  SER E  96      -0.699   4.737  16.787  1.00 19.40           C  
+ATOM    582  C   SER E  96      -1.462   5.958  16.330  1.00 24.63           C  
+ATOM    583  O   SER E  96      -1.225   6.394  15.208  1.00 24.02           O  
+ATOM    584  CB  SER E  96      -1.122   3.569  15.886  1.00 18.78           C  
+ATOM    585  OG  SER E  96      -2.437   3.200  16.284  1.00 23.31           O  
+ATOM    586  N   ASN E  97      -2.384   6.455  17.137  1.00 10.25           N  
+ATOM    587  CA  ASN E  97      -3.082   7.706  16.746  1.00 21.60           C  
+ATOM    588  C   ASN E  97      -2.191   8.912  17.105  1.00 33.22           C  
+ATOM    589  O   ASN E  97      -2.147   9.936  16.428  1.00 19.38           O  
+ATOM    590  CB  ASN E  97      -4.443   7.809  17.529  1.00 26.82           C  
+ATOM    591  CG  ASN E  97      -5.322   6.632  17.117  1.00 50.94           C  
+ATOM    592  OD1 ASN E  97      -5.734   5.791  17.930  1.00 35.26           O  
+ATOM    593  ND2 ASN E  97      -5.566   6.604  15.832  1.00 29.12           N  
+ATOM    594  N   THR E  98      -1.505   8.824  18.228  1.00 20.30           N  
+ATOM    595  CA  THR E  98      -0.800  10.000  18.699  1.00  7.46           C  
+ATOM    596  C   THR E  98       0.719   9.872  18.584  1.00  3.48           C  
+ATOM    597  O   THR E  98       1.444  10.896  18.487  1.00  9.99           O  
+ATOM    598  CB  THR E  98      -1.120  10.161  20.175  1.00 15.51           C  
+ATOM    599  OG1 THR E  98      -0.690   8.983  20.858  1.00 17.52           O  
+ATOM    600  CG2 THR E  98      -2.634  10.356  20.323  1.00 37.69           C  
+ATOM    601  N   LEU E  99       1.053   8.655  18.292  1.00  4.00           N  
+ATOM    602  CA  LEU E  99       2.481   8.311  18.073  1.00 24.80           C  
+ATOM    603  C   LEU E  99       3.222   8.445  19.399  1.00 17.21           C  
+ATOM    604  O   LEU E  99       4.443   8.508  19.421  1.00 18.39           O  
+ATOM    605  CB  LEU E  99       3.151   9.204  16.994  1.00  8.07           C  
+ATOM    606  CG  LEU E  99       2.751   8.782  15.535  1.00  5.47           C  
+ATOM    607  CD1 LEU E  99       3.364   9.747  14.493  1.00 10.75           C  
+ATOM    608  CD2 LEU E  99       3.254   7.366  15.261  1.00 15.39           C  
+ATOM    609  N   ASN E 100       2.487   8.429  20.517  1.00 21.30           N  
+ATOM    610  CA  ASN E 100       3.097   8.492  21.889  1.00  8.94           C  
+ATOM    611  C   ASN E 100       3.734   7.171  22.233  1.00 11.08           C  
+ATOM    612  O   ASN E 100       3.194   6.197  21.769  1.00  7.49           O  
+ATOM    613  CB  ASN E 100       1.995   8.740  22.940  1.00 14.97           C  
+ATOM    614  CG  ASN E 100       2.673   9.098  24.269  1.00 15.81           C  
+ATOM    615  OD1 ASN E 100       2.120   8.816  25.329  1.00 22.85           O  
+ATOM    616  ND2 ASN E 100       3.802   9.771  24.223  1.00 17.74           N  
+ATOM    617  N   ASN E 101       4.906   7.128  22.857  1.00  9.01           N  
+ATOM    618  CA  ASN E 101       5.610   5.851  23.086  1.00 13.39           C  
+ATOM    619  C   ASN E 101       6.051   5.168  21.798  1.00  3.11           C  
+ATOM    620  O   ASN E 101       6.085   3.942  21.669  1.00  6.29           O  
+ATOM    621  CB  ASN E 101       4.928   4.858  24.081  1.00  6.90           C  
+ATOM    622  CG  ASN E 101       4.507   5.615  25.344  1.00 14.62           C  
+ATOM    623  OD1 ASN E 101       3.342   5.946  25.471  1.00 18.46           O  
+ATOM    624  ND2 ASN E 101       5.412   5.917  26.177  1.00  3.00           N  
+ATOM    625  N   ASP E 102       6.503   5.998  20.860  1.00 17.31           N  
+ATOM    626  CA  ASP E 102       6.865   5.444  19.514  1.00  5.57           C  
+ATOM    627  C   ASP E 102       8.263   4.842  19.513  1.00 15.47           C  
+ATOM    628  O   ASP E 102       9.245   5.538  19.185  1.00 16.69           O  
+ATOM    629  CB  ASP E 102       6.800   6.583  18.476  1.00 11.09           C  
+ATOM    630  CG  ASP E 102       6.865   6.059  17.037  1.00  9.60           C  
+ATOM    631  OD1 ASP E 102       6.804   4.825  16.794  1.00  3.00           O  
+ATOM    632  OD2 ASP E 102       6.930   6.894  16.089  1.00  3.00           O  
+ATOM    633  N   ILE E 103       8.327   3.650  20.077  1.00  6.30           N  
+ATOM    634  CA  ILE E 103       9.638   3.000  20.282  1.00  7.69           C  
+ATOM    635  C   ILE E 103       9.506   1.490  20.065  1.00  3.00           C  
+ATOM    636  O   ILE E 103       8.479   0.975  20.449  1.00 14.77           O  
+ATOM    637  CB  ILE E 103      10.287   3.378  21.669  1.00 14.80           C  
+ATOM    638  CG1 ILE E 103      11.678   2.748  21.833  1.00  5.29           C  
+ATOM    639  CG2 ILE E 103       9.435   3.254  22.998  1.00  3.02           C  
+ATOM    640  CD1 ILE E 103      12.435   3.402  23.015  1.00 11.45           C  
+ATOM    641  N   MET E 104      10.492   0.758  19.656  1.00  3.00           N  
+ATOM    642  CA  MET E 104      10.331  -0.709  19.541  1.00  3.00           C  
+ATOM    643  C   MET E 104      11.728  -1.317  19.534  1.00  3.09           C  
+ATOM    644  O   MET E 104      12.694  -0.695  19.123  1.00  3.00           O  
+ATOM    645  CB  MET E 104       9.660  -0.969  18.148  1.00 17.64           C  
+ATOM    646  CG  MET E 104       9.853  -2.321  17.466  1.00 13.49           C  
+ATOM    647  SD  MET E 104       9.166  -2.405  15.765  1.00 16.69           S  
+ATOM    648  CE  MET E 104      10.422  -1.617  14.744  1.00  8.69           C  
+ATOM    649  N   LEU E 105      11.798  -2.530  19.991  1.00  5.49           N  
+ATOM    650  CA  LEU E 105      13.078  -3.257  20.020  1.00 12.62           C  
+ATOM    651  C   LEU E 105      13.003  -4.431  19.047  1.00 11.42           C  
+ATOM    652  O   LEU E 105      12.018  -5.149  19.012  1.00 11.39           O  
+ATOM    653  CB  LEU E 105      13.241  -3.810  21.477  1.00 19.48           C  
+ATOM    654  CG  LEU E 105      14.209  -3.078  22.491  1.00 25.25           C  
+ATOM    655  CD1 LEU E 105      14.691  -1.660  22.168  1.00 15.96           C  
+ATOM    656  CD2 LEU E 105      13.609  -3.081  23.889  1.00 19.45           C  
+ATOM    657  N   ILE E 106      14.052  -4.672  18.308  1.00  5.01           N  
+ATOM    658  CA  ILE E 106      14.089  -5.796  17.390  1.00 12.52           C  
+ATOM    659  C   ILE E 106      15.271  -6.637  17.843  1.00 13.33           C  
+ATOM    660  O   ILE E 106      16.384  -6.145  17.933  1.00 10.45           O  
+ATOM    661  CB  ILE E 106      14.278  -5.358  15.878  1.00  8.49           C  
+ATOM    662  CG1 ILE E 106      13.153  -4.481  15.301  1.00  4.72           C  
+ATOM    663  CG2 ILE E 106      14.596  -6.508  14.902  1.00  3.74           C  
+ATOM    664  CD1 ILE E 106      13.574  -3.669  14.057  1.00 11.75           C  
+ATOM    665  N   LYS E 107      15.003  -7.872  18.085  1.00  9.45           N  
+ATOM    666  CA  LYS E 107      16.060  -8.806  18.300  1.00  4.30           C  
+ATOM    667  C   LYS E 107      16.461  -9.455  16.987  1.00  4.87           C  
+ATOM    668  O   LYS E 107      15.596 -10.009  16.330  1.00 12.15           O  
+ATOM    669  CB  LYS E 107      15.503  -9.920  19.247  1.00  9.48           C  
+ATOM    670  CG  LYS E 107      16.675 -10.750  19.824  1.00  7.87           C  
+ATOM    671  CD  LYS E 107      16.186 -11.910  20.688  1.00 16.41           C  
+ATOM    672  CE  LYS E 107      17.418 -12.381  21.497  1.00 23.19           C  
+ATOM    673  NZ  LYS E 107      17.066 -13.556  22.303  1.00 31.43           N  
+ATOM    674  N   LEU E 108      17.737  -9.543  16.741  1.00  8.35           N  
+ATOM    675  CA  LEU E 108      18.298 -10.218  15.573  1.00  6.15           C  
+ATOM    676  C   LEU E 108      18.284 -11.721  15.705  1.00 13.45           C  
+ATOM    677  O   LEU E 108      18.403 -12.231  16.816  1.00 23.07           O  
+ATOM    678  CB  LEU E 108      19.742  -9.662  15.299  1.00 18.40           C  
+ATOM    679  CG  LEU E 108      19.729  -8.103  15.133  1.00  6.50           C  
+ATOM    680  CD1 LEU E 108      21.174  -7.552  15.152  1.00  3.00           C  
+ATOM    681  CD2 LEU E 108      18.874  -7.708  13.880  1.00  3.00           C  
+ATOM    682  N   LYS E 109      18.122 -12.388  14.584  1.00 14.97           N  
+ATOM    683  CA  LYS E 109      18.159 -13.874  14.554  1.00  8.11           C  
+ATOM    684  C   LYS E 109      19.562 -14.455  14.828  1.00 12.56           C  
+ATOM    685  O   LYS E 109      19.706 -15.430  15.556  1.00 20.67           O  
+ATOM    686  CB  LYS E 109      17.674 -14.278  13.156  1.00 23.27           C  
+ATOM    687  CG  LYS E 109      17.211 -15.732  13.116  1.00 24.95           C  
+ATOM    688  CD  LYS E 109      16.504 -16.048  11.794  1.00 52.98           C  
+ATOM    689  CE  LYS E 109      15.155 -15.294  11.588  1.00 53.24           C  
+ATOM    690  NZ  LYS E 109      14.613 -15.638  10.239  1.00 52.65           N  
+ATOM    691  N   SER E 110      20.588 -13.655  14.618  1.00 10.22           N  
+ATOM    692  CA  SER E 110      21.964 -13.996  15.004  1.00 17.26           C  
+ATOM    693  C   SER E 110      22.600 -12.735  15.516  1.00 19.61           C  
+ATOM    694  O   SER E 110      22.206 -11.686  15.052  1.00 12.49           O  
+ATOM    695  CB  SER E 110      22.768 -14.265  13.726  1.00 35.08           C  
+ATOM    696  OG  SER E 110      22.449 -15.539  13.266  1.00 45.25           O  
+ATOM    697  N   ALA E 111      23.659 -12.862  16.263  1.00 12.19           N  
+ATOM    698  CA  ALA E 111      24.301 -11.654  16.741  1.00  9.37           C  
+ATOM    699  C   ALA E 111      24.998 -11.128  15.506  1.00 23.08           C  
+ATOM    700  O   ALA E 111      25.653 -11.915  14.854  1.00  9.85           O  
+ATOM    701  CB  ALA E 111      25.436 -12.191  17.655  1.00  7.52           C  
+ATOM    702  N   ALA E 112      25.157  -9.860  15.413  1.00 11.57           N  
+ATOM    703  CA  ALA E 112      26.000  -9.264  14.379  1.00 14.16           C  
+ATOM    704  C   ALA E 112      27.460  -9.390  14.802  1.00 28.44           C  
+ATOM    705  O   ALA E 112      27.678  -9.352  16.018  1.00 13.03           O  
+ATOM    706  CB  ALA E 112      25.634  -7.736  14.279  1.00  6.39           C  
+ATOM    707  N   SER E 113      28.404  -9.312  13.835  1.00 18.39           N  
+ATOM    708  CA  SER E 113      29.861  -9.113  14.245  1.00 15.57           C  
+ATOM    709  C   SER E 113      30.138  -7.634  14.273  1.00 13.93           C  
+ATOM    710  O   SER E 113      30.112  -6.988  13.220  1.00 17.40           O  
+ATOM    711  CB  SER E 113      30.990  -9.594  13.269  1.00 18.82           C  
+ATOM    712  OG  SER E 113      30.361 -10.471  12.328  1.00 51.53           O  
+ATOM    713  N   LEU E 114      30.594  -7.260  15.433  1.00  4.61           N  
+ATOM    714  CA  LEU E 114      31.017  -5.927  15.664  1.00  7.63           C  
+ATOM    715  C   LEU E 114      32.426  -5.746  15.088  1.00 14.45           C  
+ATOM    716  O   LEU E 114      33.280  -6.630  15.170  1.00 14.38           O  
+ATOM    717  CB  LEU E 114      30.922  -5.560  17.183  1.00  4.07           C  
+ATOM    718  CG  LEU E 114      29.574  -5.812  17.878  1.00  6.72           C  
+ATOM    719  CD1 LEU E 114      29.644  -5.378  19.332  1.00 18.08           C  
+ATOM    720  CD2 LEU E 114      28.450  -5.024  17.238  1.00 14.21           C  
+ATOM    721  N   ASN E 115      32.596  -4.707  14.365  1.00  3.40           N  
+ATOM    722  CA  ASN E 115      33.889  -4.379  13.805  1.00 10.74           C  
+ATOM    723  C   ASN E 115      33.966  -2.876  13.712  1.00 14.13           C  
+ATOM    724  O   ASN E 115      33.256  -2.153  14.426  1.00 18.75           O  
+ATOM    725  CB  ASN E 115      34.199  -5.053  12.446  1.00  5.99           C  
+ATOM    726  CG  ASN E 115      33.077  -4.754  11.464  1.00 22.33           C  
+ATOM    727  OD1 ASN E 115      32.750  -3.597  11.250  1.00 23.03           O  
+ATOM    728  ND2 ASN E 115      32.561  -5.804  10.877  1.00 20.08           N  
+ATOM    729  N   SER E 116      34.824  -2.453  12.834  1.00 13.28           N  
+ATOM    730  CA  SER E 116      35.037  -0.984  12.789  1.00 47.51           C  
+ATOM    731  C   SER E 116      33.946  -0.226  12.005  1.00 24.38           C  
+ATOM    732  O   SER E 116      33.541   0.860  12.403  1.00 24.15           O  
+ATOM    733  CB  SER E 116      36.399  -0.753  12.135  1.00 24.27           C  
+ATOM    734  OG  SER E 116      36.348  -1.400  10.852  1.00 38.49           O  
+ATOM    735  N   ARG E 117      33.266  -0.943  11.166  1.00 15.37           N  
+ATOM    736  CA  ARG E 117      32.085  -0.466  10.425  1.00 34.21           C  
+ATOM    737  C   ARG E 117      30.769  -0.730  11.153  1.00 23.36           C  
+ATOM    738  O   ARG E 117      29.750  -0.201  10.706  1.00 21.08           O  
+ATOM    739  CB  ARG E 117      32.132  -1.055   8.979  1.00 20.69           C  
+ATOM    740  CG  ARG E 117      33.443  -0.452   8.396  1.00 36.27           C  
+ATOM    741  CD  ARG E 117      34.009  -1.022   7.095  1.00 36.71           C  
+ATOM    742  NE  ARG E 117      35.265  -0.285   6.812  1.00 56.06           N  
+ATOM    743  CZ  ARG E 117      36.278  -0.603   5.984  1.00 75.33           C  
+ATOM    744  NH1 ARG E 117      36.257  -1.653   5.174  1.00 51.49           N  
+ATOM    745  NH2 ARG E 117      37.295   0.238   5.856  1.00 49.19           N  
+ATOM    746  N   VAL E 118      30.757  -1.676  12.123  1.00 14.05           N  
+ATOM    747  CA  VAL E 118      29.523  -2.123  12.725  1.00  3.00           C  
+ATOM    748  C   VAL E 118      29.637  -2.038  14.235  1.00  8.48           C  
+ATOM    749  O   VAL E 118      30.442  -2.727  14.821  1.00 10.63           O  
+ATOM    750  CB  VAL E 118      29.010  -3.472  12.219  1.00  3.00           C  
+ATOM    751  CG1 VAL E 118      27.679  -3.864  12.861  1.00  3.00           C  
+ATOM    752  CG2 VAL E 118      28.767  -3.407  10.730  1.00  5.48           C  
+ATOM    753  N   ALA E 119      29.035  -1.042  14.842  1.00  6.45           N  
+ATOM    754  CA  ALA E 119      29.329  -0.814  16.267  1.00  5.81           C  
+ATOM    755  C   ALA E 119      28.040  -0.290  16.877  1.00 17.45           C  
+ATOM    756  O   ALA E 119      27.171   0.144  16.148  1.00  5.84           O  
+ATOM    757  CB  ALA E 119      30.400   0.270  16.368  1.00 15.66           C  
+ATOM    758  N   SER E 120      27.867  -0.472  18.134  1.00 11.21           N  
+ATOM    759  CA  SER E 120      26.665  -0.081  18.853  1.00  7.32           C  
+ATOM    760  C   SER E 120      26.843   1.238  19.613  1.00 13.28           C  
+ATOM    761  O   SER E 120      27.907   1.837  19.582  1.00 14.33           O  
+ATOM    762  CB  SER E 120      26.317  -1.182  19.863  1.00  5.52           C  
+ATOM    763  OG  SER E 120      27.458  -1.543  20.623  1.00 21.53           O  
+ATOM    764  N   ILE E 121      25.739   1.881  19.845  1.00  3.46           N  
+ATOM    765  CA  ILE E 121      25.690   3.253  20.363  1.00 11.70           C  
+ATOM    766  C   ILE E 121      25.221   3.147  21.819  1.00 19.13           C  
+ATOM    767  O   ILE E 121      24.431   2.270  22.165  1.00 14.70           O  
+ATOM    768  CB  ILE E 121      24.681   4.103  19.519  1.00  4.50           C  
+ATOM    769  CG1 ILE E 121      24.676   5.557  19.974  1.00  3.00           C  
+ATOM    770  CG2 ILE E 121      23.262   3.492  19.402  1.00  3.00           C  
+ATOM    771  CD1 ILE E 121      26.105   6.187  19.865  1.00  6.70           C  
+ATOM    772  N   SER E 122      25.740   3.971  22.688  1.00  7.42           N  
+ATOM    773  CA  SER E 122      25.321   3.830  24.092  1.00 14.27           C  
+ATOM    774  C   SER E 122      23.943   4.440  24.292  1.00  4.85           C  
+ATOM    775  O   SER E 122      23.614   5.480  23.668  1.00 10.89           O  
+ATOM    776  CB  SER E 122      26.298   4.693  24.992  1.00 14.88           C  
+ATOM    777  OG  SER E 122      27.566   4.023  25.015  1.00 29.85           O  
+ATOM    778  N   LEU E 123      23.402   3.979  25.390  1.00  6.93           N  
+ATOM    779  CA  LEU E 123      22.159   4.506  25.955  1.00  4.66           C  
+ATOM    780  C   LEU E 123      22.493   5.643  26.902  1.00  9.72           C  
+ATOM    781  O   LEU E 123      23.447   5.527  27.647  1.00 12.61           O  
+ATOM    782  CB  LEU E 123      21.354   3.434  26.721  1.00  6.20           C  
+ATOM    783  CG  LEU E 123      20.719   2.366  25.791  1.00 30.36           C  
+ATOM    784  CD1 LEU E 123      19.954   1.245  26.548  1.00 23.49           C  
+ATOM    785  CD2 LEU E 123      19.808   3.021  24.722  1.00 20.46           C  
+ATOM    786  N   PRO E 124      21.634   6.670  26.972  1.00 22.57           N  
+ATOM    787  CA  PRO E 124      21.900   7.812  27.845  1.00 18.79           C  
+ATOM    788  C   PRO E 124      21.664   7.472  29.325  1.00 21.33           C  
+ATOM    789  O   PRO E 124      20.721   6.757  29.644  1.00 16.14           O  
+ATOM    790  CB  PRO E 124      20.916   8.871  27.294  1.00 10.05           C  
+ATOM    791  CG  PRO E 124      19.713   8.111  26.820  1.00  3.00           C  
+ATOM    792  CD  PRO E 124      20.350   6.814  26.288  1.00  6.04           C  
+ATOM    793  N   THR E 125      22.359   8.194  30.198  1.00 17.66           N  
+ATOM    794  CA  THR E 125      22.107   8.147  31.629  1.00 21.23           C  
+ATOM    795  C   THR E 125      21.291   9.349  32.060  1.00 24.36           C  
+ATOM    796  O   THR E 125      20.468   9.249  32.959  1.00 39.74           O  
+ATOM    797  CB  THR E 125      23.451   8.103  32.425  1.00 32.81           C  
+ATOM    798  OG1 THR E 125      24.157   9.330  32.288  1.00 33.20           O  
+ATOM    799  CG2 THR E 125      24.407   7.020  31.921  1.00 15.44           C  
+ATOM    800  N   SER E 127      21.323  10.400  31.317  1.00 15.69           N  
+ATOM    801  CA  SER E 127      20.254  11.432  31.574  1.00 19.51           C  
+ATOM    802  C   SER E 127      19.774  12.031  30.256  1.00 10.38           C  
+ATOM    803  O   SER E 127      20.371  11.679  29.232  1.00 19.77           O  
+ATOM    804  CB  SER E 127      20.805  12.590  32.423  1.00 20.11           C  
+ATOM    805  OG  SER E 127      22.003  13.012  31.803  1.00 36.51           O  
+ATOM    806  N   CYS E 128      18.664  12.791  30.308  1.00  6.91           N  
+ATOM    807  CA  CYS E 128      18.048  13.398  29.125  1.00  3.00           C  
+ATOM    808  C   CYS E 128      18.942  14.574  28.762  1.00 11.66           C  
+ATOM    809  O   CYS E 128      19.580  15.109  29.643  1.00 21.94           O  
+ATOM    810  CB  CYS E 128      16.706  13.979  29.541  1.00  3.00           C  
+ATOM    811  SG  CYS E 128      15.623  12.659  30.091  1.00 17.25           S  
+ATOM    812  N   ALA E 129      18.864  15.010  27.561  1.00 11.13           N  
+ATOM    813  CA  ALA E 129      19.668  16.097  27.076  1.00 11.02           C  
+ATOM    814  C   ALA E 129      18.872  17.373  27.024  1.00 13.44           C  
+ATOM    815  O   ALA E 129      17.656  17.302  26.950  1.00 22.03           O  
+ATOM    816  CB  ALA E 129      20.030  15.738  25.633  1.00 10.58           C  
+ATOM    817  N   SER E 130      19.591  18.490  27.137  1.00  7.85           N  
+ATOM    818  CA  SER E 130      18.961  19.772  27.322  1.00 15.82           C  
+ATOM    819  C   SER E 130      18.819  20.510  26.000  1.00  3.74           C  
+ATOM    820  O   SER E 130      19.605  20.322  25.066  1.00  7.07           O  
+ATOM    821  CB  SER E 130      19.733  20.642  28.373  1.00 19.36           C  
+ATOM    822  OG  SER E 130      21.084  20.947  27.936  1.00 41.34           O  
+ATOM    823  N   ALA E 132      17.963  21.461  26.105  1.00  3.00           N  
+ATOM    824  CA  ALA E 132      17.596  22.304  25.005  1.00  4.72           C  
+ATOM    825  C   ALA E 132      18.842  23.068  24.567  1.00 18.21           C  
+ATOM    826  O   ALA E 132      19.633  23.366  25.422  1.00  4.48           O  
+ATOM    827  CB  ALA E 132      16.434  23.281  25.411  1.00  6.69           C  
+ATOM    828  N   GLY E 133      19.144  23.148  23.299  1.00 18.06           N  
+ATOM    829  CA  GLY E 133      20.367  23.797  22.819  1.00  5.18           C  
+ATOM    830  C   GLY E 133      21.481  22.815  22.475  1.00  3.00           C  
+ATOM    831  O   GLY E 133      22.486  23.250  21.947  1.00  4.14           O  
+ATOM    832  N   THR E 134      21.403  21.608  22.937  1.00  6.69           N  
+ATOM    833  CA  THR E 134      22.457  20.639  22.678  1.00  9.80           C  
+ATOM    834  C   THR E 134      22.417  20.102  21.253  1.00  8.77           C  
+ATOM    835  O   THR E 134      21.369  19.776  20.723  1.00  4.39           O  
+ATOM    836  CB  THR E 134      22.277  19.451  23.611  1.00  5.69           C  
+ATOM    837  OG1 THR E 134      22.279  19.917  24.965  1.00 13.26           O  
+ATOM    838  CG2 THR E 134      23.314  18.305  23.325  1.00  7.93           C  
+ATOM    839  N   GLN E 135      23.528  20.235  20.625  1.00  3.00           N  
+ATOM    840  CA  GLN E 135      23.669  19.878  19.233  1.00  8.65           C  
+ATOM    841  C   GLN E 135      23.741  18.344  19.061  1.00 17.81           C  
+ATOM    842  O   GLN E 135      24.405  17.650  19.807  1.00 12.17           O  
+ATOM    843  CB  GLN E 135      24.971  20.558  18.701  1.00 10.05           C  
+ATOM    844  CG  GLN E 135      25.111  20.219  17.204  1.00 44.35           C  
+ATOM    845  CD  GLN E 135      26.512  20.536  16.680  1.00 53.29           C  
+ATOM    846  OE1 GLN E 135      27.458  19.749  16.821  1.00 35.74           O  
+ATOM    847  NE2 GLN E 135      26.567  21.684  16.083  1.00 31.73           N  
+ATOM    848  N   CYS E 136      23.003  17.779  18.141  1.00  7.41           N  
+ATOM    849  CA  CYS E 136      22.973  16.338  17.869  1.00  6.22           C  
+ATOM    850  C   CYS E 136      23.183  16.018  16.358  1.00  3.03           C  
+ATOM    851  O   CYS E 136      23.103  16.874  15.469  1.00  5.92           O  
+ATOM    852  CB  CYS E 136      21.605  15.765  18.293  1.00  3.00           C  
+ATOM    853  SG  CYS E 136      21.126  16.213  19.952  1.00 10.90           S  
+ATOM    854  N   LEU E 137      23.477  14.770  16.103  1.00  3.00           N  
+ATOM    855  CA  LEU E 137      23.660  14.208  14.781  1.00  6.43           C  
+ATOM    856  C   LEU E 137      22.437  13.337  14.488  1.00  7.60           C  
+ATOM    857  O   LEU E 137      22.166  12.392  15.224  1.00 11.15           O  
+ATOM    858  CB  LEU E 137      24.932  13.297  14.769  1.00  3.00           C  
+ATOM    859  CG  LEU E 137      25.287  12.767  13.352  1.00  3.00           C  
+ATOM    860  CD1 LEU E 137      25.539  13.923  12.357  1.00 13.66           C  
+ATOM    861  CD2 LEU E 137      26.487  11.821  13.373  1.00  3.00           C  
+ATOM    862  N   ILE E 138      21.814  13.580  13.385  1.00  3.00           N  
+ATOM    863  CA  ILE E 138      20.712  12.796  12.828  1.00  3.00           C  
+ATOM    864  C   ILE E 138      21.131  12.193  11.496  1.00  7.65           C  
+ATOM    865  O   ILE E 138      21.761  12.878  10.696  1.00  3.00           O  
+ATOM    866  CB  ILE E 138      19.482  13.718  12.623  1.00  3.00           C  
+ATOM    867  CG1 ILE E 138      19.247  14.413  14.011  1.00  4.89           C  
+ATOM    868  CG2 ILE E 138      18.224  12.865  12.167  1.00  3.00           C  
+ATOM    869  CD1 ILE E 138      18.227  15.578  14.009  1.00  9.70           C  
+ATOM    870  N   SER E 139      20.770  10.936  11.268  1.00  4.45           N  
+ATOM    871  CA  SER E 139      21.127  10.287   9.981  1.00  7.61           C  
+ATOM    872  C   SER E 139      20.022   9.425   9.378  1.00  3.00           C  
+ATOM    873  O   SER E 139      19.127   8.950  10.083  1.00  3.00           O  
+ATOM    874  CB  SER E 139      22.421   9.464  10.126  1.00  3.00           C  
+ATOM    875  OG  SER E 139      22.411   8.942  11.422  1.00  3.11           O  
+ATOM    876  N   GLY E 140      20.150   9.243   8.098  1.00  3.00           N  
+ATOM    877  CA  GLY E 140      19.253   8.322   7.440  1.00  3.00           C  
+ATOM    878  C   GLY E 140      19.227   8.411   5.918  1.00  3.00           C  
+ATOM    879  O   GLY E 140      19.929   9.195   5.324  1.00  4.71           O  
+ATOM    880  N   TRP E 141      18.504   7.519   5.270  1.00  5.66           N  
+ATOM    881  CA  TRP E 141      18.440   7.423   3.813  1.00  3.00           C  
+ATOM    882  C   TRP E 141      17.095   7.996   3.381  1.00 12.86           C  
+ATOM    883  O   TRP E 141      16.586   7.658   2.326  1.00  6.68           O  
+ATOM    884  CB  TRP E 141      18.521   5.902   3.422  1.00  3.00           C  
+ATOM    885  CG  TRP E 141      19.967   5.364   3.579  1.00 12.55           C  
+ATOM    886  CD1 TRP E 141      21.030   5.563   2.715  1.00  3.00           C  
+ATOM    887  CD2 TRP E 141      20.496   4.611   4.651  1.00 10.85           C  
+ATOM    888  NE1 TRP E 141      22.144   4.832   3.165  1.00  8.82           N  
+ATOM    889  CE2 TRP E 141      21.836   4.232   4.262  1.00  9.44           C  
+ATOM    890  CE3 TRP E 141      19.926   4.164   5.858  1.00  3.00           C  
+ATOM    891  CZ2 TRP E 141      22.615   3.367   5.033  1.00  3.09           C  
+ATOM    892  CZ3 TRP E 141      20.709   3.257   6.651  1.00  3.00           C  
+ATOM    893  CH2 TRP E 141      22.008   2.853   6.260  1.00  6.71           C  
+ATOM    894  N   GLY E 142      16.525   8.892   4.144  1.00  3.00           N  
+ATOM    895  CA  GLY E 142      15.226   9.372   3.665  1.00  3.00           C  
+ATOM    896  C   GLY E 142      15.310  10.566   2.721  1.00  3.00           C  
+ATOM    897  O   GLY E 142      16.398  10.931   2.250  1.00  3.00           O  
+ATOM    898  N   ASN E 143      14.112  11.002   2.327  1.00  3.00           N  
+ATOM    899  CA  ASN E 143      13.926  12.035   1.339  1.00  3.00           C  
+ATOM    900  C   ASN E 143      14.784  13.271   1.672  1.00  3.68           C  
+ATOM    901  O   ASN E 143      14.877  13.720   2.830  1.00  4.29           O  
+ATOM    902  CB  ASN E 143      12.421  12.375   1.371  1.00  3.35           C  
+ATOM    903  CG  ASN E 143      12.010  13.244   0.167  1.00  6.46           C  
+ATOM    904  OD1 ASN E 143      12.830  13.648  -0.649  1.00  9.66           O  
+ATOM    905  ND2 ASN E 143      10.736  13.497   0.069  1.00  9.44           N  
+ATOM    906  N   THR E 144      15.509  13.771   0.646  1.00  3.00           N  
+ATOM    907  CA  THR E 144      16.276  14.997   0.806  1.00  6.49           C  
+ATOM    908  C   THR E 144      15.557  16.252   0.255  1.00  9.49           C  
+ATOM    909  O   THR E 144      16.173  17.315   0.172  1.00  4.97           O  
+ATOM    910  CB  THR E 144      17.688  14.796   0.160  1.00 11.58           C  
+ATOM    911  OG1 THR E 144      17.538  14.649  -1.235  1.00 11.20           O  
+ATOM    912  CG2 THR E 144      18.361  13.519   0.696  1.00  3.00           C  
+ATOM    913  N   LYS E 145      14.287  16.147  -0.229  1.00  8.29           N  
+ATOM    914  CA  LYS E 145      13.621  17.389  -0.696  1.00 10.88           C  
+ATOM    915  C   LYS E 145      12.503  17.717   0.258  1.00  6.32           C  
+ATOM    916  O   LYS E 145      11.750  16.809   0.581  1.00  9.70           O  
+ATOM    917  CB  LYS E 145      12.851  17.218  -2.053  1.00 10.93           C  
+ATOM    918  CG  LYS E 145      13.856  16.854  -3.159  1.00 18.70           C  
+ATOM    919  CD  LYS E 145      15.151  17.656  -2.976  1.00 15.21           C  
+ATOM    920  CE  LYS E 145      16.257  17.218  -3.951  0.00 20.00           C  
+ATOM    921  NZ  LYS E 145      17.524  17.864  -3.589  0.00 20.00           N  
+ATOM    922  N   SER E 146      12.265  18.978   0.469  1.00 12.86           N  
+ATOM    923  CA  SER E 146      11.138  19.347   1.314  1.00 20.32           C  
+ATOM    924  C   SER E 146       9.960  19.672   0.409  1.00 38.93           C  
+ATOM    925  O   SER E 146       8.848  19.639   0.889  1.00 38.16           O  
+ATOM    926  CB  SER E 146      11.430  20.654   2.065  1.00 34.46           C  
+ATOM    927  OG  SER E 146      11.744  21.704   1.112  1.00 32.18           O  
+ATOM    928  N   SER E 147      10.189  19.741  -0.867  1.00 42.45           N  
+ATOM    929  CA  SER E 147       9.064  19.630  -1.812  1.00 47.83           C  
+ATOM    930  C   SER E 147       9.470  18.617  -2.843  1.00 31.74           C  
+ATOM    931  O   SER E 147      10.555  18.680  -3.422  1.00 38.80           O  
+ATOM    932  CB  SER E 147       8.766  20.939  -2.578  1.00 37.86           C  
+ATOM    933  OG  SER E 147       8.396  21.962  -1.642  0.00 42.86           O  
+ATOM    934  N   GLY E 148       8.664  17.654  -3.020  1.00 30.22           N  
+ATOM    935  CA  GLY E 148       9.174  16.681  -3.983  1.00 39.48           C  
+ATOM    936  C   GLY E 148       9.925  15.546  -3.301  1.00 27.65           C  
+ATOM    937  O   GLY E 148       9.760  15.238  -2.116  1.00 31.22           O  
+ATOM    938  N   THR E 149      10.512  14.795  -4.159  1.00 24.93           N  
+ATOM    939  CA  THR E 149      10.981  13.478  -3.755  1.00 27.12           C  
+ATOM    940  C   THR E 149      12.368  13.363  -4.334  1.00 26.35           C  
+ATOM    941  O   THR E 149      12.520  13.552  -5.526  1.00 20.74           O  
+ATOM    942  CB  THR E 149      10.023  12.428  -4.409  1.00 27.98           C  
+ATOM    943  OG1 THR E 149       8.919  12.082  -3.522  1.00 29.02           O  
+ATOM    944  CG2 THR E 149      10.725  11.149  -4.845  1.00 32.66           C  
+ATOM    945  N   SER E 150      13.321  13.056  -3.501  1.00  7.27           N  
+ATOM    946  CA  SER E 150      14.566  12.598  -4.004  1.00  3.00           C  
+ATOM    947  C   SER E 150      15.188  11.727  -2.924  1.00 15.64           C  
+ATOM    948  O   SER E 150      15.578  12.261  -1.905  1.00 14.11           O  
+ATOM    949  CB  SER E 150      15.380  13.853  -4.178  1.00  3.00           C  
+ATOM    950  OG  SER E 150      16.683  13.406  -4.551  1.00 23.91           O  
+ATOM    951  N   TYR E 151      15.309  10.451  -3.152  1.00  3.31           N  
+ATOM    952  CA  TYR E 151      15.786   9.499  -2.202  1.00  3.00           C  
+ATOM    953  C   TYR E 151      17.191   9.057  -2.525  1.00 12.64           C  
+ATOM    954  O   TYR E 151      17.460   8.730  -3.675  1.00 12.36           O  
+ATOM    955  CB  TYR E 151      14.918   8.263  -2.354  1.00  3.00           C  
+ATOM    956  CG  TYR E 151      13.537   8.623  -1.779  1.00 12.12           C  
+ATOM    957  CD1 TYR E 151      13.444   8.706  -0.425  1.00 11.29           C  
+ATOM    958  CD2 TYR E 151      12.431   8.895  -2.552  1.00 17.45           C  
+ATOM    959  CE1 TYR E 151      12.243   8.994   0.180  1.00 28.81           C  
+ATOM    960  CE2 TYR E 151      11.194   9.199  -1.937  1.00 10.78           C  
+ATOM    961  CZ  TYR E 151      11.123   9.210  -0.566  1.00 21.67           C  
+ATOM    962  OH  TYR E 151       9.921   9.372   0.097  1.00 41.42           O  
+ATOM    963  N   PRO E 152      18.057   9.235  -1.551  1.00 11.88           N  
+ATOM    964  CA  PRO E 152      19.477   9.117  -1.826  1.00  6.70           C  
+ATOM    965  C   PRO E 152      19.973   7.659  -1.782  1.00  3.00           C  
+ATOM    966  O   PRO E 152      19.348   6.753  -1.229  1.00  5.01           O  
+ATOM    967  CB  PRO E 152      20.090   9.933  -0.696  1.00 12.85           C  
+ATOM    968  CG  PRO E 152      19.094   9.799   0.478  1.00  3.00           C  
+ATOM    969  CD  PRO E 152      17.761   9.754  -0.186  1.00  3.00           C  
+ATOM    970  N   ASP E 153      21.105   7.476  -2.368  1.00  3.00           N  
+ATOM    971  CA  ASP E 153      21.825   6.197  -2.432  1.00  6.31           C  
+ATOM    972  C   ASP E 153      22.646   5.945  -1.178  1.00 21.35           C  
+ATOM    973  O   ASP E 153      22.652   4.801  -0.727  1.00 15.12           O  
+ATOM    974  CB  ASP E 153      22.736   6.155  -3.709  1.00 16.30           C  
+ATOM    975  CG  ASP E 153      21.885   5.499  -4.785  1.00 64.82           C  
+ATOM    976  OD1 ASP E 153      20.652   5.746  -4.877  1.00 53.59           O  
+ATOM    977  OD2 ASP E 153      22.394   4.677  -5.580  1.00 59.19           O  
+ATOM    978  N   VAL E 154      23.283   7.023  -0.703  1.00 10.22           N  
+ATOM    979  CA  VAL E 154      24.179   7.093   0.427  1.00  4.79           C  
+ATOM    980  C   VAL E 154      23.646   7.869   1.666  1.00  3.00           C  
+ATOM    981  O   VAL E 154      22.679   8.601   1.612  1.00  3.00           O  
+ATOM    982  CB  VAL E 154      25.624   7.500   0.016  1.00  5.67           C  
+ATOM    983  CG1 VAL E 154      26.339   6.553  -0.988  1.00 10.82           C  
+ATOM    984  CG2 VAL E 154      25.804   8.987  -0.337  1.00  8.17           C  
+ATOM    985  N   LEU E 155      24.169   7.472   2.819  1.00  6.31           N  
+ATOM    986  CA  LEU E 155      23.611   7.854   4.122  1.00  3.00           C  
+ATOM    987  C   LEU E 155      23.919   9.331   4.276  1.00  7.63           C  
+ATOM    988  O   LEU E 155      25.019   9.812   3.944  1.00  6.87           O  
+ATOM    989  CB  LEU E 155      24.347   7.026   5.186  1.00  3.00           C  
+ATOM    990  CG  LEU E 155      23.818   7.341   6.626  1.00  3.00           C  
+ATOM    991  CD1 LEU E 155      22.378   6.867   6.767  1.00  3.00           C  
+ATOM    992  CD2 LEU E 155      24.667   6.587   7.658  1.00  3.00           C  
+ATOM    993  N   LYS E 156      22.903  10.072   4.670  1.00  3.70           N  
+ATOM    994  CA  LYS E 156      23.100  11.540   4.906  1.00  5.08           C  
+ATOM    995  C   LYS E 156      23.046  11.842   6.418  1.00 15.07           C  
+ATOM    996  O   LYS E 156      22.454  11.015   7.130  1.00  3.00           O  
+ATOM    997  CB  LYS E 156      21.922  12.260   4.186  1.00  3.00           C  
+ATOM    998  CG  LYS E 156      21.860  11.970   2.675  1.00  3.00           C  
+ATOM    999  CD  LYS E 156      23.081  12.642   1.967  1.00  3.00           C  
+ATOM   1000  CE  LYS E 156      23.182  12.065   0.550  1.00  5.34           C  
+ATOM   1001  NZ  LYS E 156      24.424  12.479  -0.115  1.00  3.00           N  
+ATOM   1002  N   CYS E 157      23.686  12.973   6.825  1.00  3.00           N  
+ATOM   1003  CA  CYS E 157      23.857  13.404   8.195  1.00  3.00           C  
+ATOM   1004  C   CYS E 157      23.366  14.839   8.370  1.00  3.76           C  
+ATOM   1005  O   CYS E 157      23.445  15.621   7.431  1.00  3.00           O  
+ATOM   1006  CB  CYS E 157      25.317  13.355   8.498  1.00  3.00           C  
+ATOM   1007  SG  CYS E 157      25.784  11.759   9.079  1.00  4.26           S  
+ATOM   1008  N   LEU E 158      23.002  15.193   9.567  1.00  3.00           N  
+ATOM   1009  CA  LEU E 158      22.587  16.570   9.807  1.00  3.00           C  
+ATOM   1010  C   LEU E 158      22.899  16.892  11.245  1.00  4.52           C  
+ATOM   1011  O   LEU E 158      22.474  16.145  12.117  1.00  3.00           O  
+ATOM   1012  CB  LEU E 158      21.015  16.624   9.703  1.00  5.00           C  
+ATOM   1013  CG  LEU E 158      20.323  17.996   9.994  1.00  4.45           C  
+ATOM   1014  CD1 LEU E 158      20.858  19.180   9.181  1.00  3.00           C  
+ATOM   1015  CD2 LEU E 158      18.757  17.816   9.989  1.00  3.00           C  
+ATOM   1016  N   LYS E 159      23.411  18.066  11.466  1.00  3.00           N  
+ATOM   1017  CA  LYS E 159      23.558  18.461  12.855  1.00  4.11           C  
+ATOM   1018  C   LYS E 159      22.447  19.437  13.197  1.00  3.87           C  
+ATOM   1019  O   LYS E 159      22.128  20.264  12.356  1.00  6.23           O  
+ATOM   1020  CB  LYS E 159      24.926  19.135  13.108  1.00  7.96           C  
+ATOM   1021  CG  LYS E 159      26.042  18.067  12.983  1.00  6.51           C  
+ATOM   1022  CD  LYS E 159      27.405  18.710  12.882  1.00 30.87           C  
+ATOM   1023  CE  LYS E 159      28.489  17.658  12.621  1.00 39.92           C  
+ATOM   1024  NZ  LYS E 159      29.682  18.382  12.164  1.00 43.69           N  
+ATOM   1025  N   ALA E 160      21.819  19.222  14.321  1.00  5.03           N  
+ATOM   1026  CA  ALA E 160      20.621  19.997  14.644  1.00  5.58           C  
+ATOM   1027  C   ALA E 160      20.509  20.099  16.180  1.00 15.48           C  
+ATOM   1028  O   ALA E 160      20.797  19.096  16.816  1.00  3.43           O  
+ATOM   1029  CB  ALA E 160      19.429  19.173  14.113  1.00  3.00           C  
+ATOM   1030  N   PRO E 161      20.049  21.235  16.783  1.00 15.64           N  
+ATOM   1031  CA  PRO E 161      19.939  21.396  18.256  1.00  8.03           C  
+ATOM   1032  C   PRO E 161      18.591  20.926  18.750  1.00 13.75           C  
+ATOM   1033  O   PRO E 161      17.626  20.982  17.983  1.00  3.00           O  
+ATOM   1034  CB  PRO E 161      20.096  22.937  18.511  1.00  3.00           C  
+ATOM   1035  CG  PRO E 161      19.341  23.487  17.299  1.00 11.52           C  
+ATOM   1036  CD  PRO E 161      19.623  22.502  16.124  1.00 13.87           C  
+ATOM   1037  N   ILE E 162      18.593  20.436  20.004  1.00  9.73           N  
+ATOM   1038  CA  ILE E 162      17.323  20.162  20.713  1.00 22.94           C  
+ATOM   1039  C   ILE E 162      16.644  21.504  21.005  1.00 18.95           C  
+ATOM   1040  O   ILE E 162      17.322  22.484  21.270  1.00  7.21           O  
+ATOM   1041  CB  ILE E 162      17.530  19.306  21.996  1.00 15.33           C  
+ATOM   1042  CG1 ILE E 162      18.038  17.912  21.584  1.00  3.20           C  
+ATOM   1043  CG2 ILE E 162      16.227  19.108  22.841  1.00  3.00           C  
+ATOM   1044  CD1 ILE E 162      18.507  17.026  22.731  1.00  6.34           C  
+ATOM   1045  N   LEU E 163      15.377  21.622  20.690  1.00  3.29           N  
+ATOM   1046  CA  LEU E 163      14.740  22.922  20.884  1.00  3.00           C  
+ATOM   1047  C   LEU E 163      14.003  22.853  22.229  1.00  6.10           C  
+ATOM   1048  O   LEU E 163      13.647  21.771  22.711  1.00  3.00           O  
+ATOM   1049  CB  LEU E 163      13.672  23.030  19.791  1.00  8.22           C  
+ATOM   1050  CG  LEU E 163      14.215  23.201  18.349  1.00  7.91           C  
+ATOM   1051  CD1 LEU E 163      13.009  23.123  17.376  1.00 12.99           C  
+ATOM   1052  CD2 LEU E 163      14.813  24.609  18.229  1.00  6.14           C  
+ATOM   1053  N   SER E 164      13.605  24.009  22.686  1.00 11.22           N  
+ATOM   1054  CA  SER E 164      12.891  24.017  23.957  1.00 15.20           C  
+ATOM   1055  C   SER E 164      11.545  23.297  23.933  1.00 12.79           C  
+ATOM   1056  O   SER E 164      10.890  23.285  22.895  1.00  9.07           O  
+ATOM   1057  CB  SER E 164      12.681  25.477  24.350  1.00  4.41           C  
+ATOM   1058  OG  SER E 164      11.755  26.030  23.432  1.00 28.42           O  
+ATOM   1059  N   ASP E 165      11.072  22.892  25.079  1.00 12.93           N  
+ATOM   1060  CA  ASP E 165       9.674  22.371  25.096  1.00 11.81           C  
+ATOM   1061  C   ASP E 165       8.617  23.378  24.748  1.00 24.44           C  
+ATOM   1062  O   ASP E 165       7.600  22.998  24.158  1.00 13.88           O  
+ATOM   1063  CB  ASP E 165       9.239  21.635  26.371  1.00 31.04           C  
+ATOM   1064  CG  ASP E 165       9.943  20.283  26.401  1.00 29.77           C  
+ATOM   1065  OD1 ASP E 165      11.171  20.237  26.469  0.00 20.00           O  
+ATOM   1066  OD2 ASP E 165       9.153  19.231  26.339  0.00 20.00           O  
+ATOM   1067  N   SER E 166       8.915  24.601  25.076  1.00 16.82           N  
+ATOM   1068  CA  SER E 166       7.952  25.634  24.779  1.00 15.14           C  
+ATOM   1069  C   SER E 166       7.776  25.668  23.296  1.00 21.50           C  
+ATOM   1070  O   SER E 166       6.671  25.856  22.812  1.00 27.54           O  
+ATOM   1071  CB  SER E 166       8.544  27.024  25.056  1.00 24.18           C  
+ATOM   1072  OG  SER E 166       8.975  27.000  26.399  1.00 50.02           O  
+ATOM   1073  N   SER E 167       8.931  25.791  22.677  1.00 21.81           N  
+ATOM   1074  CA  SER E 167       8.871  26.169  21.284  1.00 19.26           C  
+ATOM   1075  C   SER E 167       8.308  24.966  20.521  1.00 17.24           C  
+ATOM   1076  O   SER E 167       7.434  25.118  19.671  1.00 20.22           O  
+ATOM   1077  CB  SER E 167      10.244  26.637  20.761  1.00  3.00           C  
+ATOM   1078  OG  SER E 167      10.843  25.373  20.627  1.00 18.51           O  
+ATOM   1079  N   CYS E 168       8.501  23.797  21.081  1.00 13.04           N  
+ATOM   1080  CA  CYS E 168       7.981  22.589  20.461  1.00 14.01           C  
+ATOM   1081  C   CYS E 168       6.475  22.600  20.599  1.00 19.31           C  
+ATOM   1082  O   CYS E 168       5.772  22.248  19.652  1.00 16.14           O  
+ATOM   1083  CB  CYS E 168       8.591  21.333  21.147  1.00  3.00           C  
+ATOM   1084  SG  CYS E 168       8.342  19.708  20.324  1.00 19.93           S  
+ATOM   1085  N   LYS E 169       6.065  22.821  21.828  1.00 15.53           N  
+ATOM   1086  CA  LYS E 169       4.638  22.686  22.061  1.00 18.51           C  
+ATOM   1087  C   LYS E 169       3.886  23.733  21.298  1.00  8.05           C  
+ATOM   1088  O   LYS E 169       2.792  23.426  20.852  1.00 22.52           O  
+ATOM   1089  CB  LYS E 169       4.226  22.767  23.532  1.00 15.98           C  
+ATOM   1090  CG  LYS E 169       4.728  21.537  24.297  1.00 17.69           C  
+ATOM   1091  CD  LYS E 169       4.487  21.632  25.811  1.00 22.69           C  
+ATOM   1092  CE  LYS E 169       4.641  20.195  26.409  1.00 32.77           C  
+ATOM   1093  NZ  LYS E 169       4.464  20.230  27.866  0.00 20.00           N  
+ATOM   1094  N   SER E 170       4.479  24.876  21.099  1.00 17.99           N  
+ATOM   1095  CA  SER E 170       3.675  25.814  20.369  1.00 12.64           C  
+ATOM   1096  C   SER E 170       3.735  25.501  18.894  1.00 26.39           C  
+ATOM   1097  O   SER E 170       2.952  26.097  18.165  1.00 27.29           O  
+ATOM   1098  CB  SER E 170       4.195  27.222  20.537  1.00 14.14           C  
+ATOM   1099  OG  SER E 170       5.494  27.216  19.973  1.00 41.60           O  
+ATOM   1100  N   ALA E 171       4.717  24.706  18.473  1.00 19.46           N  
+ATOM   1101  CA  ALA E 171       4.789  24.473  17.012  1.00  4.32           C  
+ATOM   1102  C   ALA E 171       3.652  23.526  16.772  1.00  8.97           C  
+ATOM   1103  O   ALA E 171       3.195  23.460  15.646  1.00 18.36           O  
+ATOM   1104  CB  ALA E 171       6.096  23.772  16.502  1.00 12.35           C  
+ATOM   1105  N   TYR E 172       3.461  22.650  17.729  1.00  3.09           N  
+ATOM   1106  CA  TYR E 172       2.469  21.549  17.579  1.00  3.00           C  
+ATOM   1107  C   TYR E 172       1.486  21.527  18.769  1.00  6.89           C  
+ATOM   1108  O   TYR E 172       1.393  20.574  19.575  1.00 10.22           O  
+ATOM   1109  CB  TYR E 172       3.177  20.173  17.526  1.00  5.13           C  
+ATOM   1110  CG  TYR E 172       4.079  20.055  16.277  1.00 22.62           C  
+ATOM   1111  CD1 TYR E 172       3.497  19.733  15.078  1.00 14.21           C  
+ATOM   1112  CD2 TYR E 172       5.450  20.216  16.361  1.00 19.00           C  
+ATOM   1113  CE1 TYR E 172       4.285  19.510  13.958  1.00 22.81           C  
+ATOM   1114  CE2 TYR E 172       6.234  19.975  15.247  1.00 11.30           C  
+ATOM   1115  CZ  TYR E 172       5.648  19.569  14.062  1.00  3.00           C  
+ATOM   1116  OH  TYR E 172       6.415  19.476  12.946  1.00  6.19           O  
+ATOM   1117  N   PRO E 173       0.550  22.425  18.664  1.00 14.61           N  
+ATOM   1118  CA  PRO E 173      -0.459  22.595  19.752  1.00 25.29           C  
+ATOM   1119  C   PRO E 173      -1.298  21.366  20.086  1.00 12.75           C  
+ATOM   1120  O   PRO E 173      -1.923  20.709  19.255  1.00 19.07           O  
+ATOM   1121  CB  PRO E 173      -1.291  23.765  19.260  1.00 26.35           C  
+ATOM   1122  CG  PRO E 173      -0.301  24.574  18.454  1.00 36.66           C  
+ATOM   1123  CD  PRO E 173       0.445  23.485  17.670  1.00 23.21           C  
+ATOM   1124  N   GLY E 174      -1.237  20.949  21.282  1.00 15.09           N  
+ATOM   1125  CA  GLY E 174      -2.033  19.789  21.406  1.00 10.31           C  
+ATOM   1126  C   GLY E 174      -1.266  18.504  21.143  1.00 30.09           C  
+ATOM   1127  O   GLY E 174      -1.830  17.452  21.444  1.00 31.46           O  
+ATOM   1128  N   GLN E 175      -0.160  18.553  20.367  1.00 13.56           N  
+ATOM   1129  CA  GLN E 175       0.298  17.188  20.002  1.00  9.83           C  
+ATOM   1130  C   GLN E 175       1.540  16.633  20.695  1.00 36.07           C  
+ATOM   1131  O   GLN E 175       1.926  15.487  20.412  1.00 25.50           O  
+ATOM   1132  CB  GLN E 175       0.443  17.104  18.504  1.00 13.56           C  
+ATOM   1133  CG  GLN E 175      -0.926  17.422  17.855  1.00 10.68           C  
+ATOM   1134  CD  GLN E 175      -0.669  18.313  16.641  1.00 35.73           C  
+ATOM   1135  OE1 GLN E 175      -1.040  19.476  16.674  1.00 53.30           O  
+ATOM   1136  NE2 GLN E 175      -0.055  17.831  15.590  1.00 43.06           N  
+ATOM   1137  N   ILE E 176       2.202  17.471  21.495  1.00 28.41           N  
+ATOM   1138  CA  ILE E 176       3.514  17.083  22.053  1.00 24.02           C  
+ATOM   1139  C   ILE E 176       3.373  16.376  23.404  1.00 19.00           C  
+ATOM   1140  O   ILE E 176       2.836  16.973  24.320  1.00 33.29           O  
+ATOM   1141  CB  ILE E 176       4.479  18.310  22.072  1.00  8.26           C  
+ATOM   1142  CG1 ILE E 176       4.644  18.839  20.604  1.00  4.39           C  
+ATOM   1143  CG2 ILE E 176       5.877  17.881  22.636  1.00  3.00           C  
+ATOM   1144  CD1 ILE E 176       5.252  17.697  19.692  1.00  4.22           C  
+ATOM   1145  N   THR E 177       3.698  15.111  23.536  1.00 21.63           N  
+ATOM   1146  CA  THR E 177       3.635  14.535  24.865  1.00  3.00           C  
+ATOM   1147  C   THR E 177       4.998  14.599  25.551  1.00 20.51           C  
+ATOM   1148  O   THR E 177       5.900  15.192  24.990  1.00 23.82           O  
+ATOM   1149  CB  THR E 177       3.192  13.122  24.864  1.00  7.77           C  
+ATOM   1150  OG1 THR E 177       4.368  12.312  24.597  1.00 14.10           O  
+ATOM   1151  CG2 THR E 177       2.061  12.878  23.810  1.00  7.18           C  
+ATOM   1152  N   SER E 178       5.141  14.034  26.723  1.00 17.86           N  
+ATOM   1153  CA  SER E 178       6.350  14.164  27.544  1.00 14.47           C  
+ATOM   1154  C   SER E 178       7.376  13.143  27.076  1.00 11.19           C  
+ATOM   1155  O   SER E 178       8.548  13.171  27.486  1.00 14.05           O  
+ATOM   1156  CB  SER E 178       5.997  13.849  29.008  1.00 15.39           C  
+ATOM   1157  OG  SER E 178       5.522  12.480  29.110  1.00 17.87           O  
+ATOM   1158  N   ASN E 179       6.840  12.289  26.203  1.00  3.00           N  
+ATOM   1159  CA  ASN E 179       7.781  11.306  25.598  1.00 21.81           C  
+ATOM   1160  C   ASN E 179       8.442  11.735  24.252  1.00 11.50           C  
+ATOM   1161  O   ASN E 179       8.821  10.886  23.423  1.00  3.21           O  
+ATOM   1162  CB  ASN E 179       6.935  10.042  25.404  1.00 12.73           C  
+ATOM   1163  CG  ASN E 179       6.488   9.524  26.782  1.00 19.83           C  
+ATOM   1164  OD1 ASN E 179       7.286   9.498  27.744  1.00 22.19           O  
+ATOM   1165  ND2 ASN E 179       5.250   9.085  26.807  1.00 24.64           N  
+ATOM   1166  N   MET E 180       8.258  13.003  23.877  1.00  4.61           N  
+ATOM   1167  CA  MET E 180       8.703  13.542  22.542  1.00  9.77           C  
+ATOM   1168  C   MET E 180       9.622  14.714  22.732  1.00 10.10           C  
+ATOM   1169  O   MET E 180       9.260  15.453  23.609  1.00  7.67           O  
+ATOM   1170  CB  MET E 180       7.463  14.116  21.788  1.00  3.06           C  
+ATOM   1171  CG  MET E 180       6.512  12.930  21.481  1.00  3.00           C  
+ATOM   1172  SD  MET E 180       4.966  13.537  20.795  1.00 11.27           S  
+ATOM   1173  CE  MET E 180       4.046  11.998  20.671  1.00  8.48           C  
+ATOM   1174  N   PHE E 181      10.488  15.095  21.790  1.00  3.00           N  
+ATOM   1175  CA  PHE E 181      11.094  16.453  21.827  1.00  3.00           C  
+ATOM   1176  C   PHE E 181      11.249  16.897  20.386  1.00  3.47           C  
+ATOM   1177  O   PHE E 181      11.312  16.060  19.477  1.00  5.14           O  
+ATOM   1178  CB  PHE E 181      12.509  16.556  22.480  1.00  3.00           C  
+ATOM   1179  CG  PHE E 181      13.556  15.649  21.785  1.00  3.00           C  
+ATOM   1180  CD1 PHE E 181      13.741  14.346  22.260  1.00 12.75           C  
+ATOM   1181  CD2 PHE E 181      14.402  16.187  20.831  1.00  3.00           C  
+ATOM   1182  CE1 PHE E 181      14.773  13.551  21.743  1.00 10.68           C  
+ATOM   1183  CE2 PHE E 181      15.389  15.398  20.293  1.00  3.00           C  
+ATOM   1184  CZ  PHE E 181      15.581  14.069  20.744  1.00  3.00           C  
+ATOM   1185  N   CYS E 182      11.379  18.165  20.252  1.00  9.34           N  
+ATOM   1186  CA  CYS E 182      11.638  18.767  18.978  1.00  6.20           C  
+ATOM   1187  C   CYS E 182      13.121  19.016  18.883  1.00  3.00           C  
+ATOM   1188  O   CYS E 182      13.649  19.514  19.841  1.00  3.00           O  
+ATOM   1189  CB  CYS E 182      10.894  20.081  18.780  1.00  7.54           C  
+ATOM   1190  SG  CYS E 182       9.125  19.941  18.504  1.00 10.25           S  
+ATOM   1191  N   ALA E 183      13.658  18.834  17.682  1.00  4.29           N  
+ATOM   1192  CA  ALA E 183      15.046  19.146  17.268  1.00 16.94           C  
+ATOM   1193  C   ALA E 183      14.987  19.711  15.839  1.00 19.09           C  
+ATOM   1194  O   ALA E 183      14.136  19.280  15.049  1.00  8.25           O  
+ATOM   1195  CB  ALA E 183      15.995  17.875  17.330  1.00  3.00           C  
+ATOM   1196  N   GLY E 184A     15.869  20.683  15.529  1.00  8.86           N  
+ATOM   1197  CA  GLY E 184A     15.884  21.255  14.203  1.00  3.00           C  
+ATOM   1198  C   GLY E 184A     15.857  22.758  14.292  1.00  8.02           C  
+ATOM   1199  O   GLY E 184A     16.488  23.273  15.204  1.00  3.40           O  
+ATOM   1200  N   TYR E 184      15.214  23.373  13.275  1.00  7.80           N  
+ATOM   1201  CA  TYR E 184      15.322  24.823  12.984  1.00 12.58           C  
+ATOM   1202  C   TYR E 184      13.916  25.367  12.704  1.00 21.00           C  
+ATOM   1203  O   TYR E 184      13.200  24.862  11.841  1.00 16.24           O  
+ATOM   1204  CB  TYR E 184      16.241  25.047  11.699  1.00  8.33           C  
+ATOM   1205  CG  TYR E 184      17.681  24.496  11.876  1.00  6.36           C  
+ATOM   1206  CD1 TYR E 184      17.989  23.160  11.611  1.00  6.53           C  
+ATOM   1207  CD2 TYR E 184      18.630  25.321  12.425  1.00 16.08           C  
+ATOM   1208  CE1 TYR E 184      19.267  22.637  11.865  1.00  3.00           C  
+ATOM   1209  CE2 TYR E 184      19.906  24.837  12.665  1.00 11.15           C  
+ATOM   1210  CZ  TYR E 184      20.211  23.512  12.384  1.00  4.48           C  
+ATOM   1211  OH  TYR E 184      21.442  23.104  12.700  1.00 21.46           O  
+ATOM   1212  N   LEU E 185      13.490  26.338  13.478  1.00 12.25           N  
+ATOM   1213  CA  LEU E 185      12.188  26.963  13.249  1.00 12.36           C  
+ATOM   1214  C   LEU E 185      12.183  27.667  11.882  1.00 13.48           C  
+ATOM   1215  O   LEU E 185      11.150  27.798  11.242  1.00 15.10           O  
+ATOM   1216  CB  LEU E 185      11.928  27.966  14.399  1.00  7.79           C  
+ATOM   1217  CG  LEU E 185      11.592  27.196  15.710  1.00  6.54           C  
+ATOM   1218  CD1 LEU E 185      10.810  28.042  16.706  1.00 22.64           C  
+ATOM   1219  CD2 LEU E 185      10.690  25.985  15.430  1.00 13.67           C  
+ATOM   1220  N   GLU E 186      13.339  28.029  11.388  1.00 11.31           N  
+ATOM   1221  CA  GLU E 186      13.411  28.677  10.092  1.00 23.27           C  
+ATOM   1222  C   GLU E 186      13.009  27.778   8.917  1.00 22.22           C  
+ATOM   1223  O   GLU E 186      12.957  28.280   7.803  1.00 24.29           O  
+ATOM   1224  CB  GLU E 186      14.853  29.149   9.911  1.00 35.58           C  
+ATOM   1225  CG  GLU E 186      15.010  30.302   8.902  0.00 61.64           C  
+ATOM   1226  CD  GLU E 186      16.480  30.702   8.848  0.00 50.77           C  
+ATOM   1227  OE1 GLU E 186      17.015  31.204   9.835  0.00 20.00           O  
+ATOM   1228  OE2 GLU E 186      17.090  30.464   7.705  0.00 20.00           O  
+ATOM   1229  N   GLY E 187      13.047  26.487   9.110  1.00 21.63           N  
+ATOM   1230  CA  GLY E 187      12.874  25.472   8.026  1.00 25.36           C  
+ATOM   1231  C   GLY E 187      14.212  25.032   7.413  1.00 30.52           C  
+ATOM   1232  O   GLY E 187      15.246  25.559   7.826  1.00 17.66           O  
+ATOM   1233  N   GLY E 188A     14.126  24.346   6.264  1.00  7.35           N  
+ATOM   1234  CA  GLY E 188A     15.278  24.115   5.385  1.00  3.00           C  
+ATOM   1235  C   GLY E 188A     16.124  22.897   5.823  1.00 11.44           C  
+ATOM   1236  O   GLY E 188A     16.785  22.288   5.011  1.00 17.96           O  
+ATOM   1237  N   LYS E 188      16.132  22.475   7.065  1.00 16.63           N  
+ATOM   1238  CA  LYS E 188      16.920  21.249   7.378  1.00  3.36           C  
+ATOM   1239  C   LYS E 188      16.128  20.440   8.421  1.00  4.61           C  
+ATOM   1240  O   LYS E 188      15.707  21.052   9.414  1.00  7.77           O  
+ATOM   1241  CB  LYS E 188      18.229  21.670   8.055  1.00  6.00           C  
+ATOM   1242  CG  LYS E 188      19.120  22.661   7.274  1.00 16.03           C  
+ATOM   1243  CD  LYS E 188      20.384  22.960   8.089  1.00 23.65           C  
+ATOM   1244  CE  LYS E 188      20.357  24.394   8.616  1.00 47.40           C  
+ATOM   1245  NZ  LYS E 188      21.490  24.609   9.529  0.00 20.00           N  
+ATOM   1246  N   ASP E 189      15.987  19.141   8.219  1.00  3.00           N  
+ATOM   1247  CA  ASP E 189      15.130  18.358   9.049  1.00  3.00           C  
+ATOM   1248  C   ASP E 189      15.334  16.928   8.628  1.00  3.00           C  
+ATOM   1249  O   ASP E 189      15.934  16.709   7.580  1.00  3.00           O  
+ATOM   1250  CB  ASP E 189      13.681  18.784   8.603  1.00  3.00           C  
+ATOM   1251  CG  ASP E 189      12.634  18.372   9.629  1.00  7.71           C  
+ATOM   1252  OD1 ASP E 189      12.954  17.736  10.678  1.00  4.37           O  
+ATOM   1253  OD2 ASP E 189      11.429  18.635   9.416  1.00  7.88           O  
+ATOM   1254  N   SER E 190      14.796  15.988   9.346  1.00  3.00           N  
+ATOM   1255  CA  SER E 190      14.742  14.643   8.818  1.00  3.00           C  
+ATOM   1256  C   SER E 190      13.465  14.559   7.997  1.00  3.97           C  
+ATOM   1257  O   SER E 190      12.754  15.549   7.915  1.00  3.00           O  
+ATOM   1258  CB  SER E 190      14.707  13.595   9.929  1.00  3.82           C  
+ATOM   1259  OG  SER E 190      13.751  13.990  10.930  1.00  3.98           O  
+ATOM   1260  N   CYS E 191      13.151  13.379   7.437  1.00  4.67           N  
+ATOM   1261  CA  CYS E 191      12.002  13.330   6.487  1.00  4.63           C  
+ATOM   1262  C   CYS E 191      11.698  11.865   6.147  1.00  3.00           C  
+ATOM   1263  O   CYS E 191      12.291  10.976   6.742  1.00  3.00           O  
+ATOM   1264  CB  CYS E 191      12.382  14.057   5.161  1.00  3.00           C  
+ATOM   1265  SG  CYS E 191      10.969  14.517   4.059  1.00  4.54           S  
+ATOM   1266  N   GLN E 192      10.670  11.630   5.351  1.00  5.82           N  
+ATOM   1267  CA  GLN E 192      10.162  10.251   5.102  1.00 13.55           C  
+ATOM   1268  C   GLN E 192      11.306   9.280   4.689  1.00 11.01           C  
+ATOM   1269  O   GLN E 192      12.078   9.666   3.813  1.00  3.00           O  
+ATOM   1270  CB  GLN E 192       8.915  10.231   4.166  1.00  3.00           C  
+ATOM   1271  CG  GLN E 192       7.575  10.509   4.941  1.00  4.39           C  
+ATOM   1272  CD  GLN E 192       7.432  11.959   5.356  1.00  8.24           C  
+ATOM   1273  OE1 GLN E 192       7.978  12.805   4.645  1.00  6.72           O  
+ATOM   1274  NE2 GLN E 192       6.717  12.234   6.470  1.00  4.17           N  
+ATOM   1275  N   GLY E 193      11.401   8.109   5.376  1.00  3.00           N  
+ATOM   1276  CA  GLY E 193      12.350   7.083   5.173  1.00  3.00           C  
+ATOM   1277  C   GLY E 193      13.474   7.317   6.173  1.00  3.00           C  
+ATOM   1278  O   GLY E 193      14.341   6.470   6.284  1.00  3.07           O  
+ATOM   1279  N   ASP E 194      13.372   8.340   6.981  1.00  3.00           N  
+ATOM   1280  CA  ASP E 194      14.347   8.464   8.067  1.00  3.00           C  
+ATOM   1281  C   ASP E 194      13.777   7.899   9.379  1.00 10.30           C  
+ATOM   1282  O   ASP E 194      14.557   7.782  10.332  1.00  3.91           O  
+ATOM   1283  CB  ASP E 194      14.707   9.924   8.407  1.00  3.40           C  
+ATOM   1284  CG  ASP E 194      15.506  10.533   7.278  1.00  3.00           C  
+ATOM   1285  OD1 ASP E 194      16.379   9.828   6.725  1.00  3.00           O  
+ATOM   1286  OD2 ASP E 194      15.290  11.726   6.933  1.00  3.00           O  
+ATOM   1287  N   SER E 195      12.453   7.698   9.448  1.00  3.00           N  
+ATOM   1288  CA  SER E 195      11.896   7.113  10.706  1.00  3.00           C  
+ATOM   1289  C   SER E 195      12.777   6.034  11.363  1.00  3.21           C  
+ATOM   1290  O   SER E 195      13.129   5.069  10.706  1.00  3.00           O  
+ATOM   1291  CB  SER E 195      10.515   6.468  10.541  1.00  3.00           C  
+ATOM   1292  OG  SER E 195       9.592   7.512  10.618  1.00  3.00           O  
+ATOM   1293  N   GLY E 196      12.831   6.083  12.657  1.00  3.00           N  
+ATOM   1294  CA  GLY E 196      13.281   5.011  13.460  1.00  3.00           C  
+ATOM   1295  C   GLY E 196      14.774   5.208  13.705  1.00 11.82           C  
+ATOM   1296  O   GLY E 196      15.359   4.457  14.505  1.00  4.24           O  
+ATOM   1297  N   GLY E 197      15.383   6.142  12.924  1.00  3.00           N  
+ATOM   1298  CA  GLY E 197      16.858   6.320  12.953  1.00  3.00           C  
+ATOM   1299  C   GLY E 197      17.290   7.192  14.143  1.00  7.78           C  
+ATOM   1300  O   GLY E 197      16.457   7.726  14.890  1.00  6.95           O  
+ATOM   1301  N   PRO E 198      18.597   7.312  14.266  1.00  7.75           N  
+ATOM   1302  CA  PRO E 198      19.184   7.867  15.501  1.00  3.00           C  
+ATOM   1303  C   PRO E 198      19.126   9.371  15.527  1.00  5.14           C  
+ATOM   1304  O   PRO E 198      19.612   9.972  14.554  1.00  6.00           O  
+ATOM   1305  CB  PRO E 198      20.637   7.383  15.514  1.00  3.52           C  
+ATOM   1306  CG  PRO E 198      20.913   6.924  14.054  1.00  3.08           C  
+ATOM   1307  CD  PRO E 198      19.567   6.509  13.461  1.00  7.33           C  
+ATOM   1308  N   VAL E 199      19.057   9.863  16.781  1.00  4.37           N  
+ATOM   1309  CA  VAL E 199      19.481  11.253  17.115  1.00  3.00           C  
+ATOM   1310  C   VAL E 199      20.524  11.168  18.236  1.00  3.60           C  
+ATOM   1311  O   VAL E 199      20.268  10.584  19.298  1.00  3.00           O  
+ATOM   1312  CB  VAL E 199      18.194  12.005  17.615  1.00  4.51           C  
+ATOM   1313  CG1 VAL E 199      18.390  13.422  18.190  1.00  5.65           C  
+ATOM   1314  CG2 VAL E 199      17.160  12.147  16.504  1.00  5.43           C  
+ATOM   1315  N   VAL E 200      21.747  11.456  17.876  1.00  3.00           N  
+ATOM   1316  CA  VAL E 200      22.824  11.109  18.833  1.00  5.70           C  
+ATOM   1317  C   VAL E 200      23.452  12.428  19.299  1.00 21.64           C  
+ATOM   1318  O   VAL E 200      23.822  13.243  18.458  1.00  7.96           O  
+ATOM   1319  CB  VAL E 200      23.927  10.155  18.270  1.00  3.00           C  
+ATOM   1320  CG1 VAL E 200      25.242  10.120  19.120  1.00  3.00           C  
+ATOM   1321  CG2 VAL E 200      23.394   8.732  18.064  1.00  3.00           C  
+ATOM   1322  N   CYS E 201      23.509  12.619  20.608  1.00 19.90           N  
+ATOM   1323  CA  CYS E 201      24.037  13.840  21.275  1.00 10.95           C  
+ATOM   1324  C   CYS E 201      24.997  13.436  22.404  1.00 11.49           C  
+ATOM   1325  O   CYS E 201      24.734  12.499  23.181  1.00  5.53           O  
+ATOM   1326  CB  CYS E 201      22.885  14.593  21.919  1.00  3.00           C  
+ATOM   1327  SG  CYS E 201      21.257  14.554  21.145  1.00  5.55           S  
+ATOM   1328  N   SER E 202      26.215  13.883  22.214  1.00 17.76           N  
+ATOM   1329  CA  SER E 202      27.359  13.545  23.109  1.00 25.01           C  
+ATOM   1330  C   SER E 202      27.607  12.044  23.204  1.00 26.46           C  
+ATOM   1331  O   SER E 202      27.818  11.541  24.300  1.00 27.39           O  
+ATOM   1332  CB  SER E 202      27.077  13.989  24.574  1.00 33.00           C  
+ATOM   1333  OG  SER E 202      26.404  15.270  24.613  1.00 42.97           O  
+ATOM   1334  N   GLY E 203      27.499  11.379  22.109  1.00 17.40           N  
+ATOM   1335  CA  GLY E 203      27.800   9.963  22.026  1.00 14.57           C  
+ATOM   1336  C   GLY E 203      26.688   9.106  22.619  1.00 15.62           C  
+ATOM   1337  O   GLY E 203      26.962   7.937  22.813  1.00 16.14           O  
+ATOM   1338  N   LYS E 204      25.552   9.699  23.032  1.00  9.13           N  
+ATOM   1339  CA  LYS E 204      24.480   8.815  23.559  1.00  3.00           C  
+ATOM   1340  C   LYS E 204      23.302   8.860  22.567  1.00 21.97           C  
+ATOM   1341  O   LYS E 204      22.993   9.937  22.066  1.00  4.99           O  
+ATOM   1342  CB  LYS E 204      23.924   9.346  24.898  1.00  3.00           C  
+ATOM   1343  CG  LYS E 204      25.145   9.469  25.814  1.00  3.26           C  
+ATOM   1344  CD  LYS E 204      25.887   8.164  25.955  1.00 14.14           C  
+ATOM   1345  CE  LYS E 204      27.005   8.327  27.018  1.00 35.72           C  
+ATOM   1346  NZ  LYS E 204      27.134   7.064  27.732  1.00 54.75           N  
+ATOM   1347  N   LEU E 209      22.524   7.793  22.464  1.00  5.91           N  
+ATOM   1348  CA  LEU E 209      21.274   7.873  21.702  1.00  3.00           C  
+ATOM   1349  C   LEU E 209      20.130   8.588  22.437  1.00  7.09           C  
+ATOM   1350  O   LEU E 209      19.597   8.046  23.388  1.00  8.69           O  
+ATOM   1351  CB  LEU E 209      20.846   6.451  21.446  1.00  3.00           C  
+ATOM   1352  CG  LEU E 209      19.597   6.336  20.518  1.00 10.47           C  
+ATOM   1353  CD1 LEU E 209      19.815   6.838  19.031  1.00  3.00           C  
+ATOM   1354  CD2 LEU E 209      19.205   4.859  20.641  1.00  3.00           C  
+ATOM   1355  N   GLN E 210      19.923   9.855  22.182  1.00  3.00           N  
+ATOM   1356  CA  GLN E 210      18.870  10.581  22.822  1.00  3.00           C  
+ATOM   1357  C   GLN E 210      17.510  10.427  22.152  1.00 20.69           C  
+ATOM   1358  O   GLN E 210      16.532  10.789  22.805  1.00 10.35           O  
+ATOM   1359  CB  GLN E 210      19.165  12.055  22.986  1.00  3.00           C  
+ATOM   1360  CG  GLN E 210      20.379  12.285  23.958  1.00  5.64           C  
+ATOM   1361  CD  GLN E 210      20.107  12.022  25.441  1.00 19.82           C  
+ATOM   1362  OE1 GLN E 210      21.043  12.110  26.240  1.00 27.60           O  
+ATOM   1363  NE2 GLN E 210      18.907  11.671  25.824  1.00 11.43           N  
+ATOM   1364  N   GLY E 211      17.459  10.205  20.838  1.00  9.45           N  
+ATOM   1365  CA  GLY E 211      16.202  10.464  20.038  1.00  3.00           C  
+ATOM   1366  C   GLY E 211      16.006   9.306  19.077  1.00  6.09           C  
+ATOM   1367  O   GLY E 211      16.984   8.714  18.638  1.00  4.93           O  
+ATOM   1368  N   ILE E 212      14.764   9.045  18.669  1.00  7.63           N  
+ATOM   1369  CA  ILE E 212      14.383   8.248  17.477  1.00  4.80           C  
+ATOM   1370  C   ILE E 212      13.572   9.139  16.546  1.00  3.93           C  
+ATOM   1371  O   ILE E 212      12.625   9.814  17.008  1.00  5.71           O  
+ATOM   1372  CB  ILE E 212      13.573   7.006  17.944  1.00  7.32           C  
+ATOM   1373  CG1 ILE E 212      14.353   6.189  18.990  1.00  3.00           C  
+ATOM   1374  CG2 ILE E 212      13.000   6.049  16.840  1.00  3.00           C  
+ATOM   1375  CD1 ILE E 212      13.426   5.102  19.640  1.00  6.83           C  
+ATOM   1376  N   VAL E 213      13.980   9.183  15.298  1.00  3.00           N  
+ATOM   1377  CA  VAL E 213      13.156   9.917  14.243  1.00  4.09           C  
+ATOM   1378  C   VAL E 213      11.684   9.417  14.209  1.00  4.91           C  
+ATOM   1379  O   VAL E 213      11.384   8.224  14.062  1.00  3.00           O  
+ATOM   1380  CB  VAL E 213      13.817   9.818  12.801  1.00  3.00           C  
+ATOM   1381  CG1 VAL E 213      12.983  10.566  11.728  1.00  3.00           C  
+ATOM   1382  CG2 VAL E 213      15.244  10.405  12.809  1.00  3.00           C  
+ATOM   1383  N   SER E 214      10.753  10.354  14.440  1.00  3.00           N  
+ATOM   1384  CA  SER E 214       9.397   9.828  14.561  1.00  3.37           C  
+ATOM   1385  C   SER E 214       8.433  10.516  13.540  1.00  3.46           C  
+ATOM   1386  O   SER E 214       7.811   9.825  12.738  1.00  4.02           O  
+ATOM   1387  CB  SER E 214       8.900   9.963  16.040  1.00  3.00           C  
+ATOM   1388  OG  SER E 214       7.584   9.395  16.158  1.00  4.62           O  
+ATOM   1389  N   TRP E 215       8.156  11.808  13.645  1.00  3.00           N  
+ATOM   1390  CA  TRP E 215       7.069  12.433  12.853  1.00  3.00           C  
+ATOM   1391  C   TRP E 215       7.361  13.909  12.713  1.00  3.00           C  
+ATOM   1392  O   TRP E 215       8.253  14.372  13.420  1.00  5.02           O  
+ATOM   1393  CB  TRP E 215       5.623  12.055  13.384  1.00  3.07           C  
+ATOM   1394  CG  TRP E 215       5.282  12.713  14.751  1.00  9.00           C  
+ATOM   1395  CD1 TRP E 215       5.565  12.221  15.968  1.00  8.20           C  
+ATOM   1396  CD2 TRP E 215       4.614  13.943  14.994  1.00 14.41           C  
+ATOM   1397  NE1 TRP E 215       5.054  13.100  16.939  1.00  6.14           N  
+ATOM   1398  CE2 TRP E 215       4.531  14.114  16.395  1.00 19.63           C  
+ATOM   1399  CE3 TRP E 215       4.092  14.900  14.136  1.00  4.20           C  
+ATOM   1400  CZ2 TRP E 215       3.926  15.220  17.008  1.00  3.57           C  
+ATOM   1401  CZ3 TRP E 215       3.502  16.016  14.739  1.00  3.00           C  
+ATOM   1402  CH2 TRP E 215       3.402  16.170  16.142  1.00  8.34           C  
+ATOM   1403  N   GLY E 216       6.561  14.673  11.951  1.00  3.00           N  
+ATOM   1404  CA  GLY E 216       6.674  16.085  11.675  1.00  3.00           C  
+ATOM   1405  C   GLY E 216       5.461  16.441  10.815  1.00  7.61           C  
+ATOM   1406  O   GLY E 216       4.770  15.557  10.356  1.00  3.81           O  
+ATOM   1407  N   SER E 217       5.209  17.676  10.580  1.00 12.66           N  
+ATOM   1408  CA  SER E 217       4.181  18.105   9.605  1.00 17.10           C  
+ATOM   1409  C   SER E 217       4.947  18.593   8.352  1.00 16.39           C  
+ATOM   1410  O   SER E 217       5.731  19.552   8.456  1.00 14.29           O  
+ATOM   1411  CB  SER E 217       3.423  19.335  10.202  1.00  6.32           C  
+ATOM   1412  OG  SER E 217       2.315  19.571   9.348  1.00 16.72           O  
+ATOM   1413  N   GLY E 219       4.951  17.770   7.306  1.00 14.47           N  
+ATOM   1414  CA  GLY E 219       5.857  17.949   6.148  1.00 12.00           C  
+ATOM   1415  C   GLY E 219       7.313  17.660   6.520  1.00 13.39           C  
+ATOM   1416  O   GLY E 219       7.575  16.844   7.407  1.00 15.22           O  
+ATOM   1417  N   CYS E 220       8.228  18.334   5.845  1.00  5.72           N  
+ATOM   1418  CA  CYS E 220       9.659  18.205   6.157  1.00  7.08           C  
+ATOM   1419  C   CYS E 220      10.218  19.594   6.018  1.00  5.48           C  
+ATOM   1420  O   CYS E 220      10.183  20.134   4.929  1.00  5.30           O  
+ATOM   1421  CB  CYS E 220      10.457  17.225   5.262  1.00  3.00           C  
+ATOM   1422  SG  CYS E 220       9.777  15.542   5.308  1.00  3.29           S  
+ATOM   1423  N   ALA E 221A     10.987  19.952   6.954  1.00  3.99           N  
+ATOM   1424  CA  ALA E 221A     11.792  21.163   6.740  1.00  3.00           C  
+ATOM   1425  C   ALA E 221A     10.952  22.406   6.507  1.00 11.01           C  
+ATOM   1426  O   ALA E 221A     11.493  23.443   6.093  1.00 11.02           O  
+ATOM   1427  CB  ALA E 221A     12.900  20.993   5.719  1.00  3.00           C  
+ATOM   1428  N   GLN E 221       9.708  22.279   6.970  1.00  7.24           N  
+ATOM   1429  CA  GLN E 221       8.770  23.464   6.894  1.00  9.51           C  
+ATOM   1430  C   GLN E 221       9.008  24.440   8.057  1.00 19.30           C  
+ATOM   1431  O   GLN E 221       9.511  24.089   9.137  1.00 15.79           O  
+ATOM   1432  CB  GLN E 221       7.323  22.888   6.899  1.00  3.74           C  
+ATOM   1433  CG  GLN E 221       6.621  22.883   5.537  1.00 31.05           C  
+ATOM   1434  CD  GLN E 221       7.585  22.257   4.559  1.00 58.84           C  
+ATOM   1435  OE1 GLN E 221       8.135  22.901   3.667  1.00 34.71           O  
+ATOM   1436  NE2 GLN E 221       7.765  20.995   4.804  1.00 58.51           N  
+ATOM   1437  N   LYS E 222       8.902  25.693   7.714  1.00  8.33           N  
+ATOM   1438  CA  LYS E 222       9.123  26.778   8.716  1.00 12.16           C  
+ATOM   1439  C   LYS E 222       8.186  26.551   9.894  1.00  8.56           C  
+ATOM   1440  O   LYS E 222       7.031  26.171   9.710  1.00 13.55           O  
+ATOM   1441  CB  LYS E 222       8.731  28.128   8.037  1.00 14.42           C  
+ATOM   1442  CG  LYS E 222       8.948  29.352   8.971  1.00 34.97           C  
+ATOM   1443  CD  LYS E 222       8.733  30.718   8.284  1.00 42.21           C  
+ATOM   1444  CE  LYS E 222       9.061  31.909   9.232  1.00 63.37           C  
+ATOM   1445  NZ  LYS E 222       8.477  33.194   8.724  1.00 63.72           N  
+ATOM   1446  N   ASN E 223       8.672  26.692  11.067  1.00  5.33           N  
+ATOM   1447  CA  ASN E 223       7.862  26.530  12.276  1.00  3.16           C  
+ATOM   1448  C   ASN E 223       7.290  25.148  12.440  1.00 17.99           C  
+ATOM   1449  O   ASN E 223       6.354  25.026  13.228  1.00 20.00           O  
+ATOM   1450  CB  ASN E 223       6.668  27.503  12.399  1.00 17.76           C  
+ATOM   1451  CG  ASN E 223       7.267  28.899  12.481  1.00 47.99           C  
+ATOM   1452  OD1 ASN E 223       8.119  29.139  13.326  1.00 40.49           O  
+ATOM   1453  ND2 ASN E 223       6.832  29.752  11.585  1.00 35.08           N  
+ATOM   1454  N   LYS E 224       7.831  24.174  11.726  1.00 18.46           N  
+ATOM   1455  CA  LYS E 224       7.366  22.782  11.974  1.00  5.83           C  
+ATOM   1456  C   LYS E 224       8.582  21.848  12.053  1.00 18.13           C  
+ATOM   1457  O   LYS E 224       8.933  21.161  11.074  1.00 11.14           O  
+ATOM   1458  CB  LYS E 224       6.448  22.310  10.799  1.00  6.95           C  
+ATOM   1459  CG  LYS E 224       5.078  23.047  10.772  1.00 15.80           C  
+ATOM   1460  CD  LYS E 224       4.331  22.734  12.086  1.00 20.00           C  
+ATOM   1461  CE  LYS E 224       3.066  23.584  12.325  1.00 52.06           C  
+ATOM   1462  NZ  LYS E 224       2.142  22.818  13.219  1.00 43.80           N  
+ATOM   1463  N   PRO E 225       9.252  21.873  13.193  1.00 25.00           N  
+ATOM   1464  CA  PRO E 225      10.482  21.032  13.326  1.00 17.73           C  
+ATOM   1465  C   PRO E 225      10.149  19.530  13.493  1.00 10.79           C  
+ATOM   1466  O   PRO E 225       8.997  19.126  13.607  1.00  4.77           O  
+ATOM   1467  CB  PRO E 225      11.144  21.651  14.548  1.00 10.72           C  
+ATOM   1468  CG  PRO E 225       9.943  22.115  15.413  1.00 16.86           C  
+ATOM   1469  CD  PRO E 225       8.884  22.591  14.435  1.00  8.31           C  
+ATOM   1470  N   GLY E 226      11.105  18.674  13.351  1.00  3.00           N  
+ATOM   1471  CA  GLY E 226      10.825  17.276  13.563  1.00  3.00           C  
+ATOM   1472  C   GLY E 226      10.601  16.948  15.031  1.00  3.00           C  
+ATOM   1473  O   GLY E 226      11.163  17.606  15.919  1.00  3.10           O  
+ATOM   1474  N   VAL E 227       9.857  15.878  15.206  1.00  3.63           N  
+ATOM   1475  CA  VAL E 227       9.529  15.339  16.488  1.00  3.66           C  
+ATOM   1476  C   VAL E 227      10.026  13.903  16.588  1.00  4.47           C  
+ATOM   1477  O   VAL E 227      10.024  13.152  15.611  1.00  3.14           O  
+ATOM   1478  CB  VAL E 227       8.002  15.441  16.681  1.00  4.15           C  
+ATOM   1479  CG1 VAL E 227       7.738  15.043  18.159  1.00  5.32           C  
+ATOM   1480  CG2 VAL E 227       7.551  16.893  16.393  1.00  3.00           C  
+ATOM   1481  N   TYR E 228      10.739  13.699  17.705  1.00  7.25           N  
+ATOM   1482  CA  TYR E 228      11.600  12.562  18.049  1.00  3.00           C  
+ATOM   1483  C   TYR E 228      11.152  11.918  19.380  1.00  9.92           C  
+ATOM   1484  O   TYR E 228      10.701  12.575  20.317  1.00  3.00           O  
+ATOM   1485  CB  TYR E 228      13.014  13.163  18.223  1.00  3.00           C  
+ATOM   1486  CG  TYR E 228      13.513  13.749  16.866  1.00  3.03           C  
+ATOM   1487  CD1 TYR E 228      14.088  12.914  15.917  1.00  4.69           C  
+ATOM   1488  CD2 TYR E 228      13.437  15.114  16.604  1.00  4.05           C  
+ATOM   1489  CE1 TYR E 228      14.488  13.464  14.667  1.00  6.51           C  
+ATOM   1490  CE2 TYR E 228      13.850  15.712  15.389  1.00  3.00           C  
+ATOM   1491  CZ  TYR E 228      14.354  14.847  14.397  1.00  4.40           C  
+ATOM   1492  OH  TYR E 228      14.591  15.337  13.132  1.00  3.00           O  
+ATOM   1493  N   THR E 229      11.224  10.622  19.443  1.00  3.51           N  
+ATOM   1494  CA  THR E 229      10.953   9.923  20.682  1.00  3.00           C  
+ATOM   1495  C   THR E 229      12.101  10.225  21.632  1.00  3.98           C  
+ATOM   1496  O   THR E 229      13.244  10.097  21.233  1.00  3.00           O  
+ATOM   1497  CB  THR E 229      10.876   8.388  20.442  1.00  3.88           C  
+ATOM   1498  OG1 THR E 229       9.932   8.133  19.370  1.00  5.11           O  
+ATOM   1499  CG2 THR E 229      10.475   7.509  21.683  1.00  4.54           C  
+ATOM   1500  N   LYS E 230      11.738  10.562  22.855  1.00  3.67           N  
+ATOM   1501  CA  LYS E 230      12.647  10.857  23.939  1.00 13.94           C  
+ATOM   1502  C   LYS E 230      13.236   9.661  24.672  1.00 13.84           C  
+ATOM   1503  O   LYS E 230      12.610   9.213  25.630  1.00  9.77           O  
+ATOM   1504  CB  LYS E 230      11.899  11.765  24.903  1.00  6.59           C  
+ATOM   1505  CG  LYS E 230      12.881  12.516  25.807  1.00 15.39           C  
+ATOM   1506  CD  LYS E 230      12.045  13.660  26.404  1.00 15.36           C  
+ATOM   1507  CE  LYS E 230      12.755  14.264  27.621  1.00 32.45           C  
+ATOM   1508  NZ  LYS E 230      11.980  15.427  28.061  1.00 47.86           N  
+ATOM   1509  N   VAL E 231      14.343   9.105  24.104  1.00  3.00           N  
+ATOM   1510  CA  VAL E 231      14.937   7.824  24.574  1.00 14.56           C  
+ATOM   1511  C   VAL E 231      15.242   7.781  26.094  1.00 24.40           C  
+ATOM   1512  O   VAL E 231      15.110   6.758  26.776  1.00  8.86           O  
+ATOM   1513  CB  VAL E 231      16.143   7.406  23.648  1.00  3.19           C  
+ATOM   1514  CG1 VAL E 231      16.833   6.084  24.078  1.00  3.00           C  
+ATOM   1515  CG2 VAL E 231      15.651   7.211  22.201  1.00  3.00           C  
+ATOM   1516  N   CYS E 232      15.577   8.903  26.690  1.00 12.18           N  
+ATOM   1517  CA  CYS E 232      16.048   8.823  28.090  1.00 13.63           C  
+ATOM   1518  C   CYS E 232      14.885   8.396  28.999  1.00  5.81           C  
+ATOM   1519  O   CYS E 232      15.127   7.995  30.100  1.00 12.58           O  
+ATOM   1520  CB  CYS E 232      16.591  10.222  28.489  1.00  6.99           C  
+ATOM   1521  SG  CYS E 232      15.365  11.550  28.383  1.00 16.31           S  
+ATOM   1522  N   ASN E 233      13.626   8.514  28.555  1.00  8.57           N  
+ATOM   1523  CA  ASN E 233      12.487   8.179  29.342  1.00  3.00           C  
+ATOM   1524  C   ASN E 233      12.360   6.669  29.261  1.00 10.10           C  
+ATOM   1525  O   ASN E 233      11.391   6.207  29.804  1.00 13.56           O  
+ATOM   1526  CB  ASN E 233      11.180   8.769  28.774  1.00  3.00           C  
+ATOM   1527  CG  ASN E 233      11.079  10.256  29.083  1.00  6.75           C  
+ATOM   1528  OD1 ASN E 233      11.993  10.770  29.711  1.00 13.45           O  
+ATOM   1529  ND2 ASN E 233      10.029  10.920  28.569  1.00  4.31           N  
+ATOM   1530  N   TYR E 234      13.143   5.964  28.443  1.00  3.13           N  
+ATOM   1531  CA  TYR E 234      12.868   4.518  28.258  1.00  4.38           C  
+ATOM   1532  C   TYR E 234      14.047   3.602  28.634  1.00 20.05           C  
+ATOM   1533  O   TYR E 234      13.983   2.433  28.263  1.00  9.48           O  
+ATOM   1534  CB  TYR E 234      12.444   4.241  26.759  1.00 14.14           C  
+ATOM   1535  CG  TYR E 234      11.140   4.939  26.339  1.00  8.25           C  
+ATOM   1536  CD1 TYR E 234       9.926   4.316  26.576  1.00 15.86           C  
+ATOM   1537  CD2 TYR E 234      11.155   6.179  25.775  1.00  3.08           C  
+ATOM   1538  CE1 TYR E 234       8.746   4.943  26.273  1.00  4.73           C  
+ATOM   1539  CE2 TYR E 234       9.977   6.804  25.456  1.00  6.06           C  
+ATOM   1540  CZ  TYR E 234       8.769   6.210  25.729  1.00  3.84           C  
+ATOM   1541  OH  TYR E 234       7.601   6.880  25.433  1.00  4.04           O  
+ATOM   1542  N   VAL E 235      15.166   4.144  29.160  1.00  4.24           N  
+ATOM   1543  CA  VAL E 235      16.401   3.344  29.253  1.00  7.75           C  
+ATOM   1544  C   VAL E 235      16.158   2.118  30.093  1.00 15.19           C  
+ATOM   1545  O   VAL E 235      16.718   1.074  29.784  1.00 14.26           O  
+ATOM   1546  CB  VAL E 235      17.636   4.170  29.763  1.00 13.83           C  
+ATOM   1547  CG1 VAL E 235      18.921   3.364  30.076  1.00 10.52           C  
+ATOM   1548  CG2 VAL E 235      18.036   5.209  28.662  1.00 18.73           C  
+ATOM   1549  N   SER E 236      15.305   2.275  31.091  1.00  9.71           N  
+ATOM   1550  CA  SER E 236      15.098   1.099  31.996  1.00 22.82           C  
+ATOM   1551  C   SER E 236      14.406  -0.050  31.282  1.00 12.02           C  
+ATOM   1552  O   SER E 236      14.910  -1.189  31.412  1.00 26.53           O  
+ATOM   1553  CB  SER E 236      14.139   1.442  33.139  1.00 36.98           C  
+ATOM   1554  OG  SER E 236      14.835   2.286  33.991  1.00 47.54           O  
+ATOM   1555  N   TRP E 237      13.236   0.328  30.697  1.00  7.16           N  
+ATOM   1556  CA  TRP E 237      12.380  -0.559  29.866  1.00 20.63           C  
+ATOM   1557  C   TRP E 237      13.235  -1.238  28.783  1.00 13.71           C  
+ATOM   1558  O   TRP E 237      13.216  -2.447  28.637  1.00  7.53           O  
+ATOM   1559  CB  TRP E 237      11.175   0.200  29.215  1.00  6.59           C  
+ATOM   1560  CG  TRP E 237      10.393  -0.692  28.245  1.00 22.43           C  
+ATOM   1561  CD1 TRP E 237       9.541  -1.684  28.568  1.00 30.92           C  
+ATOM   1562  CD2 TRP E 237      10.467  -0.709  26.835  1.00 34.55           C  
+ATOM   1563  NE1 TRP E 237       9.098  -2.336  27.386  1.00 32.08           N  
+ATOM   1564  CE2 TRP E 237       9.639  -1.762  26.382  1.00 47.74           C  
+ATOM   1565  CE3 TRP E 237      11.201   0.057  25.943  1.00 25.79           C  
+ATOM   1566  CZ2 TRP E 237       9.502  -2.088  25.038  1.00 12.36           C  
+ATOM   1567  CZ3 TRP E 237      11.069  -0.290  24.599  1.00 25.80           C  
+ATOM   1568  CH2 TRP E 237      10.244  -1.335  24.162  1.00  8.70           C  
+ATOM   1569  N   ILE E 238      14.131  -0.516  28.144  1.00 10.50           N  
+ATOM   1570  CA  ILE E 238      15.004  -1.189  27.173  1.00  3.76           C  
+ATOM   1571  C   ILE E 238      15.930  -2.169  27.880  1.00 16.00           C  
+ATOM   1572  O   ILE E 238      16.060  -3.287  27.388  1.00 18.35           O  
+ATOM   1573  CB  ILE E 238      15.875  -0.088  26.457  1.00  3.00           C  
+ATOM   1574  CG1 ILE E 238      15.084   0.796  25.518  1.00  3.60           C  
+ATOM   1575  CG2 ILE E 238      17.073  -0.657  25.769  1.00  6.67           C  
+ATOM   1576  CD1 ILE E 238      15.793   2.144  25.187  1.00  3.46           C  
+ATOM   1577  N   LYS E 239      16.637  -1.754  28.930  1.00 17.58           N  
+ATOM   1578  CA  LYS E 239      17.655  -2.656  29.511  1.00 12.93           C  
+ATOM   1579  C   LYS E 239      16.979  -3.874  30.148  1.00 15.09           C  
+ATOM   1580  O   LYS E 239      17.478  -4.994  29.988  1.00 11.50           O  
+ATOM   1581  CB  LYS E 239      18.489  -1.873  30.576  1.00 13.36           C  
+ATOM   1582  CG  LYS E 239      19.638  -1.076  29.956  1.00 14.87           C  
+ATOM   1583  CD  LYS E 239      20.092   0.035  30.889  1.00 21.61           C  
+ATOM   1584  CE  LYS E 239      21.434   0.587  30.386  1.00 61.42           C  
+ATOM   1585  NZ  LYS E 239      22.041   1.329  31.503  1.00 63.81           N  
+ATOM   1586  N   GLN E 240      15.763  -3.627  30.577  1.00 13.59           N  
+ATOM   1587  CA  GLN E 240      14.868  -4.693  31.103  1.00 32.18           C  
+ATOM   1588  C   GLN E 240      14.596  -5.739  30.013  1.00 43.62           C  
+ATOM   1589  O   GLN E 240      14.930  -6.923  30.196  1.00 21.08           O  
+ATOM   1590  CB  GLN E 240      13.520  -4.083  31.614  1.00 36.36           C  
+ATOM   1591  CG  GLN E 240      12.810  -4.801  32.815  1.00 49.24           C  
+ATOM   1592  CD  GLN E 240      11.578  -5.579  32.352  1.00 46.44           C  
+ATOM   1593  OE1 GLN E 240      11.263  -6.623  32.916  1.00 42.16           O  
+ATOM   1594  NE2 GLN E 240      10.895  -5.146  31.290  1.00 43.55           N  
+ATOM   1595  N   THR E 241      13.966  -5.242  28.931  1.00 30.14           N  
+ATOM   1596  CA  THR E 241      13.505  -6.069  27.787  1.00 19.39           C  
+ATOM   1597  C   THR E 241      14.588  -6.921  27.130  1.00 10.64           C  
+ATOM   1598  O   THR E 241      14.471  -8.136  27.053  1.00 15.37           O  
+ATOM   1599  CB  THR E 241      12.773  -5.123  26.824  1.00 15.33           C  
+ATOM   1600  OG1 THR E 241      11.862  -4.369  27.666  1.00 12.39           O  
+ATOM   1601  CG2 THR E 241      11.947  -5.843  25.726  1.00 22.01           C  
+ATOM   1602  N   ILE E 242      15.701  -6.299  26.864  1.00 11.64           N  
+ATOM   1603  CA  ILE E 242      16.896  -6.875  26.325  1.00 16.01           C  
+ATOM   1604  C   ILE E 242      17.486  -7.972  27.177  1.00 35.48           C  
+ATOM   1605  O   ILE E 242      17.993  -8.923  26.599  1.00 29.81           O  
+ATOM   1606  CB  ILE E 242      17.906  -5.732  26.091  1.00  9.97           C  
+ATOM   1607  CG1 ILE E 242      17.518  -5.111  24.767  1.00  7.47           C  
+ATOM   1608  CG2 ILE E 242      19.351  -6.168  25.984  1.00 31.97           C  
+ATOM   1609  CD1 ILE E 242      18.032  -3.678  24.738  1.00 53.97           C  
+ATOM   1610  N   ALA E 243      17.510  -7.783  28.485  1.00 32.44           N  
+ATOM   1611  CA  ALA E 243      18.192  -8.805  29.293  1.00 19.02           C  
+ATOM   1612  C   ALA E 243      17.176  -9.862  29.701  1.00 15.87           C  
+ATOM   1613  O   ALA E 243      17.547 -10.975  30.039  1.00 44.93           O  
+ATOM   1614  CB  ALA E 243      18.931  -8.244  30.514  1.00 26.71           C  
+ATOM   1615  N   SER E 244      15.963  -9.609  29.429  1.00 23.28           N  
+ATOM   1616  CA  SER E 244      14.951 -10.654  29.654  1.00 26.62           C  
+ATOM   1617  C   SER E 244      14.351 -11.442  28.462  1.00 45.02           C  
+ATOM   1618  O   SER E 244      13.304 -12.079  28.649  1.00 36.68           O  
+ATOM   1619  CB  SER E 244      13.853  -9.947  30.401  1.00 29.13           C  
+ATOM   1620  OG  SER E 244      14.572  -9.560  31.566  1.00 37.04           O  
+ATOM   1621  N   ASN E 245      14.880 -11.266  27.221  1.00 37.73           N  
+ATOM   1622  CA  ASN E 245      14.275 -11.869  25.998  1.00 24.34           C  
+ATOM   1623  C   ASN E 245      15.334 -12.436  25.060  1.00 16.17           C  
+ATOM   1624  O   ASN E 245      15.083 -12.405  23.865  1.00 30.31           O  
+ATOM   1625  CB  ASN E 245      13.484 -10.851  25.166  1.00 18.35           C  
+ATOM   1626  CG  ASN E 245      12.131 -10.487  25.760  1.00 13.28           C  
+ATOM   1627  OD1 ASN E 245      11.146 -11.190  25.532  1.00 35.95           O  
+ATOM   1628  ND2 ASN E 245      12.087  -9.424  26.508  1.00 24.25           N  
+ATOM   1629  OXT ASN E 245      16.558 -12.460  25.376  1.00 27.93           O  
+TER    1630      ASN E 245                                                      
+ATOM   1631  N   ARG I   1      -0.012  18.656  10.567  1.00 33.34           N  
+ATOM   1632  CA  ARG I   1      -0.471  17.243  10.547  1.00 32.42           C  
+ATOM   1633  C   ARG I   1       0.571  16.320  11.166  1.00 24.38           C  
+ATOM   1634  O   ARG I   1       1.785  16.601  11.121  1.00 27.42           O  
+ATOM   1635  CB  ARG I   1      -0.702  16.787   9.099  1.00 18.37           C  
+ATOM   1636  CG  ARG I   1      -0.012  17.775   8.205  1.00 13.85           C  
+ATOM   1637  CD  ARG I   1      -0.579  17.675   6.778  1.00 20.56           C  
+ATOM   1638  NE  ARG I   1      -0.192  16.393   6.261  1.00 37.25           N  
+ATOM   1639  CZ  ARG I   1       0.962  16.055   5.690  1.00 28.69           C  
+ATOM   1640  NH1 ARG I   1       1.981  16.864   5.350  1.00 30.80           N  
+ATOM   1641  NH2 ARG I   1       0.905  14.866   5.208  1.00 23.22           N  
+ATOM   1642  N   VAL I   2       0.026  15.273  11.716  1.00 16.32           N  
+ATOM   1643  CA  VAL I   2       0.875  14.213  12.248  1.00 15.60           C  
+ATOM   1644  C   VAL I   2       1.167  13.185  11.159  1.00 14.33           C  
+ATOM   1645  O   VAL I   2       0.366  12.310  10.825  1.00 12.69           O  
+ATOM   1646  CB  VAL I   2       0.255  13.631  13.523  1.00 21.44           C  
+ATOM   1647  CG1 VAL I   2       1.074  12.512  14.194  1.00 13.21           C  
+ATOM   1648  CG2 VAL I   2      -0.100  14.784  14.482  1.00 15.92           C  
+ATOM   1649  N   CYS I   3       2.347  13.334  10.581  1.00 15.61           N  
+ATOM   1650  CA  CYS I   3       2.737  12.316   9.611  1.00  8.79           C  
+ATOM   1651  C   CYS I   3       4.069  11.610   9.986  1.00 11.83           C  
+ATOM   1652  O   CYS I   3       5.114  12.252   9.990  1.00  3.56           O  
+ATOM   1653  CB  CYS I   3       2.778  13.078   8.275  1.00 14.41           C  
+ATOM   1654  SG  CYS I   3       3.423  12.104   6.938  1.00  7.31           S  
+ATOM   1655  N   PRO I   4       4.020  10.344  10.379  1.00 11.42           N  
+ATOM   1656  CA  PRO I   4       5.234   9.570  10.623  1.00  3.00           C  
+ATOM   1657  C   PRO I   4       6.175   9.502   9.406  1.00  5.11           C  
+ATOM   1658  O   PRO I   4       5.713   9.516   8.264  1.00  3.00           O  
+ATOM   1659  CB  PRO I   4       4.769   8.201  10.988  1.00  3.00           C  
+ATOM   1660  CG  PRO I   4       3.295   8.161  10.609  1.00 14.11           C  
+ATOM   1661  CD  PRO I   4       2.778   9.571  10.661  1.00  3.60           C  
+ATOM   1662  N   ARG I   5       7.473   9.408   9.714  1.00  3.00           N  
+ATOM   1663  CA  ARG I   5       8.536   9.553   8.761  1.00 13.81           C  
+ATOM   1664  C   ARG I   5       8.913   8.253   8.124  1.00  3.00           C  
+ATOM   1665  O   ARG I   5      10.086   8.063   7.830  1.00  3.00           O  
+ATOM   1666  CB  ARG I   5       9.698  10.474   9.209  1.00  3.00           C  
+ATOM   1667  CG  ARG I   5       9.129  11.918   9.373  1.00  4.47           C  
+ATOM   1668  CD  ARG I   5      10.083  12.946   9.980  1.00  3.00           C  
+ATOM   1669  NE  ARG I   5       9.435  14.208   9.737  1.00  3.00           N  
+ATOM   1670  CZ  ARG I   5      10.007  15.325  10.111  1.00  6.07           C  
+ATOM   1671  NH1 ARG I   5      11.134  15.314  10.789  1.00  4.50           N  
+ATOM   1672  NH2 ARG I   5       9.530  16.492   9.780  1.00  5.62           N  
+ATOM   1673  N   ILE I   6       7.940   7.370   8.010  1.00  3.77           N  
+ATOM   1674  CA  ILE I   6       8.294   6.039   7.320  1.00  3.00           C  
+ATOM   1675  C   ILE I   6       8.189   6.218   5.792  1.00  9.34           C  
+ATOM   1676  O   ILE I   6       7.344   7.001   5.273  1.00  5.14           O  
+ATOM   1677  CB  ILE I   6       7.301   4.888   7.788  1.00  7.04           C  
+ATOM   1678  CG1 ILE I   6       7.532   3.495   7.167  1.00  3.00           C  
+ATOM   1679  CG2 ILE I   6       5.810   5.373   7.719  1.00  3.10           C  
+ATOM   1680  CD1 ILE I   6       6.684   2.447   7.888  1.00  4.89           C  
+ATOM   1681  N   LEU I   7       9.040   5.428   5.094  1.00 11.09           N  
+ATOM   1682  CA  LEU I   7       8.936   5.443   3.612  1.00  3.00           C  
+ATOM   1683  C   LEU I   7       7.866   4.426   3.246  1.00 12.66           C  
+ATOM   1684  O   LEU I   7       8.001   3.257   3.615  1.00  4.25           O  
+ATOM   1685  CB  LEU I   7      10.253   4.985   2.969  1.00  7.89           C  
+ATOM   1686  CG  LEU I   7      10.264   5.001   1.393  1.00 13.86           C  
+ATOM   1687  CD1 LEU I   7       9.758   6.343   0.885  1.00 13.88           C  
+ATOM   1688  CD2 LEU I   7      11.704   4.868   0.845  1.00  5.11           C  
+ATOM   1689  N   MET I   8       6.749   4.932   2.683  1.00  8.64           N  
+ATOM   1690  CA  MET I   8       5.630   4.076   2.362  1.00  3.00           C  
+ATOM   1691  C   MET I   8       5.068   4.386   0.964  1.00 11.88           C  
+ATOM   1692  O   MET I   8       4.745   5.542   0.651  1.00  4.49           O  
+ATOM   1693  CB  MET I   8       4.582   4.222   3.471  1.00  5.23           C  
+ATOM   1694  CG  MET I   8       3.298   3.393   3.298  1.00 12.17           C  
+ATOM   1695  SD  MET I   8       2.179   3.301   4.796  1.00 24.21           S  
+ATOM   1696  CE  MET I   8       3.466   3.180   6.070  1.00 21.40           C  
+ATOM   1697  N   GLU I   9       5.087   3.351   0.099  1.00  7.23           N  
+ATOM   1698  CA  GLU I   9       4.505   3.490  -1.271  1.00 26.64           C  
+ATOM   1699  C   GLU I   9       2.999   3.719  -1.140  1.00 23.44           C  
+ATOM   1700  O   GLU I   9       2.355   3.149  -0.256  1.00 15.55           O  
+ATOM   1701  CB  GLU I   9       4.741   2.171  -2.053  1.00 10.59           C  
+ATOM   1702  CG  GLU I   9       6.107   2.125  -2.760  1.00 28.46           C  
+ATOM   1703  CD  GLU I   9       6.509   0.696  -3.149  1.00 17.54           C  
+ATOM   1704  OE1 GLU I   9       5.806  -0.022  -3.883  1.00 29.40           O  
+ATOM   1705  OE2 GLU I   9       7.564   0.181  -2.736  1.00 26.45           O  
+ATOM   1706  N   CYS I  10       2.394   4.509  -2.004  1.00  6.88           N  
+ATOM   1707  CA  CYS I  10       0.921   4.492  -1.912  1.00  5.74           C  
+ATOM   1708  C   CYS I  10       0.298   4.677  -3.311  1.00 33.94           C  
+ATOM   1709  O   CYS I  10       0.947   5.234  -4.199  1.00 14.26           O  
+ATOM   1710  CB  CYS I  10       0.542   5.639  -0.984  1.00  3.00           C  
+ATOM   1711  SG  CYS I  10       1.310   7.186  -1.506  1.00  5.50           S  
+ATOM   1712  N   LYS I  11      -1.007   4.522  -3.426  1.00 23.70           N  
+ATOM   1713  CA  LYS I  11      -1.724   4.992  -4.643  1.00 11.76           C  
+ATOM   1714  C   LYS I  11      -2.836   5.983  -4.312  1.00 12.95           C  
+ATOM   1715  O   LYS I  11      -3.238   6.796  -5.160  1.00 12.13           O  
+ATOM   1716  CB  LYS I  11      -2.377   3.813  -5.356  1.00 17.39           C  
+ATOM   1717  CG  LYS I  11      -1.368   3.061  -6.231  1.00 30.12           C  
+ATOM   1718  CD  LYS I  11      -2.057   2.034  -7.150  0.00 32.78           C  
+ATOM   1719  CE  LYS I  11      -1.349   0.664  -7.148  1.00 39.14           C  
+ATOM   1720  NZ  LYS I  11      -1.878  -0.167  -6.078  1.00 43.85           N  
+ATOM   1721  N   LYS I  12      -3.353   5.847  -3.091  1.00 13.80           N  
+ATOM   1722  CA  LYS I  12      -4.240   6.889  -2.635  1.00 13.15           C  
+ATOM   1723  C   LYS I  12      -3.922   7.351  -1.229  1.00 22.23           C  
+ATOM   1724  O   LYS I  12      -3.189   6.631  -0.556  1.00  8.06           O  
+ATOM   1725  CB  LYS I  12      -5.683   6.456  -2.676  1.00 11.87           C  
+ATOM   1726  CG  LYS I  12      -5.817   5.087  -2.101  1.00 11.39           C  
+ATOM   1727  CD  LYS I  12      -6.624   4.287  -3.139  1.00 31.10           C  
+ATOM   1728  CE  LYS I  12      -7.796   3.703  -2.414  1.00 42.73           C  
+ATOM   1729  NZ  LYS I  12      -7.206   3.112  -1.219  1.00 41.01           N  
+ATOM   1730  N   ASP I  13      -4.483   8.535  -0.889  1.00 11.51           N  
+ATOM   1731  CA  ASP I  13      -4.233   9.099   0.451  1.00  8.27           C  
+ATOM   1732  C   ASP I  13      -4.437   8.050   1.544  1.00 18.87           C  
+ATOM   1733  O   ASP I  13      -3.672   7.992   2.500  1.00 27.37           O  
+ATOM   1734  CB  ASP I  13      -5.119  10.312   0.788  1.00 24.47           C  
+ATOM   1735  CG  ASP I  13      -4.644  11.515  -0.011  1.00 13.86           C  
+ATOM   1736  OD1 ASP I  13      -3.524  11.563  -0.569  1.00  8.36           O  
+ATOM   1737  OD2 ASP I  13      -5.389  12.502  -0.131  1.00 10.42           O  
+ATOM   1738  N   SER I  14      -5.502   7.310   1.368  1.00  5.77           N  
+ATOM   1739  CA  SER I  14      -6.053   6.352   2.365  1.00  8.51           C  
+ATOM   1740  C   SER I  14      -5.088   5.192   2.564  1.00  3.52           C  
+ATOM   1741  O   SER I  14      -5.045   4.594   3.627  1.00 13.85           O  
+ATOM   1742  CB  SER I  14      -7.409   5.797   1.863  1.00 20.50           C  
+ATOM   1743  OG  SER I  14      -7.190   4.744   0.919  1.00 24.94           O  
+ATOM   1744  N   ASP I  15      -4.153   5.070   1.643  1.00  5.92           N  
+ATOM   1745  CA  ASP I  15      -3.080   4.085   1.893  1.00 10.99           C  
+ATOM   1746  C   ASP I  15      -2.142   4.483   3.045  1.00 22.47           C  
+ATOM   1747  O   ASP I  15      -1.297   3.673   3.411  1.00 12.29           O  
+ATOM   1748  CB  ASP I  15      -2.226   3.935   0.623  1.00  9.99           C  
+ATOM   1749  CG  ASP I  15      -3.026   3.262  -0.509  1.00 13.56           C  
+ATOM   1750  OD1 ASP I  15      -4.089   2.633  -0.293  1.00 16.33           O  
+ATOM   1751  OD2 ASP I  15      -2.624   3.343  -1.694  1.00 14.39           O  
+ATOM   1752  N   CYS I  16      -2.100   5.760   3.399  1.00  4.27           N  
+ATOM   1753  CA  CYS I  16      -0.988   6.246   4.223  1.00  3.00           C  
+ATOM   1754  C   CYS I  16      -1.230   6.112   5.731  1.00 11.88           C  
+ATOM   1755  O   CYS I  16      -2.383   6.117   6.126  1.00 15.03           O  
+ATOM   1756  CB  CYS I  16      -0.658   7.689   3.858  1.00  3.00           C  
+ATOM   1757  SG  CYS I  16      -0.015   7.744   2.188  1.00  5.76           S  
+ATOM   1758  N   LEU I  17      -0.176   6.332   6.564  1.00 12.85           N  
+ATOM   1759  CA  LEU I  17      -0.432   6.351   8.019  1.00 10.24           C  
+ATOM   1760  C   LEU I  17      -0.917   7.722   8.476  1.00  6.48           C  
+ATOM   1761  O   LEU I  17      -0.331   8.728   8.109  1.00 11.35           O  
+ATOM   1762  CB  LEU I  17       0.773   5.979   8.887  1.00  9.83           C  
+ATOM   1763  CG  LEU I  17       1.349   4.578   8.787  1.00 14.51           C  
+ATOM   1764  CD1 LEU I  17       2.505   4.399   9.805  1.00 14.44           C  
+ATOM   1765  CD2 LEU I  17       0.231   3.576   9.119  1.00 22.84           C  
+ATOM   1766  N   ALA I  18      -1.690   7.714   9.558  1.00 10.63           N  
+ATOM   1767  CA  ALA I  18      -1.940   8.949  10.351  1.00 10.47           C  
+ATOM   1768  C   ALA I  18      -2.506  10.079   9.518  1.00 12.73           C  
+ATOM   1769  O   ALA I  18      -3.381   9.851   8.704  1.00 19.62           O  
+ATOM   1770  CB  ALA I  18      -0.762   9.465  11.237  1.00  3.00           C  
+ATOM   1771  N   GLU I  19      -1.894  11.222   9.573  1.00  5.57           N  
+ATOM   1772  CA  GLU I  19      -2.302  12.256   8.644  1.00  3.00           C  
+ATOM   1773  C   GLU I  19      -1.206  12.558   7.647  1.00  3.00           C  
+ATOM   1774  O   GLU I  19      -1.253  13.631   7.037  1.00  8.05           O  
+ATOM   1775  CB  GLU I  19      -2.567  13.575   9.348  1.00 10.47           C  
+ATOM   1776  CG  GLU I  19      -3.787  13.482  10.312  1.00 18.79           C  
+ATOM   1777  CD  GLU I  19      -3.411  13.918  11.716  1.00 62.93           C  
+ATOM   1778  OE1 GLU I  19      -3.038  15.114  11.925  1.00 37.65           O  
+ATOM   1779  OE2 GLU I  19      -3.459  13.064  12.656  1.00 52.39           O  
+ATOM   1780  N   CYS I  20      -0.570  11.489   7.226  1.00  5.82           N  
+ATOM   1781  CA  CYS I  20       0.183  11.619   5.972  1.00 18.76           C  
+ATOM   1782  C   CYS I  20      -0.748  11.635   4.755  1.00 12.93           C  
+ATOM   1783  O   CYS I  20      -1.720  10.889   4.774  1.00 14.38           O  
+ATOM   1784  CB  CYS I  20       1.143  10.449   5.802  1.00  4.60           C  
+ATOM   1785  SG  CYS I  20       2.472  10.334   7.028  1.00  6.41           S  
+ATOM   1786  N   VAL I  21      -0.295  12.167   3.636  1.00  3.00           N  
+ATOM   1787  CA  VAL I  21      -1.112  11.983   2.405  1.00 10.33           C  
+ATOM   1788  C   VAL I  21      -0.274  11.315   1.312  1.00 19.31           C  
+ATOM   1789  O   VAL I  21       0.940  11.212   1.480  1.00  9.47           O  
+ATOM   1790  CB  VAL I  21      -1.601  13.370   1.944  1.00  3.03           C  
+ATOM   1791  CG1 VAL I  21      -2.502  14.061   3.005  1.00  3.69           C  
+ATOM   1792  CG2 VAL I  21      -0.379  14.273   1.593  1.00  8.57           C  
+ATOM   1793  N   CYS I  22      -0.900  10.873   0.213  1.00  7.02           N  
+ATOM   1794  CA  CYS I  22      -0.147  10.183  -0.822  1.00  3.33           C  
+ATOM   1795  C   CYS I  22       0.301  11.185  -1.842  1.00 14.48           C  
+ATOM   1796  O   CYS I  22      -0.574  11.811  -2.416  1.00  9.02           O  
+ATOM   1797  CB  CYS I  22      -1.026   9.221  -1.580  1.00  3.00           C  
+ATOM   1798  SG  CYS I  22      -0.083   8.169  -2.719  1.00  6.58           S  
+ATOM   1799  N   LEU I  23       1.606  11.400  -1.954  1.00 10.27           N  
+ATOM   1800  CA  LEU I  23       1.954  12.509  -2.853  1.00 15.09           C  
+ATOM   1801  C   LEU I  23       2.233  11.991  -4.267  1.00 23.96           C  
+ATOM   1802  O   LEU I  23       2.194  10.779  -4.482  1.00 24.44           O  
+ATOM   1803  CB  LEU I  23       3.200  13.140  -2.255  1.00  4.86           C  
+ATOM   1804  CG  LEU I  23       2.825  13.767  -0.918  1.00 12.51           C  
+ATOM   1805  CD1 LEU I  23       4.090  14.020  -0.115  1.00 28.01           C  
+ATOM   1806  CD2 LEU I  23       2.020  15.051  -1.191  1.00 16.05           C  
+ATOM   1807  N   GLU I  24       2.331  12.950  -5.184  1.00 11.91           N  
+ATOM   1808  CA  GLU I  24       2.634  12.810  -6.613  1.00 28.44           C  
+ATOM   1809  C   GLU I  24       3.552  11.634  -7.038  1.00 27.08           C  
+ATOM   1810  O   GLU I  24       3.166  10.950  -7.986  1.00 40.03           O  
+ATOM   1811  CB  GLU I  24       3.172  14.169  -7.133  1.00 42.99           C  
+ATOM   1812  CG  GLU I  24       3.185  14.302  -8.664  1.00 51.22           C  
+ATOM   1813  CD  GLU I  24       3.877  15.611  -9.033  0.00 34.20           C  
+ATOM   1814  OE1 GLU I  24       3.404  16.711  -8.641  0.00  0.00           O  
+ATOM   1815  OE2 GLU I  24       4.927  15.600  -9.729  0.00  0.00           O  
+ATOM   1816  N   HIS I  25       4.725  11.352  -6.467  1.00 12.40           N  
+ATOM   1817  CA  HIS I  25       5.504  10.137  -7.003  1.00  8.41           C  
+ATOM   1818  C   HIS I  25       5.266   8.835  -6.226  1.00 33.52           C  
+ATOM   1819  O   HIS I  25       6.027   7.881  -6.371  1.00 29.21           O  
+ATOM   1820  CB  HIS I  25       7.019  10.338  -7.046  1.00 17.26           C  
+ATOM   1821  CG  HIS I  25       7.256  11.745  -7.627  1.00 58.38           C  
+ATOM   1822  ND1 HIS I  25       7.331  12.894  -6.769  1.00 46.25           N  
+ATOM   1823  CD2 HIS I  25       7.364  12.135  -8.918  1.00 40.20           C  
+ATOM   1824  CE1 HIS I  25       7.576  14.024  -7.584  1.00 43.88           C  
+ATOM   1825  NE2 HIS I  25       7.590  13.524  -8.924  1.00 45.93           N  
+ATOM   1826  N   GLY I  26       4.099   8.724  -5.658  1.00  9.40           N  
+ATOM   1827  CA  GLY I  26       3.618   7.443  -5.199  1.00  3.00           C  
+ATOM   1828  C   GLY I  26       4.195   7.105  -3.824  1.00  6.20           C  
+ATOM   1829  O   GLY I  26       4.193   5.930  -3.421  1.00  9.81           O  
+ATOM   1830  N   TYR I  27       4.548   8.120  -3.105  1.00  3.00           N  
+ATOM   1831  CA  TYR I  27       4.999   7.886  -1.717  1.00  3.00           C  
+ATOM   1832  C   TYR I  27       4.202   8.755  -0.730  1.00  5.39           C  
+ATOM   1833  O   TYR I  27       3.910   9.905  -1.031  1.00  6.99           O  
+ATOM   1834  CB  TYR I  27       6.478   8.247  -1.570  1.00  3.00           C  
+ATOM   1835  CG  TYR I  27       7.404   7.240  -2.258  1.00 11.13           C  
+ATOM   1836  CD1 TYR I  27       7.575   5.979  -1.723  1.00  9.16           C  
+ATOM   1837  CD2 TYR I  27       8.045   7.606  -3.424  1.00  4.25           C  
+ATOM   1838  CE1 TYR I  27       8.373   5.037  -2.358  1.00  4.25           C  
+ATOM   1839  CE2 TYR I  27       8.855   6.672  -4.073  1.00  8.50           C  
+ATOM   1840  CZ  TYR I  27       9.004   5.402  -3.552  1.00 24.42           C  
+ATOM   1841  OH  TYR I  27       9.793   4.501  -4.193  1.00 30.06           O  
+ATOM   1842  N   CYS I  28       3.961   8.263   0.468  1.00  9.03           N  
+ATOM   1843  CA  CYS I  28       3.327   9.063   1.536  1.00  3.96           C  
+ATOM   1844  C   CYS I  28       4.208  10.216   2.041  1.00  5.72           C  
+ATOM   1845  O   CYS I  28       5.451  10.154   1.995  1.00  3.00           O  
+ATOM   1846  CB  CYS I  28       2.971   8.120   2.708  1.00  3.00           C  
+ATOM   1847  SG  CYS I  28       1.821   6.789   2.307  1.00  6.81           S  
+ATOM   1848  N   GLY I  29       3.556  11.233   2.584  1.00  3.00           N  
+ATOM   1849  CA  GLY I  29       4.383  12.342   2.982  1.00  3.56           C  
+ATOM   1850  C   GLY I  29       3.413  13.353   3.495  1.00 14.31           C  
+ATOM   1851  O   GLY I  29       2.314  12.944   3.855  1.00  3.00           O  
+ATOM   1852  OXT GLY I  29       3.859  14.453   3.888  1.00 11.48           O  
+TER    1853      GLY I  29                                                      
+HETATM 1854  O   HOH E 406      17.043   4.766  16.720  1.00  3.14           O  
+HETATM 1855  O   HOH E 408       6.856  10.214  19.045  1.00 17.08           O  
+HETATM 1856  O   HOH E 410      16.954   5.838   7.248  1.00  3.00           O  
+HETATM 1857  O   HOH E 412      27.539   8.429   3.542  1.00  7.57           O  
+HETATM 1858  O   HOH E 415       8.362  20.078   8.487  1.00 12.90           O  
+HETATM 1859  O   HOH E 416      11.335  13.371  13.221  1.00 11.58           O  
+HETATM 1860  O   HOH E 429      20.362  16.095   2.683  1.00 11.32           O  
+HETATM 1861  O   HOH E 430      18.672  11.198   3.669  1.00  3.00           O  
+HETATM 1862  O   HOH E 457      17.695  -1.600   2.590  1.00 17.96           O  
+HETATM 1863  O   HOH E 470      24.322  19.741   9.369  1.00  4.50           O  
+HETATM 1864  O   HOH E 473      11.537  20.077  22.558  1.00 13.99           O  
+HETATM 1865  O   HOH E 516      28.486   1.299   8.803  1.00  8.28           O  
+HETATM 1866  O   HOH E 562      11.416  21.568   9.954  1.00 11.19           O  
+HETATM 1867  O   HOH E 604      27.531   4.434   5.818  1.00 13.45           O  
+HETATM 1868  O   HOH E 701      17.358   6.988   9.792  1.00  3.00           O  
+HETATM 1869  O   HOH E 703       7.014   9.027  21.813  1.00  8.52           O  
+HETATM 1870  O   HOH E 704      14.770  17.920  12.772  1.00  7.86           O  
+HETATM 1871  O   HOH E 705      13.893  21.331  11.640  1.00  4.69           O  
+HETATM 1872  O   HOH E 706      29.021  -1.518   2.624  1.00 19.75           O  
+HETATM 1873  O   HOH E 708      23.516  -0.088   7.937  1.00  3.00           O  
+HETATM 1874  O   HOH E 709      25.762   2.267   8.482  1.00 14.19           O  
+HETATM 1875  O   HOH E 714      27.115  -0.297   1.185  1.00 12.94           O  
+HETATM 1876  O   HOH E 716      25.663  -0.467  10.978  1.00 19.85           O  
+HETATM 1877  O   HOH E 717      27.745   4.813   8.377  1.00 14.58           O  
+HETATM 1878  O   HOH E 718      29.285   8.216   1.244  1.00 18.55           O  
+HETATM 1879  O   HOH E 721      23.357   9.610  14.020  1.00  3.00           O  
+HETATM 1880  O   HOH E 722      16.203  11.262  25.314  1.00  8.75           O  
+HETATM 1881  O   HOH E 723       0.513  13.372  19.266  1.00 20.88           O  
+HETATM 1882  O   HOH E 726      17.822  25.073  20.757  1.00 24.57           O  
+HETATM 1883  O   HOH E 727      14.688  26.358  21.338  1.00 21.00           O  
+HETATM 1884  O   HOH E 728      18.471  18.608   0.751  1.00 14.22           O  
+HETATM 1885  O   HOH E 729      23.642  13.090  25.547  1.00 21.20           O  
+HETATM 1886  O   HOH E 730      23.909  20.557   6.662  1.00 12.33           O  
+HETATM 1887  O   HOH E 741      30.668  -5.945   8.411  1.00 22.33           O  
+HETATM 1888  O   HOH E 743      32.620  -2.481  17.069  1.00 21.02           O  
+HETATM 1889  O   HOH E 746      17.463  25.817  15.914  1.00 20.39           O  
+HETATM 1890  O   HOH E 747       1.371   2.929  13.345  1.00 16.64           O  
+HETATM 1891  O   HOH E 749       5.208  26.409   7.950  1.00 29.08           O  
+HETATM 1892  O   HOH E 750       8.443   5.385  30.023  1.00 40.27           O  
+HETATM 1893  O   HOH E 754      24.289   1.677  27.224  1.00 35.90           O  
+HETATM 1894  O   HOH E 755      16.584  14.353  25.832  1.00 23.60           O  
+HETATM 1895  O   HOH E 801      32.940   7.977   2.066  1.00 22.81           O  
+HETATM 1896  O   HOH E 802       3.008  -0.524  14.714  1.00 20.68           O  
+HETATM 1897  O   HOH E 804       7.904  26.276   4.824  1.00 21.94           O  
+HETATM 1898  O   HOH E 806      18.953 -14.105   9.474  1.00 22.32           O  
+HETATM 1899  O   HOH E 807      -1.316   1.851  12.235  1.00 21.57           O  
+HETATM 1900  O   HOH E 809      32.601   7.848  12.845  1.00 23.24           O  
+HETATM 1901  O   HOH E 811      24.340 -15.464  17.526  1.00 21.09           O  
+HETATM 1902  O   HOH E 812      29.086  -8.595  21.680  1.00 21.48           O  
+HETATM 1903  O   HOH E 813      24.281  -9.217  22.949  1.00 19.65           O  
+HETATM 1904  O   HOH E 814      20.402  -9.787  24.331  1.00 22.51           O  
+HETATM 1905  O   HOH E 816       1.885   6.286  28.527  1.00 21.73           O  
+HETATM 1906  O   HOH E 818      12.713   9.708  33.237  1.00 22.50           O  
+HETATM 1907  O   HOH E 819      13.370   3.539  36.023  1.00 19.71           O  
+HETATM 1908  O   HOH E 907      23.793  11.895  -2.846  1.00 29.86           O  
+HETATM 1909  O   HOH E 910      16.930   6.260  -0.225  1.00 19.00           O  
+HETATM 1910  O   HOH E 913       7.723  10.930   0.441  1.00 13.72           O  
+HETATM 1911  O   HOH E 916       8.514  13.209   1.859  1.00  5.71           O  
+HETATM 1912  O   HOH E 917       7.095  19.196   3.109  1.00 14.47           O  
+HETATM 1913  O   HOH E 918       6.606   0.759   4.088  1.00 23.16           O  
+HETATM 1914  O   HOH E 921       6.884  14.265   8.237  1.00  3.00           O  
+HETATM 1915  O   HOH E 922       5.544  -0.201   9.598  1.00 18.14           O  
+HETATM 1916  O   HOH E 923      12.311 -11.270   9.762  1.00 24.15           O  
+HETATM 1917  O   HOH E 924      26.725 -11.250  10.404  1.00 34.43           O  
+HETATM 1918  O   HOH E 925      33.753  -8.433  11.251  1.00 28.41           O  
+HETATM 1919  O   HOH E 927      16.007  28.803  12.908  1.00 19.78           O  
+HETATM 1920  O   HOH E 928      15.173  27.357  15.526  1.00 20.67           O  
+HETATM 1921  O   HOH E 929      29.243   8.276  18.454  1.00 24.89           O  
+HETATM 1922  O   HOH E 930      23.972   0.353  24.012  1.00 17.81           O  
+HETATM 1923  O   HOH E 931      -0.582   6.069  25.279  1.00 25.55           O  
+HETATM 1924  O   HOH E 932      22.400  23.696  26.372  1.00 21.91           O  
+HETATM 1925  O   HOH E 933      13.174  22.520  27.288  1.00 18.97           O  
+HETATM 1926  O   HOH E 934      23.798  10.934  29.097  1.00 28.32           O  
+HETATM 1927  O   HOH E 935      14.650   5.033  32.423  1.00 28.35           O  
+HETATM 1928  O   HOH E 938      28.508   4.871  -3.672  1.00 31.19           O  
+HETATM 1929  O   HOH E 939      29.569   4.613  -1.174  1.00 30.86           O  
+HETATM 1930  O   HOH E 940      29.682   9.181  -1.473  1.00 30.65           O  
+HETATM 1931  O   HOH E 941      14.854   4.674  -0.609  1.00 26.84           O  
+HETATM 1932  O   HOH E 942      15.891  -0.039  -0.727  1.00 33.92           O  
+HETATM 1933  O   HOH E 943      14.621  20.934  -0.648  1.00 35.71           O  
+HETATM 1934  O   HOH E 944      25.096  -1.809   0.139  1.00 27.37           O  
+HETATM 1935  O   HOH E 945       9.181  16.387   1.079  1.00 22.11           O  
+HETATM 1936  O   HOH E 946      22.005  19.315   1.090  1.00 13.88           O  
+HETATM 1937  O   HOH E 947       3.904  19.730   3.665  1.00 35.21           O  
+HETATM 1938  O   HOH E 948      30.904   0.521   2.912  1.00 34.38           O  
+HETATM 1939  O   HOH E 949       6.620  15.137   4.014  1.00 30.24           O  
+HETATM 1940  O   HOH E 951       1.396  20.337   5.551  1.00 29.52           O  
+HETATM 1941  O   HOH E 952      34.733   1.878   5.393  1.00 28.10           O  
+HETATM 1942  O   HOH E 953      34.631   5.897   5.110  1.00 28.41           O  
+HETATM 1943  O   HOH E 955      13.327 -11.240   6.754  1.00 30.64           O  
+HETATM 1944  O   HOH E 956       3.149  -6.838   8.586  1.00 37.63           O  
+HETATM 1945  O   HOH E 957      23.381  22.201  10.601  1.00 33.07           O  
+HETATM 1946  O   HOH E 958      29.472  13.755  10.799  1.00 27.37           O  
+HETATM 1947  O   HOH E 960       2.720   1.173  11.696  1.00 29.61           O  
+HETATM 1948  O   HOH E 961       0.601   5.901  12.818  1.00 33.94           O  
+HETATM 1949  O   HOH E 962      -4.576   4.749  14.297  1.00 37.52           O  
+HETATM 1950  O   HOH E 964      28.086  25.045  14.984  1.00 40.92           O  
+HETATM 1951  O   HOH E 965      27.759   9.857  16.211  1.00 24.19           O  
+HETATM 1952  O   HOH E 967      30.560  -9.351  17.560  1.00 29.74           O  
+HETATM 1953  O   HOH E 968       0.751  27.686  18.508  1.00 49.64           O  
+HETATM 1954  O   HOH E 969      18.194  26.292  18.427  1.00 32.45           O  
+HETATM 1955  O   HOH E 970      -0.836  -0.171  18.811  1.00 49.24           O  
+HETATM 1956  O   HOH E 971      23.951  23.639  19.673  1.00 35.54           O  
+HETATM 1957  O   HOH E 972       5.265  -6.465  20.503  1.00 33.21           O  
+HETATM 1958  O   HOH E 973      26.307  16.761  21.268  1.00 22.01           O  
+HETATM 1959  O   HOH E 974      28.411   5.397  22.265  1.00 30.06           O  
+HETATM 1960  O   HOH E 975      13.859  20.269  25.256  1.00 31.91           O  
+HETATM 1961  O   HOH E 977       2.351  14.657  28.391  1.00 31.68           O  
+HETATM 1962  O   HOH E 978      15.920  21.481  28.156  1.00 36.90           O  
+HETATM 1963  O   HOH E 979       5.661   5.858  28.915  1.00 30.93           O  
+HETATM 1964  O   HOH E 980       8.547   2.552  29.763  1.00 24.29           O  
+HETATM 1965  O   HOH E 981      20.201  -5.107  29.592  1.00 32.18           O  
+HETATM 1966  O   HOH E 982      17.468  13.332  32.948  1.00 36.86           O  
+HETATM 1967  O   HOH E 983      12.993   5.127  -2.907  1.00 29.73           O  
+HETATM 1968  O   HOH E 984      13.733   2.216  -0.475  1.00 32.05           O  
+HETATM 1969  O   HOH E 985      20.312  -2.304   1.220  1.00 33.72           O  
+HETATM 1970  O   HOH E 986      30.083  11.251   9.552  1.00 35.50           O  
+HETATM 1971  O   HOH E 988      33.096   3.542  12.150  1.00 35.80           O  
+HETATM 1972  O   HOH E 989       7.614  27.522  17.618  1.00 26.49           O  
+HETATM 1973  O   HOH E 990      27.178  -6.730  22.487  1.00 34.44           O  
+HETATM 1974  O   HOH E 991      23.283  -3.831  25.862  1.00 36.08           O  
+HETATM 1975  O   HOH E 992      27.627  11.821  27.603  1.00 32.04           O  
+HETATM 1976  O   HOH E 993       0.084   0.580  28.615  1.00 33.00           O  
+HETATM 1977  O   HOH E 997      30.820  -1.887  19.032  1.00 32.45           O  
+HETATM 1978  O   HOH E 998      -2.442   2.108  18.983  1.00 32.40           O  
+HETATM 1979  O   HOH E 999      18.470  12.502  -2.757  1.00 21.64           O  
+HETATM 1980  O   HOH I 803      -8.714  10.207   0.819  1.00 22.09           O  
+HETATM 1981  O   HOH I 808       2.645   6.715   5.776  1.00  3.00           O  
+HETATM 1982  O   HOH I 904       5.755  11.100  -3.652  1.00 25.17           O  
+HETATM 1983  O   HOH I 906      10.562   2.210  -2.759  1.00 19.30           O  
+HETATM 1984  O   HOH I 911      -8.096  12.272  -0.300  1.00  7.15           O  
+HETATM 1985  O   HOH I 914      -6.227   2.381   1.164  1.00 17.74           O  
+HETATM 1986  O   HOH I 915       6.805   7.702   2.535  1.00  6.91           O  
+HETATM 1987  O   HOH I 919       4.806   8.384   5.743  1.00  3.18           O  
+HETATM 1988  O   HOH I 920      -4.713   7.338   7.062  1.00 34.84           O  
+HETATM 1989  O   HOH I 937      13.269   1.736  -3.411  1.00 29.07           O  
+HETATM 1990  O   HOH I 950      -4.066   9.748   4.823  1.00 41.16           O  
+HETATM 1991  O   HOH I 954      -3.595  15.175   6.005  1.00 31.73           O  
+HETATM 1992  O   HOH I 994       2.931  15.885  -4.719  1.00 33.47           O  
+HETATM 1993  O   HOH I 995      -5.121   1.699  -2.770  1.00 32.85           O  
+CONECT   48 1007                                                                
+CONECT  185  298                                                                
+CONECT  298  185                                                                
+CONECT  811 1521                                                                
+CONECT  853 1327                                                                
+CONECT 1007   48                                                                
+CONECT 1084 1190                                                                
+CONECT 1190 1084                                                                
+CONECT 1265 1422                                                                
+CONECT 1327  853                                                                
+CONECT 1422 1265                                                                
+CONECT 1521  811                                                                
+CONECT 1654 1785                                                                
+CONECT 1711 1798                                                                
+CONECT 1757 1847                                                                
+CONECT 1785 1654                                                                
+CONECT 1798 1711                                                                
+CONECT 1847 1757                                                                
+MASTER      405    1    0    4   20    0    0    6 1991    2   18   21          
+END                                                                             

--- a/test/1ppe/golden/1ppe_prediction.txt
+++ b/test/1ppe/golden/1ppe_prediction.txt
@@ -1,0 +1,31 @@
+[+] Parsed structure file 1ppe (2 chains, 252 residues)
+[+] No. of intermolecular contacts: 71
+[+] No. of charged-charged contacts: 4
+[+] No. of charged-polar contacts: 8
+[+] No. of charged-apolar contacts: 24
+[+] No. of polar-polar contacts: 0
+[+] No. of apolar-polar contacts: 15
+[+] No. of apolar-apolar contacts: 20
+[+] ALA: 1
+[+] CYS: 12
+[+] GLU: 1
+[+] ASP: 2
+[+] GLY: 14
+[+] PHE: 3
+[+] ILE: 8
+[+] HIS: 7
+[+] LYS: 2
+[+] MET: 1
+[+] LEU: 10
+[+] ASN: 1
+[+] GLN: 10
+[+] PRO: 7
+[+] SER: 9
+[+] ARG: 28
+[+] THR: 3
+[+] TRP: 5
+[+] VAL: 8
+[+] TYR: 10
+[+] Link density: 0.1352
+[+] Class: BIO
+

--- a/test/1ppe/test_1ppe.py
+++ b/test/1ppe/test_1ppe.py
@@ -1,0 +1,25 @@
+"""Regression tests for 1ppe complex"""
+
+import shutil
+import os
+import filecmp
+from test.regression import RegressionTest
+
+
+class TestRegression1ppe(RegressionTest):
+
+    def setup(self):
+        self.path = os.path.dirname(os.path.realpath(__file__))
+        self.test_path = self.path + '/scratch_1ppe/'
+        self.ini_test_path()
+        self.golden_data_path = os.path.join(os.path.normpath(os.path.dirname(os.path.realpath(__file__))), 'golden')
+
+    def teardown(self):
+        self.clean_test_path()
+
+    def test_1ppe(self):
+        os.chdir(self.test_path)
+        command = "python ../../../interface_classifier.py {} | tail -n +2 > prediction".format(os.path.join(self.golden_data_path, '1ppe.pdb'))
+        os.system(command)
+
+        assert filecmp.cmp(os.path.join(self.golden_data_path, '1ppe_prediction.txt'), os.path.join(self.test_path, 'prediction'))

--- a/test/1ppe/test_1ppe_selection.py
+++ b/test/1ppe/test_1ppe_selection.py
@@ -1,0 +1,25 @@
+"""Regression tests for 1ppe complex"""
+
+import shutil
+import os
+import filecmp
+from test.regression import RegressionTest
+
+
+class TestRegression1ppe(RegressionTest):
+
+    def setup(self):
+        self.path = os.path.dirname(os.path.realpath(__file__))
+        self.test_path = self.path + '/scratch_1ppe/'
+        self.ini_test_path()
+        self.golden_data_path = os.path.join(os.path.normpath(os.path.dirname(os.path.realpath(__file__))), 'golden')
+
+    def teardown(self):
+        self.clean_test_path()
+
+    def test_1ppe(self):
+        os.chdir(self.test_path)
+        command = "python ../../../interface_classifier.py {} --selection E I | tail -n +2 > prediction".format(os.path.join(self.golden_data_path, '1ppe.pdb'))
+        os.system(command)
+
+        assert filecmp.cmp(os.path.join(self.golden_data_path, '1ppe_prediction.txt'), os.path.join(self.test_path, 'prediction'))

--- a/test/2uuy/golden/2uuy.pdb
+++ b/test/2uuy/golden/2uuy.pdb
@@ -1,0 +1,6638 @@
+HEADER    HYDROLASE                               08-MAR-07   2UUY              
+TITLE     STRUCTURE OF A TICK TRYPTASE INHIBITOR IN COMPLEX WITH                
+TITLE    2 BOVINE TRYPSIN                                                       
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: CATIONIC TRYPSIN;                                          
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 FRAGMENT: RESIDUES 21-243;                                           
+COMPND   5 SYNONYM: TRYPSIN FROM BOVINE PANCREAS, BETA-TRYPSIN;                 
+COMPND   6 EC: 3.4.21.4;                                                        
+COMPND   7 MOL_ID: 2;                                                           
+COMPND   8 MOLECULE: TRYPTASE INHIBITOR;                                        
+COMPND   9 CHAIN: B;                                                            
+COMPND  10 FRAGMENT: RESIDUES 45-96;                                            
+COMPND  11 SYNONYM: TRYPTASE INHIBITOR TDPI                                     
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: BOS TAURUS;                                     
+SOURCE   3 ORGANISM_COMMON: BOVINE;                                             
+SOURCE   4 ORGANISM_TAXID: 9913;                                                
+SOURCE   5 TISSUE: PANCREAS;                                                    
+SOURCE   6 MOL_ID: 2;                                                           
+SOURCE   7 ORGANISM_SCIENTIFIC: RHIPICEPHALUS APPENDICULATUS;                   
+SOURCE   8 ORGANISM_COMMON: BROWN EAR TICK;                                     
+SOURCE   9 ORGANISM_TAXID: 34631                                                
+KEYWDS    CALCIUM, ZYMOGEN, PROTEASE, HYDROLASE, DIGESTION, METAL-              
+KEYWDS   2 BINDING, SERINE PROTEASE, TRYPTASE INHIBITOR                         
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    C.SIEBOLD,G.C.PAESEN,K.HARLOS,M.F.PEACEY,P.A.NUTTALL,                 
+AUTHOR   2 D.I.STUART                                                           
+REVDAT   3   24-FEB-09 2UUY    1       VERSN                                    
+REVDAT   2   01-MAY-07 2UUY    1       JRNL                                     
+REVDAT   1   10-APR-07 2UUY    0                                                
+JRNL        AUTH   G.C.PAESEN,C.SIEBOLD,K.HARLOS,M.F.PEACEY,                    
+JRNL        AUTH 2 P.A.NUTTALL,D.I.STUART                                       
+JRNL        TITL   A TICK PROTEIN WITH A MODIFIED KUNITZ FOLD                   
+JRNL        TITL 2 INHIBITS HUMAN TRYPTASE.                                     
+JRNL        REF    J.MOL.BIOL.                   V. 368  1172 2007              
+JRNL        REFN                   ISSN 0022-2836                               
+JRNL        PMID   17391695                                                     
+JRNL        DOI    10.1016/J.JMB.2007.03.011                                    
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    1.15 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : REFMAC 5.2.0019                                      
+REMARK   3   AUTHORS     : MURSHUDOV,VAGIN,DODSON                               
+REMARK   3                                                                      
+REMARK   3    REFINEMENT TARGET : MAXIMUM LIKELIHOOD                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 1.15                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 48.34                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : NULL                           
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 98.4                           
+REMARK   3   NUMBER OF REFLECTIONS             : 73793                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.132                           
+REMARK   3   R VALUE            (WORKING SET) : 0.130                           
+REMARK   3   FREE R VALUE                     : 0.163                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 5.000                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 3902                            
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 20                           
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 1.15                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 1.18                         
+REMARK   3   REFLECTION IN BIN     (WORKING SET) : 4683                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : 85.33                        
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.2690                       
+REMARK   3   BIN FREE R VALUE SET COUNT          : 250                          
+REMARK   3   BIN FREE R VALUE                    : 0.3140                       
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 2133                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 2                                       
+REMARK   3   SOLVENT ATOMS            : 510                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : NULL                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 8.63                           
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : -0.45000                                             
+REMARK   3    B22 (A**2) : 0.34000                                              
+REMARK   3    B33 (A**2) : 0.11000                                              
+REMARK   3    B12 (A**2) : 0.00000                                              
+REMARK   3    B13 (A**2) : 0.00000                                              
+REMARK   3    B23 (A**2) : 0.00000                                              
+REMARK   3                                                                      
+REMARK   3  ESTIMATED OVERALL COORDINATE ERROR.                                 
+REMARK   3   ESU BASED ON R VALUE                            (A): 0.035         
+REMARK   3   ESU BASED ON FREE R VALUE                       (A): 0.036         
+REMARK   3   ESU BASED ON MAXIMUM LIKELIHOOD                 (A): 0.022         
+REMARK   3   ESU FOR B VALUES BASED ON MAXIMUM LIKELIHOOD (A**2): 1.075         
+REMARK   3                                                                      
+REMARK   3 CORRELATION COEFFICIENTS.                                            
+REMARK   3   CORRELATION COEFFICIENT FO-FC      : 0.980                         
+REMARK   3   CORRELATION COEFFICIENT FO-FC FREE : 0.971                         
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES        COUNT    RMS    WEIGHT      
+REMARK   3   BOND LENGTHS REFINED ATOMS        (A):  2210 ; 0.013 ; 0.022       
+REMARK   3   BOND LENGTHS OTHERS               (A):  1503 ; 0.002 ; 0.020       
+REMARK   3   BOND ANGLES REFINED ATOMS   (DEGREES):  3037 ; 1.556 ; 1.952       
+REMARK   3   BOND ANGLES OTHERS          (DEGREES):  3703 ; 0.912 ; 3.011       
+REMARK   3   TORSION ANGLES, PERIOD 1    (DEGREES):   321 ; 6.506 ; 5.000       
+REMARK   3   TORSION ANGLES, PERIOD 2    (DEGREES):    77 ;39.812 ;24.805       
+REMARK   3   TORSION ANGLES, PERIOD 3    (DEGREES):   376 ;11.590 ;15.000       
+REMARK   3   TORSION ANGLES, PERIOD 4    (DEGREES):     6 ;18.613 ;15.000       
+REMARK   3   CHIRAL-CENTER RESTRAINTS       (A**3):   337 ; 0.094 ; 0.200       
+REMARK   3   GENERAL PLANES REFINED ATOMS      (A):  2527 ; 0.008 ; 0.020       
+REMARK   3   GENERAL PLANES OTHERS             (A):   426 ; 0.001 ; 0.020       
+REMARK   3   NON-BONDED CONTACTS REFINED ATOMS (A):   402 ; 0.206 ; 0.200       
+REMARK   3   NON-BONDED CONTACTS OTHERS        (A):  1590 ; 0.190 ; 0.200       
+REMARK   3   NON-BONDED TORSION REFINED ATOMS  (A):  1075 ; 0.182 ; 0.200       
+REMARK   3   NON-BONDED TORSION OTHERS         (A):  1215 ; 0.091 ; 0.200       
+REMARK   3   H-BOND (X...Y) REFINED ATOMS      (A):   330 ; 0.197 ; 0.200       
+REMARK   3   H-BOND (X...Y) OTHERS             (A):  NULL ;  NULL ;  NULL       
+REMARK   3   POTENTIAL METAL-ION REFINED ATOMS (A):     6 ; 0.262 ; 0.200       
+REMARK   3   POTENTIAL METAL-ION OTHERS        (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY VDW REFINED ATOMS        (A):    15 ; 0.180 ; 0.200       
+REMARK   3   SYMMETRY VDW OTHERS               (A):    61 ; 0.235 ; 0.200       
+REMARK   3   SYMMETRY H-BOND REFINED ATOMS     (A):    83 ; 0.186 ; 0.200       
+REMARK   3   SYMMETRY H-BOND OTHERS            (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY METAL-ION REFINED ATOMS  (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY METAL-ION OTHERS         (A):  NULL ;  NULL ;  NULL       
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.     COUNT   RMS    WEIGHT      
+REMARK   3   MAIN-CHAIN BOND REFINED ATOMS  (A**2):  1469 ; 1.501 ; 1.500       
+REMARK   3   MAIN-CHAIN BOND OTHER ATOMS    (A**2):   597 ; 0.653 ; 1.500       
+REMARK   3   MAIN-CHAIN ANGLE REFINED ATOMS (A**2):  2319 ; 2.106 ; 2.000       
+REMARK   3   SIDE-CHAIN BOND REFINED ATOMS  (A**2):   875 ; 2.726 ; 3.000       
+REMARK   3   SIDE-CHAIN ANGLE REFINED ATOMS (A**2):   693 ; 3.663 ; 4.500       
+REMARK   3                                                                      
+REMARK   3 ANISOTROPIC THERMAL FACTOR RESTRAINTS.    COUNT   RMS   WEIGHT       
+REMARK   3   RIGID-BOND RESTRAINTS          (A**2):  NULL ;  NULL ;  NULL       
+REMARK   3   SPHERICITY; FREE ATOMS         (A**2):  NULL ;  NULL ;  NULL       
+REMARK   3   SPHERICITY; BONDED ATOMS       (A**2):  NULL ;  NULL ;  NULL       
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS STATISTICS                                           
+REMARK   3   NUMBER OF DIFFERENT NCS GROUPS : NULL                              
+REMARK   3                                                                      
+REMARK   3  TLS DETAILS                                                         
+REMARK   3   NUMBER OF TLS GROUPS  : NULL                                       
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELLING.                                             
+REMARK   3   METHOD USED : MASK                                                 
+REMARK   3   PARAMETERS FOR MASK CALCULATION                                    
+REMARK   3   VDW PROBE RADIUS   : 1.40                                          
+REMARK   3   ION PROBE RADIUS   : 0.80                                          
+REMARK   3   SHRINKAGE RADIUS   : 0.80                                          
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: HYDROGENS HAVE BEEN ADDED IN THE          
+REMARK   3  RIDING POSITIONS                                                    
+REMARK   4                                                                      
+REMARK   4 2UUY COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY PDBE ON  09-MAR-07.                 
+REMARK 100 THE PDBE ID CODE IS EBI-31800.                                       
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : NULL                               
+REMARK 200  TEMPERATURE           (KELVIN) : 100.0                              
+REMARK 200  PH                             : NULL                               
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : ESRF                               
+REMARK 200  BEAMLINE                       : BM14                               
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 0.978                              
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : MARRESEARCH                        
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : DENZO                              
+REMARK 200  DATA SCALING SOFTWARE          : SCALEPACK                          
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 77853                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 1.150                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 30.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : 0.000                              
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 98.4                               
+REMARK 200  DATA REDUNDANCY                : 6.900                              
+REMARK 200  R MERGE                    (I) : 0.07000                            
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 15.0000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 1.15                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 1.25                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 94.0                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : 2.80                               
+REMARK 200  R MERGE FOR SHELL          (I) : 0.38000                            
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 2.400                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: PHASER                                                
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 36                                        
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 1.48                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: 0.1 M BIS-TRIS, PH 6.5 0.2 M             
+REMARK 280  MGCL2 25% PEG3350 (W/V)                                             
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 21 21 21                       
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X+1/2,-Y,Z+1/2                                         
+REMARK 290       3555   -X,Y+1/2,-Z+1/2                                         
+REMARK 290       4555   X+1/2,-Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000       23.47450            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       34.53400            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       33.84500            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       34.53400            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       23.47450            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000       33.84500            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY.  THE REMARK MAY ALSO PROVIDE INFORMATION ON              
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 GENERATING THE BIOMOLECULE                                           
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE:  1                                                      
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: DIMERIC                    
+REMARK 350 SOFTWARE USED: PQS                                                   
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   OH   TYR B    45  -  O    HOH B  2061              2.17            
+REMARK 500   O    HOH A  2152  -  O    HOH A  2208              2.08            
+REMARK 500   O    HOH A  2311  -  O    HOH A  2317              2.16            
+REMARK 500   O    HOH A  2334  -  O    HOH A  2336              2.09            
+REMARK 500   O    HOH B  2009  -  O    HOH B  2068              2.05            
+REMARK 500   O    HOH B  2065  -  O    HOH B  2068              2.18            
+REMARK 500   O    HOH B  2066  -  O    HOH B  2104              2.13            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS                                             
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS THAT ARE RELATED BY CRYSTALLOGRAPHIC             
+REMARK 500 SYMMETRY ARE IN CLOSE CONTACT.  AN ATOM LOCATED WITHIN 0.15          
+REMARK 500 ANGSTROMS OF A SYMMETRY RELATED ATOM IS ASSUMED TO BE ON A           
+REMARK 500 SPECIAL POSITION AND IS, THEREFORE, LISTED IN REMARK 375             
+REMARK 500 INSTEAD OF REMARK 500.  ATOMS WITH NON-BLANK ALTERNATE               
+REMARK 500 LOCATION INDICATORS ARE NOT INCLUDED IN THE CALCULATIONS.            
+REMARK 500                                                                      
+REMARK 500 DISTANCE CUTOFF:                                                     
+REMARK 500 2.2 ANGSTROMS FOR CONTACTS NOT INVOLVING HYDROGEN ATOMS              
+REMARK 500 1.6 ANGSTROMS FOR CONTACTS INVOLVING HYDROGEN ATOMS                  
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI  SSYMOP   DISTANCE          
+REMARK 500                                                                      
+REMARK 500   O    HOH B  2104     O    HOH A  2179     4455      2.19           
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    VAL A  32       71.92   -119.84                                   
+REMARK 500    ASP A  73      -77.14   -119.22                                   
+REMARK 500    SER A 212      -69.38   -124.18                                   
+REMARK 500    ARG B  41       77.65   -119.47                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 525                                                                      
+REMARK 525 SOLVENT                                                              
+REMARK 525                                                                      
+REMARK 525 THE SOLVENT MOLECULES HAVE CHAIN IDENTIFIERS THAT                    
+REMARK 525 INDICATE THE POLYMER CHAIN WITH WHICH THEY ARE MOST                  
+REMARK 525 CLOSELY ASSOCIATED. THE REMARK LISTS ALL THE SOLVENT                 
+REMARK 525 MOLECULES WHICH ARE MORE THAN 5A AWAY FROM THE                       
+REMARK 525 NEAREST POLYMER CHAIN (M = MODEL NUMBER;                             
+REMARK 525 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE                  
+REMARK 525 NUMBER; I=INSERTION CODE):                                           
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620  (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;              
+REMARK 620   SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                           
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              CA A1244  CA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 VAL A  77   O                                                      
+REMARK 620 2 GLU A  82   OE2  90.7                                              
+REMARK 620 3 HOH A2108   O    87.7  93.5                                        
+REMARK 620 4 ASN A  74   O    82.1 163.8 100.7                                  
+REMARK 620 5 HOH A2133   O   104.4  79.9 166.2  87.8                            
+REMARK 620 6 GLU A  72   OE1 167.6  98.6  83.6  90.9  85.5                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 700                                                                      
+REMARK 700 SHEET                                                                
+REMARK 700 DETERMINATION METHOD: DSSP                                           
+REMARK 700 THE SHEETS PRESENTED AS "AB" IN EACH CHAIN ON SHEET RECORDS          
+REMARK 700 BELOW IS ACTUALLY AN  6-STRANDED BARREL THIS IS REPRESENTED BY       
+REMARK 700 A  7-STRANDED SHEET IN WHICH THE FIRST AND LAST STRANDS              
+REMARK 700 ARE IDENTICAL.                                                       
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE  CA A1244                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE  CL B1076                 
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 2UUX   RELATED DB: PDB                                   
+REMARK 900  STRUCTURE OF THE TRYPTASE INHIBITOR TDPI                            
+REMARK 900 RELATED ID: 1AQ7   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN WITH INHIBITOR AERUGINOSIN 98-B                             
+REMARK 900 RELATED ID: 1AUJ   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED TO META-CYANO-                             
+REMARK 900  BENZYLIC INHIBITOR                                                  
+REMARK 900 RELATED ID: 1AZ8   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED TO BIS-PHENYLAMIDINE                       
+REMARK 900   INHIBITOR                                                          
+REMARK 900 RELATED ID: 1BJU   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN COMPLEXED WITH ACPU                                    
+REMARK 900 RELATED ID: 1BJV   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN COMPLEXED WITH APPU                                    
+REMARK 900 RELATED ID: 1BTP   RELATED DB: PDB                                   
+REMARK 900  MOL_ID: 1; MOLECULE: BETA-TRYPSIN; CHAIN:                           
+REMARK 900  NULL; EC: 3.4.21.4; HETEROGEN: N-[3-[4                              
+REMARK 900  -[4-(AMIDINOPHENOXY)-CARBONYL]PHENYL]-2-                            
+REMARK 900  METHYL-2-PROPENOYL]-N-ALLYLGLYCINE                                  
+REMARK 900  METHANESULFONATE                                                    
+REMARK 900 RELATED ID: 1BTW   RELATED DB: PDB                                   
+REMARK 900  MOL_ID: 1; MOLECULE: BETA-TRYPSIN; CHAIN: A                         
+REMARK 900  ; EC: 3.4.21.4; MOL_ID: 2; MOLECULE: T                              
+REMARK 900  -BUTOXY-ALA-VAL-BORO-LYS 1,3-PROPANEDIOL                            
+REMARK 900   MONOESTER; CHAIN: H                                                
+REMARK 900 RELATED ID: 1BTX   RELATED DB: PDB                                   
+REMARK 900  MOL_ID: 1; MOLECULE: BETA-TRYPSIN; CHAIN: A                         
+REMARK 900  ; EC: 3.4.21.4; MOL_ID: 2; MOLECULE: T                              
+REMARK 900  -BUTOXY-ALA-VAL-BORO-LYS ETHYL ESTER;                               
+REMARK 900  CHAIN: H                                                            
+REMARK 900 RELATED ID: 1BTY   RELATED DB: PDB                                   
+REMARK 900  MOL_ID: 1; MOLECULE: BETA-TRYPSIN; CHAIN:                           
+REMARK 900  NULL; EC: 3.4.21.4; HETEROGEN: BENZAMIDINE                          
+REMARK 900 RELATED ID: 1BTZ   RELATED DB: PDB                                   
+REMARK 900  MOL_ID: 1; MOLECULE: BETA-TRYPSIN; CHAIN: A                         
+REMARK 900  ; EC: 3.4.21.4; MOL_ID: 2; MOLECULE: T                              
+REMARK 900  -BUTOXY-ALA-VAL-BORO-LYS METHYL ESTER;                              
+REMARK 900  CHAIN: H                                                            
+REMARK 900 RELATED ID: 1C1N   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C1O   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C1P   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C1Q   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C1R   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C1S   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C1T   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2D   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2E   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2F   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2G   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2H   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2I   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2J   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2K   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OFSERINE PROTEASES                                       
+REMARK 900 RELATED ID: 1C2L   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C2M   RELATED DB: PDB                                   
+REMARK 900  RECRUITING ZINC TO MEDIATE POTENT, SPECIFIC                         
+REMARK 900  INHIBITION OF SERINE PROTEASES                                      
+REMARK 900 RELATED ID: 1C5P   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL BASIS FOR SELECTIVITY OF A SMALL                         
+REMARK 900   MOLECULE, S1-BINDING, SUB- MICROMOLAR                              
+REMARK 900  INHIBITOR OF UROKINASE TYPE PLASMINOGEN                             
+REMARK 900  ACTIVATOR                                                           
+REMARK 900 RELATED ID: 1C5Q   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL BASIS FOR SELECTIVITY OF A SMALL                         
+REMARK 900   MOLECULE, S1-BINDING, SUB- MICROMOLAR                              
+REMARK 900  INHIBITOR OF UROKINASE TYPE PLASMINOGEN                             
+REMARK 900  ACTIVATOR                                                           
+REMARK 900 RELATED ID: 1C5R   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL BASIS FOR SELECTIVITY OF A SMALL                         
+REMARK 900   MOLECULE, S1-BINDING, SUB- MICROMOLAR                              
+REMARK 900  INHIBITOR OF UROKINASE TYPE PLASMINOGEN                             
+REMARK 900  ACTIVATOR                                                           
+REMARK 900 RELATED ID: 1C5S   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL BASIS FOR SELECTIVITY OF A SMALL                         
+REMARK 900   MOLECULE, S1-BINDING, SUB- MICROMOLAR                              
+REMARK 900  INHIBITOR OF UROKINASE TYPE PLASMINOGEN                             
+REMARK 900  ACTIVATOR                                                           
+REMARK 900 RELATED ID: 1C5T   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL BASIS FOR SELECTIVITY OF A SMALL                         
+REMARK 900   MOLECULE, S1-BINDING, SUB- MICROMOLAR                              
+REMARK 900  INHIBITOR OF UROKINASE TYPE PLASMINOGEN                             
+REMARK 900  ACTIVATOR                                                           
+REMARK 900 RELATED ID: 1C5U   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL BASIS FOR SELECTIVITY OF A SMALL                         
+REMARK 900   MOLECULE, S1-BINDING, SUB- MICROMOLAR                              
+REMARK 900  INHIBITOR OF UROKINASE TYPE PLASMINOGEN                             
+REMARK 900  ACTIVATOR                                                           
+REMARK 900 RELATED ID: 1C5V   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL BASIS FOR SELECTIVITY OF A SMALL                         
+REMARK 900   MOLECULE, S1-BINDING, SUB- MICROMOLAR                              
+REMARK 900  INHIBITOR OF UROKINASE TYPE PLASMINOGEN                             
+REMARK 900  ACTIVATOR                                                           
+REMARK 900 RELATED ID: 1C9T   RELATED DB: PDB                                   
+REMARK 900  COMPLEX OF BDELLASTASIN WITH BOVINE TRYPSIN                         
+REMARK 900 RELATED ID: 1CE5   RELATED DB: PDB                                   
+REMARK 900  BOVINE PANCREAS BETA-TRYPSIN IN COMPLEX WITH                        
+REMARK 900   BENZAMIDINE                                                        
+REMARK 900 RELATED ID: 1CU7   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED WITH 2-[3-AMINO(                           
+REMARK 900  IMINOMETHYL) PHENOXY]-6-[3-(AMINOMETHYL)                            
+REMARK 900  PHENOXY]-3,5-DIFLUORO-4- METHYLPYRIDINE (ZK                         
+REMARK 900  -806299), BINDING MODEL FROM DOUBLE REDOR                           
+REMARK 900  NMR AND MD SIMULATIONS                                              
+REMARK 900 RELATED ID: 1CU8   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED WITH 2,6-BIS[3-                            
+REMARK 900  AMINO(IMINO)METHYL PHENOXY]-3,5-DIFLUORO-4                          
+REMARK 900  -METHYLPYRIDINE (ZK-805623), BINDING MODEL                          
+REMARK 900  FROM DOUBLE REDOR NMR AND MD SIMULATIONS                            
+REMARK 900 RELATED ID: 1CU9   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED WITH 2,6-BIS[3-                            
+REMARK 900  AMINO(IMINO)METHYL PHENOXY]-3,5-DIFLUORO-4                          
+REMARK 900  -METHYLPYRIDINE (ZK-805623), BINDING MODEL                          
+REMARK 900  FROM DOUBLE REDOR NMR AND MD SIMULATIONS                            
+REMARK 900 RELATED ID: 1D6R   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF CANCER CHEMOPREVENTIVE                         
+REMARK 900  BOWMAN-BIRK INHIBITOR IN TERNARY COMPLEX                            
+REMARK 900  WITH BOVINE TRYPSIN AT 2.3 A RESOLUTION.                            
+REMARK 900  STRUCTURAL BASIS OF JANUS-FACED SERINE                              
+REMARK 900  PROTEASE INHIBITOR SPECIFICITY                                      
+REMARK 900 RELATED ID: 1EB2   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX (FRA)                                     
+REMARK 900 RELATED ID: 1EJM   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF THE BPTI ALA16LEU                              
+REMARK 900  MUTANT IN COMPLEX WITH BOVINE TRYPSIN                               
+REMARK 900 RELATED ID: 1EZX   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF A SERPIN:PROTEASE                              
+REMARK 900  COMPLEX                                                             
+REMARK 900 RELATED ID: 1F0T   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED WITH RPR131247                             
+REMARK 900 RELATED ID: 1F0U   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED WITH RPR128515                             
+REMARK 900 RELATED ID: 1F2S   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF THE COMPLEX FORMED                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND MCTI-A, A                          
+REMARK 900   TRYPSIN INHIBITOR OF SQUASH FAMILY AT 1.                           
+REMARK 900  8 A RESOLUTION                                                      
+REMARK 900 RELATED ID: 1G36   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1G3B   RELATED DB: PDB                                   
+REMARK 900  BOVINE BETA-TRYPSIN BOUND TO META-AMIDINO                           
+REMARK 900  SCHIFF BASEMAGNESIUM(II) CHELATE                                    
+REMARK 900 RELATED ID: 1G3C   RELATED DB: PDB                                   
+REMARK 900  BOVINE BETA-TRYPSIN BOUND TO PARA-AMIDINO                           
+REMARK 900  SCHIFF BASEIRON(III) CHELATE                                        
+REMARK 900 RELATED ID: 1G3D   RELATED DB: PDB                                   
+REMARK 900  BOVINE BETA-TRYPSIN BOUND TO META-AMIDINO                           
+REMARK 900  SCHIFF BASECOPPER (II) CHELATE                                      
+REMARK 900 RELATED ID: 1G3E   RELATED DB: PDB                                   
+REMARK 900  BOVINE BETA-TRYPSIN BOUND TO PARA-AMIDINO                           
+REMARK 900  SCHIFF-BASECOPPER (II) CHELATE                                      
+REMARK 900 RELATED ID: 1G9I   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF BETA-TRYSIN COMPLEX IN                         
+REMARK 900   CYCLOHEXANE                                                        
+REMARK 900 RELATED ID: 1GBT   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN GUANIDINOBENZOYLATED AT SERINE                         
+REMARK 900  195 (PH 5.5)                                                        
+REMARK 900 RELATED ID: 1GHZ   RELATED DB: PDB                                   
+REMARK 900  A NOVEL SERINE PROTEASE INHIBITION MOTIF                            
+REMARK 900  INVOLVING A MULTI-CENTERED SHORT HYDROGEN                           
+REMARK 900  BONDING NETWORK AT THE ACTIVE SITE                                  
+REMARK 900 RELATED ID: 1GI0   RELATED DB: PDB                                   
+REMARK 900  A NOVEL SERINE PROTEASE INHIBITION MOTIF                            
+REMARK 900  INVOLVING A MULTI-CENTERED SHORT HYDROGEN                           
+REMARK 900  BONDING NETWORK AT THE ACTIVE SITE                                  
+REMARK 900 RELATED ID: 1GI1   RELATED DB: PDB                                   
+REMARK 900  A NOVEL SERINE PROTEASE INHIBITION MOTIF                            
+REMARK 900  INVOLVING A MULTI-CENTERED SHORT HYDROGEN                           
+REMARK 900  BONDING NETWORK AT THE ACTIVE SITE                                  
+REMARK 900 RELATED ID: 1GI2   RELATED DB: PDB                                   
+REMARK 900  A NOVEL SERINE PROTEASE INHIBITION MOTIF                            
+REMARK 900  INVOLVING A MULTI-CENTERED SHORT HYDROGEN                           
+REMARK 900  BONDING NETWORK AT THE ACTIVE SITE                                  
+REMARK 900 RELATED ID: 1GI3   RELATED DB: PDB                                   
+REMARK 900  A NOVEL SERINE PROTEASE INHIBITION MOTIF                            
+REMARK 900  INVOLVING A MULTI-CENTERED SHORT HYDROGEN                           
+REMARK 900  BONDING NETWORK AT THE ACTIVE SITE                                  
+REMARK 900 RELATED ID: 1GI4   RELATED DB: PDB                                   
+REMARK 900  A NOVEL SERINE PROTEASE INHIBITION MOTIF                            
+REMARK 900  INVOLVING A MULTI-CENTERED SHORT HYDROGEN                           
+REMARK 900  BONDING NETWORK AT THE ACTIVE SITE                                  
+REMARK 900 RELATED ID: 1GI5   RELATED DB: PDB                                   
+REMARK 900  A NOVEL SERINE PROTEASE INHIBITION MOTIF                            
+REMARK 900  INVOLVING A MULTI-CENTERED SHORT HYDROGEN                           
+REMARK 900  BONDING NETWORK AT THE ACTIVE SITE                                  
+REMARK 900 RELATED ID: 1GI6   RELATED DB: PDB                                   
+REMARK 900  A NOVEL SERINE PROTEASE INHIBITION MOTIF                            
+REMARK 900  INVOLVING A MULTI-CENTERED SHORT HYDROGEN                           
+REMARK 900  BONDING NETWORK AT THE ACTIVE SITE                                  
+REMARK 900 RELATED ID: 1GJ6   RELATED DB: PDB                                   
+REMARK 900  ENGINEERING INHIBITORS HIGHLY SELECTIVE FOR                         
+REMARK 900  THE S1 SITES OFSER190 TRYPSIN-LIKE SERINE                           
+REMARK 900  PROTEASE DRUG TARGETS                                               
+REMARK 900 RELATED ID: 1HJ9   RELATED DB: PDB                                   
+REMARK 900  ATOMIC RESOLUTION STRUCTURES OF TRYPSIN                             
+REMARK 900  PROVIDE INSIGHT INTO STRUCTURAL RADIATION                           
+REMARK 900  DAMAGE                                                              
+REMARK 900 RELATED ID: 1J8A   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF BENZAMIDINE INHIBITED                          
+REMARK 900  BOVINEPANCREATIC TRYPSIN AT 105K TO 1.21A                           
+REMARK 900  RESOLUTION FROMLABORATORY SOURCE WITH HIGH                          
+REMARK 900  NUMBER OF WATERS MODELLED                                           
+REMARK 900 RELATED ID: 1JIR   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF TRYPSIN COMPLEX WITH                           
+REMARK 900  AMYLAMINE INCYCLOHEXANE                                             
+REMARK 900 RELATED ID: 1JRS   RELATED DB: PDB                                   
+REMARK 900  HEMIACETAL COMPLEX BETWEEN LEUPEPTIN AND                            
+REMARK 900  TRYPSIN                                                             
+REMARK 900 RELATED ID: 1JRT   RELATED DB: PDB                                   
+REMARK 900  HEMIACETAL COMPLEX BETWEEN LEUPEPTIN AND                            
+REMARK 900  TRYPSIN                                                             
+REMARK 900 RELATED ID: 1K1I   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN-INHIBITOR COMPLEX                                    
+REMARK 900 RELATED ID: 1K1J   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN-INHIBITOR COMPLEX                                    
+REMARK 900 RELATED ID: 1K1L   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN-INHIBITOR COMPLEX                                    
+REMARK 900 RELATED ID: 1K1M   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN-INHIBITOR COMPLEX                                    
+REMARK 900 RELATED ID: 1K1N   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN-INHIBITOR COMPLEX                                    
+REMARK 900 RELATED ID: 1K1O   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN-INHIBITOR COMPLEX                                    
+REMARK 900 RELATED ID: 1K1P   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN-INHIBITOR COMPLEX                                    
+REMARK 900 RELATED ID: 1LQE   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF TRYPSIN IN COMPLEX WITH                        
+REMARK 900   79.                                                                
+REMARK 900 RELATED ID: 1MAX   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN PHOSPHONATE INHIBITED                                  
+REMARK 900 RELATED ID: 1MAY   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN PHOSPHONATE INHIBITED                                  
+REMARK 900 RELATED ID: 1MTS   RELATED DB: PDB                                   
+REMARK 900  FACTOR XA SPECIFIC INHIBITOR IN COMPLEX WITH                        
+REMARK 900   BOVINE TRYPSIN                                                     
+REMARK 900 RELATED ID: 1MTU   RELATED DB: PDB                                   
+REMARK 900  FACTOR XA SPECIFIC INHIBITOR IN COMPLEX WITH                        
+REMARK 900   BOVINE TRYPSIN                                                     
+REMARK 900 RELATED ID: 1MTV   RELATED DB: PDB                                   
+REMARK 900  FACTOR XA SPECIFIC INHIBITOR IN COMPLEX WITH                        
+REMARK 900   BOVINE TRYPSIN                                                     
+REMARK 900 RELATED ID: 1MTW   RELATED DB: PDB                                   
+REMARK 900  FACTOR XA SPECIFIC INHIBITOR IN COMPLEX WITH                        
+REMARK 900   BOVINE TRYPSIN                                                     
+REMARK 900 RELATED ID: 1N6X   RELATED DB: PDB                                   
+REMARK 900  RIP-PHASING ON BOVINE TRYPSIN                                       
+REMARK 900 RELATED ID: 1N6Y   RELATED DB: PDB                                   
+REMARK 900  RIP-PHASING ON BOVINE TRYPSIN                                       
+REMARK 900 RELATED ID: 1NC6   RELATED DB: PDB                                   
+REMARK 900  POTENT, SMALL MOLECULE INHIBITORS OF HUMAN                          
+REMARK 900  MAST CELLTRYPTASE. ANTI-ASTHMATIC ACTION OF                         
+REMARK 900  A DIPEPTIDE-BASEDTRANSITION STATE ANALOGUE                          
+REMARK 900  CONTAINING BENZOTHIAZOLE KETONE                                     
+REMARK 900 RELATED ID: 1NTP   RELATED DB: PDB                                   
+REMARK 900  MODIFIED BETA TRYPSIN (MONOISOPROPYLPHOSPHORYL                      
+REMARK 900  INHIBITED) (NEUTRON DATA)                                           
+REMARK 900 RELATED ID: 1O2H   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2I   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2J   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2K   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2L   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2M   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2N   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2O   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2P   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2Q   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2R   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2S   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2T   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2U   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2V   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2W   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2X   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2Y   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O2Z   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O30   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O31   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O32   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O33   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O34   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O35   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O36   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O37   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O38   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O39   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3A   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3B   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3C   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3D   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3E   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3F   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3G   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3H   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3I   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3J   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3K   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3L   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3M   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3N   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1O3O   RELATED DB: PDB                                   
+REMARK 900  ELABORATE MANIFOLD OF SHORT HYDROGEN BOND                           
+REMARK 900  ARRAYS MEDIATINGBINDING OF ACTIVE SITE-                             
+REMARK 900  DIRECTED SERINE PROTEASE INHIBITORS                                 
+REMARK 900 RELATED ID: 1OPH   RELATED DB: PDB                                   
+REMARK 900  NON-COVALENT COMPLEX BETWEEN ALPHA-1-PI-                            
+REMARK 900  PITTSBURGH ANDS195A TRYPSIN                                         
+REMARK 900 RELATED ID: 1OX1   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF THE BOVINE TRYPSIN                             
+REMARK 900  COMPLEX WITH ASYNTHETIC 11 PEPTIDE INHIBITOR                        
+REMARK 900 RELATED ID: 1OYQ   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1P2I   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL CONSEQUENCES OF ACCOMMODATION OF                         
+REMARK 900  FOUR NON-COGNATE AMINO-ACID RESIDUES IN                             
+REMARK 900  THE S1 POCKET OF BOVINETRYPSIN AND                                  
+REMARK 900  CHYMOTRYPSIN                                                        
+REMARK 900 RELATED ID: 1P2J   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL CONSEQUENCES OF ACCOMMODATION OF                         
+REMARK 900  FOUR NON-COGNATE AMINO-ACID RESIDUES IN                             
+REMARK 900  THE S1 POCKET OF BOVINETRYPSIN AND                                  
+REMARK 900  CHYMOTRYPSIN                                                        
+REMARK 900 RELATED ID: 1P2K   RELATED DB: PDB                                   
+REMARK 900  STRUCTURAL CONSEQUENCES OF ACCOMMODATION OF                         
+REMARK 900  FOUR NON-COGNATE AMINO-ACID RESIDUES IN                             
+REMARK 900  THE S1 POCKET OF BOVINETRYPSIN AND                                  
+REMARK 900  CHYMOTRYPSIN                                                        
+REMARK 900 RELATED ID: 1PPC   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEX WITH NONCOVALENTLY BOUND NAPAP                      
+REMARK 900 RELATED ID: 1PPE   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEX WITH (CUCURBITA MAXIMA)                             
+REMARK 900  TRYPSIN INHIBITOR (CMTI-I)                                          
+REMARK 900 RELATED ID: 1PPH   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEX WITH NONCOVALENTLY BOUND 3-                         
+REMARK 900  TAPAP                                                               
+REMARK 900 RELATED ID: 1QA0   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN 2-AMINOBENZIMIDAZOLE COMPLEX                         
+REMARK 900 RELATED ID: 1QB1   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN WITH 1-[2-[5-[AMINO(IMINO)                           
+REMARK 900  METHYL]-2- HYDROXYPHENOXY]-6-[3-(4,5-                               
+REMARK 900  DIHYDRO-1-METHYL-1H-IMIDAZOL-2-YL) PHENOXY                          
+REMARK 900  ]PYRIDIN-4-YL]PIPERIDINE-3-CARBOXYLIC ACID                          
+REMARK 900   (ZK- 806974)                                                       
+REMARK 900 RELATED ID: 1QB6   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN 3,3'-[3,5-DIFLUORO-4-                                
+REMARK 900  METHYL-2, 6- PYRIDINEDIYLBIS(OXY)]BIS(                              
+REMARK 900  BENZENECARBOXIMIDAMIDE) (ZK-805623) COMPLEX                         
+REMARK 900 RELATED ID: 1QB9   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN 7-[[2-[[1-(1-IMINOETHYL)                             
+REMARK 900  PIPERIDIN-4-YL]OXY]- 9H-CARBOZOL-9-YL]                              
+REMARK 900  METHYL]NAPHTHALENE-2-CARBOXIMIDAMIDE (ZK-                           
+REMARK 900  806450) COMPLEX                                                     
+REMARK 900 RELATED ID: 1QBN   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN 2-[AMINO(IMINO)METHYL]-2-                            
+REMARK 900  HYDROXYPHENOXY]-6- [3-(4,5-DIHYDRO-1H-                              
+REMARK 900  IMIDAZOL-2-YL)PHENOXY]PYRIDINE-4- CARBOXYLIC                        
+REMARK 900   ACID (ZK-806688) COMPLEX                                           
+REMARK 900 RELATED ID: 1QBO   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN 7-[[6-[[1-(1-IMINOETHYL)                             
+REMARK 900  PIPERIDIN-4-YL]OXY]- 2-METHYL-BENZIMIDAZOL-                         
+REMARK 900  1-YL]METHYL]NAPHTHALENE-2- CARBOXIMIDAMID ZK                        
+REMARK 900  -806711 INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1QCP   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF THE RWJ-51084 BOVINE                           
+REMARK 900  PANCREATIC BETA- TRYPSIN AT 1.8 A                                   
+REMARK 900 RELATED ID: 1QL7   RELATED DB: PDB                                   
+REMARK 900  FACTOR XA SPECIFIC INHIBITOR IN COMPLEX WITH                        
+REMARK 900   BOVINE TRYPSIN                                                     
+REMARK 900 RELATED ID: 1QL8   RELATED DB: PDB                                   
+REMARK 900  FACTOR XA SPECIFIC INHIBITOR IN COMPLEX WITH                        
+REMARK 900   BOVINE TRYPSIN                                                     
+REMARK 900 RELATED ID: 1RXP   RELATED DB: PDB                                   
+REMARK 900  STRUCTURE OF TRYPSIN (ORTHORHOMBIC) WITH 1-(                        
+REMARK 900  4-TERT-BUTYLCARBAMOYL- PIPERAZINE-1-CARBONYL                        
+REMARK 900  )-3-(3-GUANIDINO-PROPYL)-4-OXO-AZETIDINE-                           
+REMARK 900  2-CARBOXYLIC ACID                                                   
+REMARK 900 RELATED ID: 1S0Q   RELATED DB: PDB                                   
+REMARK 900  NATIVE BOVINE PANCREATIC TRYPSIN                                    
+REMARK 900 RELATED ID: 1S0R   RELATED DB: PDB                                   
+REMARK 900  BOVINE PANCREATIC TRYPSIN INHIBITED WITH                            
+REMARK 900  BENZAMIDINE ATATOMIC RESOLUTION                                     
+REMARK 900 RELATED ID: 1SBW   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF MUNG BEAN INHIBITOR                            
+REMARK 900  LYSINE ACTIVE FRAGMENT COMPLEX WITH BOVINE                          
+REMARK 900  BETA-TRYPSIN AT 1.8A RESOLUTION                                     
+REMARK 900 RELATED ID: 1SFI   RELATED DB: PDB                                   
+REMARK 900  HIGH RESOLUTION STRUCTURE OF A POTENT,                              
+REMARK 900  CYCLIC PROTEASE INHIBITOR FROM SUNFLOWER SEEDS                      
+REMARK 900 RELATED ID: 1SMF   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEXED WITH BOWMAN-BIRK INHIBITOR                        
+REMARK 900 RELATED ID: 1TAB   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEX WITH BOWMAN-BIRK INHIBITOR (                        
+REMARK 900  AB-I)                                                               
+REMARK 900 RELATED ID: 1TAW   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED TO APPI                                    
+REMARK 900 RELATED ID: 1TGB   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN-CA FROM PEG                                             
+REMARK 900 RELATED ID: 1TGC   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN (0.50 METHANOL, 0.50 WATER)                             
+REMARK 900 RELATED ID: 1TGN   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN                                                         
+REMARK 900 RELATED ID: 1TGS   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN COMPLEX WITH PORCINE PANCREATIC                         
+REMARK 900  SECRETORY TRYPSIN INHIBITOR                                         
+REMARK 900 RELATED ID: 1TGT   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN (173 DEGREES K, 0.70 METHANOL,                          
+REMARK 900  0.30 WATER)                                                         
+REMARK 900 RELATED ID: 1TIO   RELATED DB: PDB                                   
+REMARK 900  HIGH PACKING DENSITY FORM OF BOVINE BETA-                           
+REMARK 900  TRYPSIN IN CYCLOHEXANE                                              
+REMARK 900 RELATED ID: 1TLD   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN (ORTHORHOMBIC) AT PH 5.3                               
+REMARK 900 RELATED ID: 1TNG   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEXED WITH THE INHIBITOR                                
+REMARK 900  AMINOMETHYLCYCLOHEXANE                                              
+REMARK 900 RELATED ID: 1TNH   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEXED WITH THE INHIBITOR 4-                             
+REMARK 900  FLUOROBENZYLAMINE                                                   
+REMARK 900 RELATED ID: 1TNI   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEXED WITH THE INHIBITOR 4-                             
+REMARK 900  PHENYLBUTYLAMINE                                                    
+REMARK 900 RELATED ID: 1TNJ   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEXED WITH THE INHIBITOR 2-                             
+REMARK 900  PHENYLETHYLAMINE                                                    
+REMARK 900 RELATED ID: 1TNK   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEXED WITH THE INHIBITOR 3-                             
+REMARK 900  PHENYLPROPYLAMINE                                                   
+REMARK 900 RELATED ID: 1TNL   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEXED WITH THE INHIBITOR                                
+REMARK 900  TRANYLCYPROMINE                                                     
+REMARK 900 RELATED ID: 1TPA   RELATED DB: PDB                                   
+REMARK 900  ANHYDRO-TRYPSIN COMPLEX WITH PANCREATIC                             
+REMARK 900  TRYPSIN INHIBITOR                                                   
+REMARK 900 RELATED ID: 1TPO   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN (ORTHORHOMBIC) AT PH5.0                                
+REMARK 900 RELATED ID: 1TPP   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN COMPLEX WITH P-AMIDINO-PHENYL-                         
+REMARK 900  PYRUVATE (APPA)                                                     
+REMARK 900 RELATED ID: 1TPS   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN COMPLEXED WITH INHIBITOR A90720A                            
+REMARK 900 RELATED ID: 1TX7   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED WITH P-                                    
+REMARK 900  AMIDINOPHENYLMETHYLPHOSPHINIC ACID (AMPA)                           
+REMARK 900 RELATED ID: 1TX8   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED WITH AMSO                                  
+REMARK 900 RELATED ID: 1TYN   RELATED DB: PDB                                   
+REMARK 900  BETA TRYPSIN COMPLEXED WITH CYCLOTHEONAMIDE A                       
+REMARK 900 RELATED ID: 1UTN   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN SPECIFICITY AS ELUCIDATED BY LIE                            
+REMARK 900  CALCULATIONS, X-RAY STRUCTURES AND ASSOCIATION                      
+REMARK 900   CONSTANT MEASUREMENTS                                              
+REMARK 900 RELATED ID: 1UTO   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN SPECIFICITY AS ELUCIDATED BY LIE                            
+REMARK 900  CALCULATIONS, X-RAY STRUCTURES AND ASSOCIATION                      
+REMARK 900   CONSTANT MEASUREMENTS                                              
+REMARK 900 RELATED ID: 1UTP   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN SPECIFICITY AS ELUCIDATED BY LIE                            
+REMARK 900  CALCULATIONS, X-RAY STRUCTURES AND ASSOCIATION                      
+REMARK 900   CONSTANT MEASUREMENTS                                              
+REMARK 900 RELATED ID: 1UTQ   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN SPECIFICITY AS ELUCIDATED BY LIE                            
+REMARK 900  CALCULATIONS, X-RAY STRUCTURES AND ASSOCIATION                      
+REMARK 900   CONSTANT MEASUREMENTS                                              
+REMARK 900 RELATED ID: 1V2J   RELATED DB: PDB                                   
+REMARK 900  BENZAMIDINE IN COMPLEX WITH BOVINE TRYPSIN                          
+REMARK 900  VARIANT X(SSRI)BT.C1                                                
+REMARK 900 RELATED ID: 1V2K   RELATED DB: PDB                                   
+REMARK 900  FACTOR XA SPECIFIC INHIBITOR IN COMPLEX WITH                        
+REMARK 900   BOVINE TRYPSINVARIANT X(TRIPLE.GLU)BT.D2                           
+REMARK 900 RELATED ID: 1V2L   RELATED DB: PDB                                   
+REMARK 900  BENZAMIDINE IN COMPLEX WITH BOVINE TRYPSIN                          
+REMARK 900  VARIANTX(TRIPLE.GLU)BT.D1                                           
+REMARK 900 RELATED ID: 1V2M   RELATED DB: PDB                                   
+REMARK 900  BENZAMIDINE IN COMPLEX WITH BOVINE TRYPSIN                          
+REMARK 900  VARIANTX(TRIPLE.GLU)BT.A1                                           
+REMARK 900 RELATED ID: 1V2N   RELATED DB: PDB                                   
+REMARK 900  POTENT FACTOR XA INHIBITOR IN COMPLEX WITH                          
+REMARK 900  BOVINE TRYPSINVARIANT X(99/175/190)BT                               
+REMARK 900 RELATED ID: 1V2O   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN VARIANTX(SSYI)BT.B4                                         
+REMARK 900 RELATED ID: 1V2P   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN VARIANTX(SSYI)BT.A4                                         
+REMARK 900 RELATED ID: 1V2Q   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN VARIANTX(SSWI)BT.B4                                         
+REMARK 900 RELATED ID: 1V2R   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN VARIANTX(SSRI)BT.B4                                         
+REMARK 900 RELATED ID: 1V2S   RELATED DB: PDB                                   
+REMARK 900  BENZAMIDINE IN COMPLEX WITH BOVINE TRYPSIN                          
+REMARK 900  VARIANTX(SSFI.GLU)BT.D1                                             
+REMARK 900 RELATED ID: 1V2T   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN VARIANTX(SSFI.GLU)BT.B4                                     
+REMARK 900 RELATED ID: 1V2U   RELATED DB: PDB                                   
+REMARK 900  BENZAMIDINE IN COMPLEX WITH BOVINE TRYPSIN                          
+REMARK 900  VARINAT X(SSAI)BT.D1                                                
+REMARK 900 RELATED ID: 1V2V   RELATED DB: PDB                                   
+REMARK 900  BENZAMIDINE IN COMPLEX WITH BOVINE TRYPSIN                          
+REMARK 900  VARIANT X(SSAI)BT.C1                                                
+REMARK 900 RELATED ID: 1V2W   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN VARIANTX(SSAI)BT.B4                                         
+REMARK 900 RELATED ID: 1XUF   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN-BABIM-ZN+2, PH 8.2                                          
+REMARK 900 RELATED ID: 1XUG   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN-BABIM-ZN+2, PH 8.2                                          
+REMARK 900 RELATED ID: 1XUH   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN-KETO-BABIM-CO+2, PH 8.2                                     
+REMARK 900 RELATED ID: 1XUI   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN-KETO-BABIM, ZN+2-FREE, PH 8.2                               
+REMARK 900 RELATED ID: 1XUJ   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN-KETO-BABIM-ZN+2, PH 8.2                                     
+REMARK 900 RELATED ID: 1XUK   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN-BABIM-SULFATE, PH 5.9                                       
+REMARK 900 RELATED ID: 1Y3U   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1Y3V   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1Y3W   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1Y3X   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1Y3Y   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1Y59   RELATED DB: PDB                                   
+REMARK 900  DIANHYDROSUGAR-BASED BENZAMIDINE, FACTOR XA                         
+REMARK 900  SPECIFICINHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN MUTANT                                                      
+REMARK 900 RELATED ID: 1Y5A   RELATED DB: PDB                                   
+REMARK 900  DIANHYDROSUGAR-BASED BENZAMIDINE, FACTOR XA                         
+REMARK 900  SPECIFICINHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN MUTANT                                                      
+REMARK 900 RELATED ID: 1Y5B   RELATED DB: PDB                                   
+REMARK 900  DIANHYDROSUGAR-BASED BENZAMIDINE, FACTOR XA                         
+REMARK 900  SPECIFICINHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN MUTANT                                                      
+REMARK 900 RELATED ID: 1Y5U   RELATED DB: PDB                                   
+REMARK 900  DIANHYDROSUGAR-BASED BENZAMIDINE, FACTOR XA                         
+REMARK 900  SPECIFICINHIBITOR IN COMPLEX WITH BOVINE                            
+REMARK 900  TRYPSIN MUTANT                                                      
+REMARK 900 RELATED ID: 1YP9   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITOR COMPLEX                                           
+REMARK 900 RELATED ID: 1YYY   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITORS WITH RIGID TRIPEPTIDYL                           
+REMARK 900  ALDEHYDES                                                           
+REMARK 900 RELATED ID: 1ZR0   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF KUNITZ DOMAIN 1 OF                             
+REMARK 900  TISSUE FACTORPATHWAY INHIBITOR-2 WITH BOVINE                        
+REMARK 900  TRYPSIN                                                             
+REMARK 900 RELATED ID: 1ZZZ   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN INHIBITORS WITH RIGID TRIPEPTIDYL                           
+REMARK 900  ALDEHYDES                                                           
+REMARK 900 RELATED ID: 2A7H   RELATED DB: PDB                                   
+REMARK 900  ON THE ROUTINE USE OF SOFT X-RAYS IN                                
+REMARK 900  MACROMOLECULARCRYSTALLOGRAPHY, PART III- THE                        
+REMARK 900  OPTIMAL DATA COLLECTIONWAVELENGTH                                   
+REMARK 900 RELATED ID: 2AH4   RELATED DB: PDB                                   
+REMARK 900  GUANIDINOBENZOYL-TRYPSIN ACYL-ENZYME AT 1.13                        
+REMARK 900   A RESOLUTION                                                       
+REMARK 900 RELATED ID: 2AYW   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF THE COMPLEX FORMED                             
+REMARK 900  BETWEEN TRYPSIN ANDA DESIGNED SYNTHETIC HIGHLY                      
+REMARK 900   POTENT INHIBITOR IN THEPRESENCE OF                                 
+REMARK 900  BENZAMIDINE AT 0.97 A RESOLUTION                                    
+REMARK 900 RELATED ID: 2BLV   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN BEFORE A HIGH DOSE X-RAY "BURN"                             
+REMARK 900 RELATED ID: 2BLW   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN AFTER A HIGH DOSE X-RAY "BURN"                              
+REMARK 900 RELATED ID: 2BTC   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN IN COMPLEX WITH SQUASH SEED                          
+REMARK 900  INHIBITOR (CUCURBITA PEPO TRYPSIN INHIBITOR II                      
+REMARK 900  )                                                                   
+REMARK 900 RELATED ID: 2BY5   RELATED DB: PDB                                   
+REMARK 900  IS RADIATION DAMAGE DEPENDENT ON THE DOSE-                          
+REMARK 900  RATE USED DURING MACROMOLECULAR CRYSTALLOGRAPHY                     
+REMARK 900   DATA COLLECTION                                                    
+REMARK 900 RELATED ID: 2BY6   RELATED DB: PDB                                   
+REMARK 900  IS RADIATION DAMAGE DEPENDENT ON THE DOSE-                          
+REMARK 900  RATE USED DURING MACROMOLECULAR CRYSTALLOGRAPHY                     
+REMARK 900   DATA COLLECTION                                                    
+REMARK 900 RELATED ID: 2BY7   RELATED DB: PDB                                   
+REMARK 900  IS RADIATION DAMAGE DEPENDENT ON THE DOSE-                          
+REMARK 900  RATE USED DURING MACROMOLECULAR CRYSTALLOGRAPHY                     
+REMARK 900   DATA COLLECTION                                                    
+REMARK 900 RELATED ID: 2BY8   RELATED DB: PDB                                   
+REMARK 900  IS RADIATION DAMAGE DEPENDENT ON THE DOSE-                          
+REMARK 900  RATE USED DURING MACROMOLECULAR CRYSTALLOGRAPHY                     
+REMARK 900   DATA COLLECTION                                                    
+REMARK 900 RELATED ID: 2BY9   RELATED DB: PDB                                   
+REMARK 900  IS RADIATION DAMAGE DEPENDENT ON THE DOSE-                          
+REMARK 900  RATE USED DURING MACROMOLECULAR CRYSTALLOGRAPHY                     
+REMARK 900   DATA COLLECTION                                                    
+REMARK 900 RELATED ID: 2BYA   RELATED DB: PDB                                   
+REMARK 900  IS RADIATION DAMAGE DEPENDENT ON THE DOSE-                          
+REMARK 900  RATE USED DURING MACROMOLECULAR CRYSTALLOGRAPHY                     
+REMARK 900   DATA COLLECTION                                                    
+REMARK 900 RELATED ID: 2BZA   RELATED DB: PDB                                   
+REMARK 900  BOVINE PANCREAS BETA-TRYPSIN IN COMPLEX WITH                        
+REMARK 900   BENZYLAMINE                                                        
+REMARK 900 RELATED ID: 2CMY   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL COMPLEX BETWEEN BOVINE TRYPSIN AND                          
+REMARK 900  VERONICA HEDERIFOLIA TRYPSIN INHIBITOR                              
+REMARK 900 RELATED ID: 2FI3   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF A BPTI VARIANT (CYS14                          
+REMARK 900  ->SER, CYS38->SER) IN COMPLEX WITH TRYPSIN                          
+REMARK 900 RELATED ID: 2FI4   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF A BPTI VARIANT (CYS14                          
+REMARK 900  ->SER) IN COMPLEXWITH TRYPSIN                                       
+REMARK 900 RELATED ID: 2FI5   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF A BPTI VARIANT (CYS38                          
+REMARK 900  ->SER) IN COMPLEXWITH TRYPSIN                                       
+REMARK 900 RELATED ID: 2FTL   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF TRYPSIN COMPLEXED WITH                         
+REMARK 900  BPTI AT 100K                                                        
+REMARK 900 RELATED ID: 2FTM   RELATED DB: PDB                                   
+REMARK 900  CRYSTAL STRUCTURE OF TRYPSIN COMPLEXED WITH                         
+REMARK 900  THE BPTIVARIANT (TYR35->GLY)                                        
+REMARK 900 RELATED ID: 2FX4   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN BOUND BY 4-PIPERIDINEBUTYRATE                        
+REMARK 900  TO MAKEACYLENZYME COMPLEX                                           
+REMARK 900 RELATED ID: 2FX6   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEXED WITH 2-                                    
+REMARK 900  AMINOBENZAMIDAZOLE                                                  
+REMARK 900 RELATED ID: 2J9N   RELATED DB: PDB                                   
+REMARK 900  ROBOTICALLY HARVESTED TRYPSIN COMPLEXED WITH                        
+REMARK 900  BENZAMIDINE CONTAINING POLYPEPTIDE MEDIATED                         
+REMARK 900  CRYSTAL CONTACTS                                                    
+REMARK 900 RELATED ID: 2PTC   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN COMPLEX WITH PANCREATIC TRYPSIN                        
+REMARK 900  INHIBITOR                                                           
+REMARK 900 RELATED ID: 2PTN   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN (ORTHORHOMBIC, 2.4 M AMMONIUM                               
+REMARK 900  SULFATE)                                                            
+REMARK 900 RELATED ID: 2TGA   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN (2.4 M MAGNESIUM SULFATE)                               
+REMARK 900 RELATED ID: 2TGD   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN, DIISOPROPYLPHOSPHORYL INHIBITED                        
+REMARK 900 RELATED ID: 2TGP   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN COMPLEX WITH PANCREATIC TRYPSIN                         
+REMARK 900  INHIBITOR                                                           
+REMARK 900 RELATED ID: 2TGT   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN (103 DEGREES K, 0.70 METHANOL,                          
+REMARK 900  0.30 WATER)                                                         
+REMARK 900 RELATED ID: 2TIO   RELATED DB: PDB                                   
+REMARK 900  LOW PACKING DENSITY FORM OF BOVINE BETA-                            
+REMARK 900  TRYPSIN IN CYCLOHEXANE                                              
+REMARK 900 RELATED ID: 2TLD   RELATED DB: PDB                                   
+REMARK 900  BOVINE TRYPSIN COMPLEX WITH A MODIFIED SSI                          
+REMARK 900   (STREPTOMYCES SUBTILISIN INHIBITOR) WITH MET                       
+REMARK 900  70 REPLACED BY GLY AND MET 73 REPLACED                              
+REMARK 900  BY LYS (SSI(M70G,M73K))                                             
+REMARK 900 RELATED ID: 2TPI   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN - PANCREATIC TRYPSIN INHIBITOR - ILE                    
+REMARK 900  -VAL COMPLEX (2.4 M MAGNESIUM SULFATE)                              
+REMARK 900 RELATED ID: 3BTD   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN THE BOVINE BETA-TRYPSIN AND TEN P1                          
+REMARK 900   VARIANTS OF BPTI.                                                  
+REMARK 900 RELATED ID: 3BTE   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI.                                                   
+REMARK 900 RELATED ID: 3BTF   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI.                                                   
+REMARK 900 RELATED ID: 3BTG   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI                                                    
+REMARK 900 RELATED ID: 3BTH   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI                                                    
+REMARK 900 RELATED ID: 3BTK   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI                                                    
+REMARK 900 RELATED ID: 3BTM   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI                                                    
+REMARK 900 RELATED ID: 3BTQ   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI                                                    
+REMARK 900 RELATED ID: 3BTT   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI                                                    
+REMARK 900 RELATED ID: 3BTW   RELATED DB: PDB                                   
+REMARK 900  THE CRYSTAL STRUCTURES OF THE COMPLEXES                             
+REMARK 900  BETWEEN BOVINE BETA- TRYPSIN AND TEN P1                             
+REMARK 900  VARIANTS OF BPTI                                                    
+REMARK 900 RELATED ID: 3PTB   RELATED DB: PDB                                   
+REMARK 900  BETA-TRYPSIN (BENZAMIDINE INHIBITED) AT PH7                         
+REMARK 900 RELATED ID: 3PTN   RELATED DB: PDB                                   
+REMARK 900  TRYPSIN (TRIGONAL, 2.4 M AMMONIUM SULFATE)                          
+REMARK 900 RELATED ID: 3TPI   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN COMPLEX WITH PANCREATIC TRYPSIN                         
+REMARK 900  INHIBITOR AND ILE-VAL                                               
+REMARK 900 RELATED ID: 4TPI   RELATED DB: PDB                                   
+REMARK 900  TRYPSINOGEN COMPLEX WITH THE ARG==15==-                             
+REMARK 900  ANALOGUE OF PANCREATIC TRYPSIN INHIBITOR AND                        
+REMARK 900  VAL-VAL                                                             
+REMARK 900 RELATED ID: 5PTP   RELATED DB: PDB                                   
+REMARK 900  STRUCTURE OF HYDROLASE (SERINE PROTEINASE)                          
+DBREF  2UUY A   21   243  UNP    P00760   TRY1_BOVIN      21    243             
+DBREF  2UUY B   24    75  UNP    Q1EG59   Q1EG59_RHIAP    45     96             
+SEQADV 2UUY ALA B   75  UNP  Q1EG59    GLY    96 CONFLICT                       
+SEQRES   1 A  223  ILE VAL GLY GLY TYR THR CYS GLY ALA ASN THR VAL PRO          
+SEQRES   2 A  223  TYR GLN VAL SER LEU ASN SER GLY TYR HIS PHE CYS GLY          
+SEQRES   3 A  223  GLY SER LEU ILE ASN SER GLN TRP VAL VAL SER ALA ALA          
+SEQRES   4 A  223  HIS CYS TYR LYS SER GLY ILE GLN VAL ARG LEU GLY GLU          
+SEQRES   5 A  223  ASP ASN ILE ASN VAL VAL GLU GLY ASN GLU GLN PHE ILE          
+SEQRES   6 A  223  SER ALA SER LYS SER ILE VAL HIS PRO SER TYR ASN SER          
+SEQRES   7 A  223  ASN THR LEU ASN ASN ASP ILE MET LEU ILE LYS LEU LYS          
+SEQRES   8 A  223  SER ALA ALA SER LEU ASN SER ARG VAL ALA SER ILE SER          
+SEQRES   9 A  223  LEU PRO THR SER CYS ALA SER ALA GLY THR GLN CYS LEU          
+SEQRES  10 A  223  ILE SER GLY TRP GLY ASN THR LYS SER SER GLY THR SER          
+SEQRES  11 A  223  TYR PRO ASP VAL LEU LYS CYS LEU LYS ALA PRO ILE LEU          
+SEQRES  12 A  223  SER ASP SER SER CYS LYS SER ALA TYR PRO GLY GLN ILE          
+SEQRES  13 A  223  THR SER ASN MET PHE CYS ALA GLY TYR LEU GLU GLY GLY          
+SEQRES  14 A  223  LYS ASP SER CYS GLN GLY ASP SER GLY GLY PRO VAL VAL          
+SEQRES  15 A  223  CYS SER GLY LYS LEU GLN GLY ILE VAL SER TRP GLY SER          
+SEQRES  16 A  223  GLY CYS ALA GLN LYS ASN LYS PRO GLY VAL TYR THR LYS          
+SEQRES  17 A  223  VAL CYS ASN TYR VAL SER TRP ILE LYS GLN THR ILE ALA          
+SEQRES  18 A  223  SER ASN                                                      
+SEQRES   1 B   52  CYS THR VAL PRO ILE GLY TRP SER GLU PRO VAL LYS GLY          
+SEQRES   2 B   52  LEU CYS LYS ALA ARG PHE THR ARG TYR TYR CYS MET GLY          
+SEQRES   3 B   52  ASN CYS CYS LYS VAL TYR GLU GLY CYS TYR THR GLY GLY          
+SEQRES   4 B   52  TYR SER ARG MET GLY GLU CYS ALA ARG ASN CYS PRO ALA          
+HET     CA  A1244       1                                                       
+HET     CL  B1076       1                                                       
+HETNAM      CA CALCIUM ION                                                      
+HETNAM      CL CHLORIDE ION                                                     
+FORMUL   3   CA    CA 2+                                                        
+FORMUL   4   CL    CL 1-                                                        
+FORMUL   5  HOH   *510(H2 O1)                                                   
+HELIX    1   1 ALA A   58  TYR A   62  5                                   5    
+HELIX    2   2 SER A  164  TYR A  172  1                                   9    
+HELIX    3   3 TYR A  232  ASN A  243  1                                  12    
+HELIX    4   4 ARG B   65  ARG B   71  1                                   7    
+SHEET    1  AA 7 TYR A  25  THR A  26  0                                        
+SHEET    2  AA 7 LYS A 156  PRO A 161 -1  O  CYS A 157   N  TYR A  25           
+SHEET    3  AA 7 GLN A 135  GLY A 140 -1  O  CYS A 136   N  ALA A 160           
+SHEET    4  AA 7 PRO A 200  CYS A 203 -1  O  PRO A 200   N  SER A 139           
+SHEET    5  AA 7 LYS A 206  TRP A 213 -1  O  LYS A 206   N  CYS A 203           
+SHEET    6  AA 7 GLY A 224  LYS A 228 -1  O  VAL A 225   N  TRP A 213           
+SHEET    7  AA 7 MET A 180  ALA A 183 -1  O  PHE A 181   N  TYR A 226           
+SHEET    1  AB 7 GLN A  35  ASN A  39  0                                        
+SHEET    2  AB 7 HIS A  43  ASN A  51 -1  N  PHE A  44   O  LEU A  38           
+SHEET    3  AB 7 TRP A  54  SER A  57 -1  O  TRP A  54   N  ILE A  50           
+SHEET    4  AB 7 MET A 106  LEU A 110 -1  O  MET A 106   N  SER A  57           
+SHEET    5  AB 7 GLN A  83  VAL A  92 -1  N  SER A  88   O  LYS A 109           
+SHEET    6  AB 7 GLN A  67  LEU A  70 -1  O  VAL A  68   N  ILE A  85           
+SHEET    7  AB 7 GLN A  35  ASN A  39 -1  O  SER A  37   N  ARG A  69           
+SHEET    1  BA 2 PHE B  42  MET B  48  0                                        
+SHEET    2  BA 2 CYS B  51  GLY B  57 -1  O  CYS B  51   N  MET B  48           
+SSBOND   1 CYS A   27    CYS A  157                          1555   1555  2.05  
+SSBOND   2 CYS A   45    CYS A   61                          1555   1555  2.04  
+SSBOND   3 CYS A  129    CYS A  230                          1555   1555  2.02  
+SSBOND   4 CYS A  136    CYS A  203                          1555   1555  2.05  
+SSBOND   5 CYS A  168    CYS A  182                          1555   1555  2.05  
+SSBOND   6 CYS A  193    CYS A  217                          1555   1555  2.06  
+SSBOND   7 CYS B   24    CYS B   51                          1555   1555  2.05  
+SSBOND   8 CYS B   38    CYS B   58                          1555   1555  2.07  
+SSBOND   9 CYS B   47    CYS B   73                          1555   1555  2.05  
+SSBOND  10 CYS B   52    CYS B   69                          1555   1555  2.04  
+LINK        CA    CA A1244                 O   VAL A  77     1555   1555  2.18  
+LINK        CA    CA A1244                 OE2 GLU A  82     1555   1555  2.17  
+LINK        CA    CA A1244                 O   HOH A2108     1555   1555  2.12  
+LINK        CA    CA A1244                 O   ASN A  74     1555   1555  2.17  
+LINK        CA    CA A1244                 O   HOH A2133     1555   1555  2.18  
+LINK        CA    CA A1244                 OE1 GLU A  72     1555   1555  2.14  
+CISPEP   1 CYS B   73    PRO B   74          0         1.06                     
+SITE     1 AC1  6 GLU A  72  ASN A  74  VAL A  77  GLU A  82                    
+SITE     2 AC1  6 HOH A2108  HOH A2133                                          
+SITE     1 AC2  3 LYS B  35  GLY B  67  HOH B2066                               
+CRYST1   46.949   67.690   69.068  90.00  90.00  90.00 P 21 21 21    4          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.021300  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.014773  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.014478        0.00000                         
+ATOM      1  N   ILE A  21      22.793  -0.373  10.730  1.00  5.78           N  
+ANISOU    1  N   ILE A  21      777    632    788     72    -49     50       N  
+ATOM      2  CA  ILE A  21      23.659  -1.472  11.274  1.00  6.00           C  
+ANISOU    2  CA  ILE A  21      693    674    911      2     66     32       C  
+ATOM      3  C   ILE A  21      24.166  -2.260  10.095  1.00  6.28           C  
+ANISOU    3  C   ILE A  21      823    721    839    -64    -10     75       C  
+ATOM      4  O   ILE A  21      23.367  -2.793   9.312  1.00  6.09           O  
+ANISOU    4  O   ILE A  21      824    624    863     27     27    -21       O  
+ATOM      5  CB  ILE A  21      22.869  -2.395  12.223  1.00  6.38           C  
+ANISOU    5  CB  ILE A  21      735    666   1021   -123     35     81       C  
+ATOM      6  CG1 ILE A  21      22.240  -1.641  13.422  1.00  6.73           C  
+ANISOU    6  CG1 ILE A  21      826    702   1027    -53     85    125       C  
+ATOM      7  CG2 ILE A  21      23.762  -3.560  12.653  1.00  7.61           C  
+ANISOU    7  CG2 ILE A  21      986    769   1136    149    -29    321       C  
+ATOM      8  CD1 ILE A  21      23.234  -1.139  14.517  1.00  6.38           C  
+ANISOU    8  CD1 ILE A  21      865    659    897    -96    -69     48       C  
+ATOM      9  N   VAL A  22      25.492  -2.342   9.976  1.00  6.14           N  
+ANISOU    9  N   VAL A  22      802    616    914     -7    -35    -80       N  
+ATOM     10  CA  VAL A  22      26.154  -3.122   8.945  1.00  6.77           C  
+ANISOU   10  CA  VAL A  22      956    708    905    -23     31     28       C  
+ATOM     11  C   VAL A  22      26.664  -4.411   9.559  1.00  6.37           C  
+ANISOU   11  C   VAL A  22      730    715    974      5     61    -12       C  
+ATOM     12  O   VAL A  22      27.302  -4.414  10.596  1.00  6.54           O  
+ANISOU   12  O   VAL A  22      739    603   1141    -16     84    109       O  
+ATOM     13  CB  VAL A  22      27.338  -2.321   8.354  1.00  7.12           C  
+ANISOU   13  CB  VAL A  22     1076    641    988    -37     56    -42       C  
+ATOM     14  CG1 VAL A  22      28.112  -3.163   7.318  1.00  7.73           C  
+ANISOU   14  CG1 VAL A  22      917    915   1103    -71    125   -114       C  
+ATOM     15  CG2 VAL A  22      26.850  -1.010   7.706  1.00  8.19           C  
+ANISOU   15  CG2 VAL A  22     1171    877   1064      8    155     63       C  
+ATOM     16  N   GLY A  23      26.411  -5.530   8.883  1.00  6.22           N  
+ANISOU   16  N   GLY A  23      793    629    941    -28      9    -78       N  
+ATOM     17  CA  GLY A  23      26.933  -6.830   9.328  1.00  7.25           C  
+ANISOU   17  CA  GLY A  23      815    730   1207    -10     37    -43       C  
+ATOM     18  C   GLY A  23      26.197  -7.443  10.493  1.00  6.96           C  
+ANISOU   18  C   GLY A  23      857    545   1242    -78    -17    -64       C  
+ATOM     19  O   GLY A  23      26.741  -8.356  11.104  1.00  7.76           O  
+ANISOU   19  O   GLY A  23      874    687   1386     35    -10     39       O  
+ATOM     20  N   GLY A  24      24.986  -6.954  10.764  1.00  6.64           N  
+ANISOU   20  N   GLY A  24      791    639   1091    -85    -18     57       N  
+ATOM     21  CA  GLY A  24      24.155  -7.491  11.820  1.00  7.10           C  
+ANISOU   21  CA  GLY A  24      856    667   1174    -63      4     40       C  
+ATOM     22  C   GLY A  24      22.992  -8.316  11.336  1.00  7.17           C  
+ANISOU   22  C   GLY A  24      870    662   1192    -50     19      1       C  
+ATOM     23  O   GLY A  24      23.030  -8.889  10.259  1.00  7.60           O  
+ANISOU   23  O   GLY A  24      909    809   1166    -46     72    -10       O  
+ATOM     24  N   TYR A  25      21.949  -8.358  12.148  1.00  7.09           N  
+ANISOU   24  N   TYR A  25      816    752   1123    -38    -35     17       N  
+ATOM     25  CA  TYR A  25      20.862  -9.310  11.940  1.00  7.33           C  
+ANISOU   25  CA  TYR A  25      828    697   1259    -34    -79     90       C  
+ATOM     26  C   TYR A  25      19.556  -8.686  12.420  1.00  6.94           C  
+ANISOU   26  C   TYR A  25      881    551   1205    -41    -69    101       C  
+ATOM     27  O   TYR A  25      19.525  -7.603  12.981  1.00  7.16           O  
+ANISOU   27  O   TYR A  25      848    484   1385     15    -36     -3       O  
+ATOM     28  CB  TYR A  25      21.187 -10.648  12.678  1.00  7.25           C  
+ANISOU   28  CB  TYR A  25      778    604   1372    -30    -36     33       C  
+ATOM     29  CG  TYR A  25      21.338 -10.467  14.162  1.00  7.21           C  
+ANISOU   29  CG  TYR A  25      880    457   1402    -21    -75    228       C  
+ATOM     30  CD1 TYR A  25      20.250 -10.558  14.999  1.00  7.10           C  
+ANISOU   30  CD1 TYR A  25      939    468   1287     83   -172    190       C  
+ATOM     31  CD2 TYR A  25      22.550 -10.094  14.726  1.00  9.11           C  
+ANISOU   31  CD2 TYR A  25     1071    887   1500    -93   -103    311       C  
+ATOM     32  CE1 TYR A  25      20.318 -10.283  16.327  1.00  8.27           C  
+ANISOU   32  CE1 TYR A  25     1176    682   1282     55   -135    218       C  
+ATOM     33  CE2 TYR A  25      22.649  -9.828  16.075  1.00 10.14           C  
+ANISOU   33  CE2 TYR A  25     1228   1160   1462   -310   -249    465       C  
+ATOM     34  CZ  TYR A  25      21.535  -9.915  16.888  1.00  9.25           C  
+ANISOU   34  CZ  TYR A  25     1369    839   1304   -219   -131    297       C  
+ATOM     35  OH  TYR A  25      21.659  -9.618  18.229  1.00 10.69           O  
+ANISOU   35  OH  TYR A  25     1586   1089   1386   -204   -279    245       O  
+ATOM     36  N   THR A  26      18.457  -9.379  12.232  1.00  6.66           N  
+ANISOU   36  N   THR A  26      705    668   1154   -144   -146     35       N  
+ATOM     37  CA  THR A  26      17.147  -8.923  12.649  1.00  7.05           C  
+ANISOU   37  CA  THR A  26      793    676   1207    -49   -121     11       C  
+ATOM     38  C   THR A  26      16.922  -9.162  14.125  1.00  7.03           C  
+ANISOU   38  C   THR A  26      679    805   1185     11    -51      4       C  
+ATOM     39  O   THR A  26      16.971 -10.289  14.601  1.00  7.48           O  
+ANISOU   39  O   THR A  26      767    754   1320      2    -38    145       O  
+ATOM     40  CB  THR A  26      16.078  -9.625  11.805  1.00  7.80           C  
+ANISOU   40  CB  THR A  26      896    720   1344    -48   -168    -27       C  
+ATOM     41  OG1 THR A  26      16.279  -9.214  10.454  1.00  8.33           O  
+ANISOU   41  OG1 THR A  26      915   1053   1194    -29    -80   -119       O  
+ATOM     42  CG2 THR A  26      14.673  -9.275  12.256  1.00  8.57           C  
+ANISOU   42  CG2 THR A  26      633   1066   1556    -90   -139      3       C  
+ATOM     43  N   CYS A  27      16.698  -8.101  14.876  1.00  7.26           N  
+ANISOU   43  N   CYS A  27      870    645   1243    -23    -72    122       N  
+ATOM     44  CA  CYS A  27      16.518  -8.231  16.305  1.00  7.67           C  
+ANISOU   44  CA  CYS A  27      822    819   1274    -55    -36     92       C  
+ATOM     45  C   CYS A  27      15.342  -9.121  16.660  1.00  8.67           C  
+ANISOU   45  C   CYS A  27     1055    921   1317   -122     64    180       C  
+ATOM     46  O   CYS A  27      15.434  -9.945  17.565  1.00 10.61           O  
+ANISOU   46  O   CYS A  27     1377   1024   1628   -163    107    351       O  
+ATOM     47  CB  CYS A  27      16.243  -6.863  16.937  1.00  7.56           C  
+ANISOU   47  CB  CYS A  27      791    918   1163   -155     69     50       C  
+ATOM     48  SG  CYS A  27      17.469  -5.564  16.641  1.00  7.08           S  
+ANISOU   48  SG  CYS A  27      840    761   1086    -36    -32    137       S  
+ATOM     49  N   GLY A  28      14.241  -8.895  15.964  1.00  8.51           N  
+ANISOU   49  N   GLY A  28      936    844   1452   -107    203    152       N  
+ATOM     50  CA  GLY A  28      12.975  -9.524  16.301  1.00  9.63           C  
+ANISOU   50  CA  GLY A  28     1100    857   1699   -206    137     90       C  
+ATOM     51  C   GLY A  28      12.051  -8.469  16.895  1.00  9.29           C  
+ANISOU   51  C   GLY A  28     1058   1020   1448   -152    162     73       C  
+ATOM     52  O   GLY A  28      12.462  -7.610  17.669  1.00  9.57           O  
+ANISOU   52  O   GLY A  28      950   1038   1645   -143     55     26       O  
+ATOM     53  N   ALA A  29      10.791  -8.528  16.516  1.00  9.33           N  
+ANISOU   53  N   ALA A  29     1043   1059   1441   -144     25    -28       N  
+ATOM     54  CA  ALA A  29       9.848  -7.451  16.788  1.00  9.68           C  
+ANISOU   54  CA  ALA A  29      999   1234   1442    -78     35     57       C  
+ATOM     55  C   ALA A  29       9.721  -7.148  18.277  1.00  9.43           C  
+ANISOU   55  C   ALA A  29     1083   1169   1331   -175     52     69       C  
+ATOM     56  O   ALA A  29       9.396  -8.029  19.069  1.00 10.47           O  
+ANISOU   56  O   ALA A  29     1207   1281   1487   -254    149     78       O  
+ATOM     57  CB  ALA A  29       8.494  -7.766  16.202  1.00 11.29           C  
+ANISOU   57  CB  ALA A  29     1150   1514   1624    -86   -147    -90       C  
+ATOM     58  N   ASN A  30       9.953  -5.880  18.636  1.00  9.12           N  
+ANISOU   58  N   ASN A  30     1023   1168   1271   -172    -29     99       N  
+ATOM     59  CA  ASN A  30       9.786  -5.371  19.994  1.00  9.29           C  
+ANISOU   59  CA  ASN A  30     1126   1186   1214   -149    -26    156       C  
+ATOM     60  C   ASN A  30      10.683  -6.031  21.039  1.00  9.67           C  
+ANISOU   60  C   ASN A  30     1148   1198   1325    -54    104    131       C  
+ATOM     61  O   ASN A  30      10.424  -5.907  22.232  1.00 10.72           O  
+ANISOU   61  O   ASN A  30     1315   1373   1384    -84    206    176       O  
+ATOM     62  CB  ASN A  30       8.305  -5.402  20.374  1.00  9.58           C  
+ANISOU   62  CB  ASN A  30     1217   1160   1261    -15     14     57       C  
+ATOM     63  CG  ASN A  30       7.434  -4.743  19.336  1.00  9.76           C  
+ANISOU   63  CG  ASN A  30     1166   1233   1306    139    -33     53       C  
+ATOM     64  OD1 ASN A  30       6.591  -5.400  18.734  1.00 11.69           O  
+ANISOU   64  OD1 ASN A  30     1278   1414   1749   -178   -155     76       O  
+ATOM     65  ND2 ASN A  30       7.625  -3.454  19.116  1.00 10.80           N  
+ANISOU   65  ND2 ASN A  30     1255   1240   1607    101     24    107       N  
+ATOM     66  N   THR A  31      11.747  -6.705  20.589  1.00  9.09           N  
+ANISOU   66  N   THR A  31     1135   1028   1290    -74     93    193       N  
+ATOM     67  CA  THR A  31      12.706  -7.291  21.493  1.00  9.06           C  
+ANISOU   67  CA  THR A  31     1117    987   1336     26     27    252       C  
+ATOM     68  C   THR A  31      13.696  -6.303  22.077  1.00  8.45           C  
+ANISOU   68  C   THR A  31     1028    960   1221    -94     -4    271       C  
+ATOM     69  O   THR A  31      14.436  -6.634  22.998  1.00  8.96           O  
+ANISOU   69  O   THR A  31     1203    996   1203    -35    -70    369       O  
+ATOM     70  CB  THR A  31      13.505  -8.412  20.838  1.00  9.72           C  
+ANISOU   70  CB  THR A  31     1282    906   1502    -29    -15    243       C  
+ATOM     71  OG1 THR A  31      14.308  -7.922  19.767  1.00 11.65           O  
+ANISOU   71  OG1 THR A  31     1172   1524   1728    107     38   -126       O  
+ATOM     72  CG2 THR A  31      12.609  -9.540  20.331  1.00 12.29           C  
+ANISOU   72  CG2 THR A  31     1757   1144   1767   -133    -84     20       C  
+ATOM     73  N   VAL A  32      13.712  -5.096  21.532  1.00  8.03           N  
+ANISOU   73  N   VAL A  32     1151    813   1086    -88   -108    208       N  
+ATOM     74  CA  VAL A  32      14.522  -3.993  22.031  1.00  7.30           C  
+ANISOU   74  CA  VAL A  32      873    887   1014    -95    -47    225       C  
+ATOM     75  C   VAL A  32      13.517  -2.899  22.402  1.00  7.06           C  
+ANISOU   75  C   VAL A  32      737    921   1022    -50     -9    232       C  
+ATOM     76  O   VAL A  32      13.371  -1.888  21.729  1.00  7.11           O  
+ANISOU   76  O   VAL A  32      882    866    953    -55     71    269       O  
+ATOM     77  CB  VAL A  32      15.555  -3.530  20.995  1.00  7.95           C  
+ANISOU   77  CB  VAL A  32      935   1003   1081    -12      0    203       C  
+ATOM     78  CG1 VAL A  32      16.543  -2.558  21.624  1.00  7.68           C  
+ANISOU   78  CG1 VAL A  32      872    964   1079   -273    -47    159       C  
+ATOM     79  CG2 VAL A  32      16.301  -4.719  20.390  1.00  9.16           C  
+ANISOU   79  CG2 VAL A  32     1145   1065   1268    -23    100    105       C  
+ATOM     80  N   PRO A  33      12.763  -3.104  23.496  1.00  7.84           N  
+ANISOU   80  N   PRO A  33      903   1036   1038    -71     59    335       N  
+ATOM     81  CA  PRO A  33      11.566  -2.259  23.699  1.00  7.62           C  
+ANISOU   81  CA  PRO A  33      840   1095    956   -115     79    287       C  
+ATOM     82  C   PRO A  33      11.834  -0.822  24.109  1.00  7.22           C  
+ANISOU   82  C   PRO A  33      857   1061    824      0    114    259       C  
+ATOM     83  O   PRO A  33      10.917  -0.010  24.113  1.00  6.92           O  
+ANISOU   83  O   PRO A  33      781    876    971    -52     47    200       O  
+ATOM     84  CB  PRO A  33      10.796  -3.008  24.810  1.00  8.71           C  
+ANISOU   84  CB  PRO A  33     1019   1125   1164   -158    123    228       C  
+ATOM     85  CG  PRO A  33      11.847  -3.764  25.518  1.00  9.03           C  
+ANISOU   85  CG  PRO A  33     1267    996   1167   -137    173    333       C  
+ATOM     86  CD  PRO A  33      12.825  -4.198  24.477  1.00  8.78           C  
+ANISOU   86  CD  PRO A  33     1155   1072   1108   -135     47    199       C  
+ATOM     87  N   TYR A  34      13.090  -0.525  24.424  1.00  6.99           N  
+ANISOU   87  N   TYR A  34      845    964    845    -69    163    275       N  
+ATOM     88  CA  TYR A  34      13.555   0.819  24.731  1.00  6.81           C  
+ANISOU   88  CA  TYR A  34      859    844    881    -71    124    223       C  
+ATOM     89  C   TYR A  34      14.034   1.568  23.480  1.00  6.21           C  
+ANISOU   89  C   TYR A  34      730    746    884    -74    110    179       C  
+ATOM     90  O   TYR A  34      14.309   2.744  23.572  1.00  6.86           O  
+ANISOU   90  O   TYR A  34      917    807    882   -185     88    156       O  
+ATOM     91  CB  TYR A  34      14.706   0.731  25.749  1.00  7.27           C  
+ANISOU   91  CB  TYR A  34      929   1027    805   -173    104    178       C  
+ATOM     92  CG  TYR A  34      15.809  -0.247  25.357  1.00  7.70           C  
+ANISOU   92  CG  TYR A  34     1077    997    851    -56    113    269       C  
+ATOM     93  CD1 TYR A  34      16.856   0.147  24.560  1.00  7.67           C  
+ANISOU   93  CD1 TYR A  34      836   1199    877     24    -50    348       C  
+ATOM     94  CD2 TYR A  34      15.800  -1.552  25.782  1.00  8.33           C  
+ANISOU   94  CD2 TYR A  34      836   1222   1106   -154    -27    284       C  
+ATOM     95  CE1 TYR A  34      17.837  -0.739  24.166  1.00  8.07           C  
+ANISOU   95  CE1 TYR A  34      888   1173   1002    -32      3    188       C  
+ATOM     96  CE2 TYR A  34      16.780  -2.459  25.398  1.00  9.09           C  
+ANISOU   96  CE2 TYR A  34      975   1314   1164    -32     27    382       C  
+ATOM     97  CZ  TYR A  34      17.795  -2.045  24.571  1.00  8.06           C  
+ANISOU   97  CZ  TYR A  34      932   1089   1039    -95    -27    213       C  
+ATOM     98  OH  TYR A  34      18.760  -2.956  24.186  1.00  8.01           O  
+ANISOU   98  OH  TYR A  34      951    948   1142    -35   -119    330       O  
+ATOM     99  N   GLN A  35      14.126   0.886  22.343  1.00  6.69           N  
+ANISOU   99  N   GLN A  35      881    716    945    -34      1    224       N  
+ATOM    100  CA  GLN A  35      14.561   1.516  21.114  1.00  5.99           C  
+ANISOU  100  CA  GLN A  35      832    625    818     11    -31    122       C  
+ATOM    101  C   GLN A  35      13.478   2.391  20.559  1.00  5.37           C  
+ANISOU  101  C   GLN A  35      702    573    764     63     32    128       C  
+ATOM    102  O   GLN A  35      12.360   1.928  20.322  1.00  6.01           O  
+ANISOU  102  O   GLN A  35      699    759    823   -112      1    281       O  
+ATOM    103  CB  GLN A  35      14.918   0.459  20.055  1.00  6.18           C  
+ANISOU  103  CB  GLN A  35      815    774    756      3    -17    184       C  
+ATOM    104  CG  GLN A  35      15.236   1.052  18.671  1.00  6.26           C  
+ANISOU  104  CG  GLN A  35      827    765    783     54     25    105       C  
+ATOM    105  CD  GLN A  35      16.666   1.553  18.492  1.00  5.43           C  
+ANISOU  105  CD  GLN A  35      668    676    719     77    -10    105       C  
+ATOM    106  OE1 GLN A  35      17.617   0.811  18.715  1.00  6.26           O  
+ANISOU  106  OE1 GLN A  35      713    689    977    132   -108     70       O  
+ATOM    107  NE2 GLN A  35      16.829   2.791  18.047  1.00  5.80           N  
+ANISOU  107  NE2 GLN A  35      831    652    717     89    -49    169       N  
+ATOM    108  N   VAL A  36      13.812   3.655  20.280  1.00  5.98           N  
+ANISOU  108  N   VAL A  36      808    655    809    -14    -37     98       N  
+ATOM    109  C   VAL A  36      13.434   5.030  18.278  1.00  6.01           C  
+ANISOU  109  C   VAL A  36      701    663    918    -49     36     34       C  
+ATOM    110  O   VAL A  36      14.655   4.969  18.032  1.00  5.90           O  
+ANISOU  110  O   VAL A  36      635    692    914    -24    -93     53       O  
+ATOM    111  CA AVAL A  36      12.866   4.552  19.601  0.50  6.22           C  
+ANISOU  111  CA AVAL A  36      836    766    758     55     -9     66       C  
+ATOM    112  CB AVAL A  36      12.388   5.734  20.454  0.50  7.38           C  
+ANISOU  112  CB AVAL A  36     1137    927    741    -37     96    132       C  
+ATOM    113  CG1AVAL A  36      11.813   5.253  21.784  0.50  5.48           C  
+ANISOU  113  CG1AVAL A  36      720    718    645     62     82    271       C  
+ATOM    114  CG2AVAL A  36      13.509   6.626  20.753  0.50  5.91           C  
+ANISOU  114  CG2AVAL A  36      413   1355    475     63     -7    225       C  
+ATOM    115  CA BVAL A  36      12.877   4.567  19.621  0.50  7.48           C  
+ANISOU  115  CA BVAL A  36     1046    843    949     44    -24     27       C  
+ATOM    116  CB BVAL A  36      12.400   5.722  20.545  0.50  9.50           C  
+ANISOU  116  CB BVAL A  36     1462   1060   1087    -19     57     34       C  
+ATOM    117  CG1BVAL A  36      13.222   7.013  20.376  0.50 10.02           C  
+ANISOU  117  CG1BVAL A  36     1530   1051   1225    -35    -31    -40       C  
+ATOM    118  CG2BVAL A  36      10.917   5.979  20.331  0.50 14.19           C  
+ANISOU  118  CG2BVAL A  36     1858   1758   1772     53    -11      9       C  
+ATOM    119  N   SER A  37      12.517   5.440  17.410  1.00  6.07           N  
+ANISOU  119  N   SER A  37      594    821    888    -48     -3    142       N  
+ATOM    120  CA  SER A  37      12.841   6.111  16.169  1.00  6.31           C  
+ANISOU  120  CA  SER A  37      720    887    789     47     38     28       C  
+ATOM    121  C   SER A  37      12.462   7.563  16.309  1.00  6.33           C  
+ANISOU  121  C   SER A  37      611    872    922     23      4     49       C  
+ATOM    122  O   SER A  37      11.367   7.879  16.770  1.00  7.01           O  
+ANISOU  122  O   SER A  37      664    889   1107     85    120    103       O  
+ATOM    123  CB  SER A  37      12.053   5.479  15.019  1.00  7.22           C  
+ANISOU  123  CB  SER A  37      713   1001   1026     -4    -36     -2       C  
+ATOM    124  OG  SER A  37      12.135   6.281  13.849  1.00  7.17           O  
+ANISOU  124  OG  SER A  37      852    942    930     72    -72    -38       O  
+ATOM    125  N   LEU A  38      13.379   8.458  15.949  1.00  5.53           N  
+ANISOU  125  N   LEU A  38      542    698    860     66    -14     60       N  
+ATOM    126  CA  LEU A  38      13.089   9.891  15.840  1.00  5.51           C  
+ANISOU  126  CA  LEU A  38      648    631    813    173     -3    -14       C  
+ATOM    127  C   LEU A  38      12.748  10.177  14.404  1.00  5.63           C  
+ANISOU  127  C   LEU A  38      717    666    757     -4      2     71       C  
+ATOM    128  O   LEU A  38      13.515   9.869  13.478  1.00  6.48           O  
+ANISOU  128  O   LEU A  38      818    888    754     79    -92     81       O  
+ATOM    129  CB  LEU A  38      14.291  10.724  16.313  1.00  5.63           C  
+ANISOU  129  CB  LEU A  38      671    663    802    163     53    -55       C  
+ATOM    130  CG  LEU A  38      14.816  10.398  17.709  1.00  6.43           C  
+ANISOU  130  CG  LEU A  38      956    727    758     95    -50     -9       C  
+ATOM    131  CD1 LEU A  38      15.920  11.399  18.059  1.00  8.41           C  
+ANISOU  131  CD1 LEU A  38     1027   1062   1105    -10   -125    -99       C  
+ATOM    132  CD2 LEU A  38      13.689  10.439  18.746  1.00  7.91           C  
+ANISOU  132  CD2 LEU A  38     1195   1169    639     25    -17     20       C  
+ATOM    133  N   ASN A  39      11.590  10.793  14.225  1.00  5.60           N  
+ANISOU  133  N   ASN A  39      781    689    655     76    -86     20       N  
+ATOM    134  CA  ASN A  39      11.002  11.016  12.932  1.00  6.35           C  
+ANISOU  134  CA  ASN A  39      763    842    806     45    -83     65       C  
+ATOM    135  C   ASN A  39      10.679  12.501  12.734  1.00  6.71           C  
+ANISOU  135  C   ASN A  39      828    846    874    103    -51    116       C  
+ATOM    136  O   ASN A  39      10.100  13.126  13.619  1.00  7.68           O  
+ANISOU  136  O   ASN A  39      994   1027    896    244    -15    114       O  
+ATOM    137  CB  ASN A  39       9.734  10.123  12.809  1.00  6.86           C  
+ANISOU  137  CB  ASN A  39      904    929    772     -1    -34     79       C  
+ATOM    138  CG  ASN A  39       9.115  10.121  11.425  1.00  7.77           C  
+ANISOU  138  CG  ASN A  39      793   1044   1112     30   -129     50       C  
+ATOM    139  OD1 ASN A  39       8.514  11.100  10.996  1.00  7.97           O  
+ANISOU  139  OD1 ASN A  39      965    968   1092     33   -245    137       O  
+ATOM    140  ND2 ASN A  39       9.285   9.033  10.718  1.00  7.81           N  
+ANISOU  140  ND2 ASN A  39      921    972   1074     74   -104     -4       N  
+ATOM    141  N   SER A  40      11.049  13.058  11.585  1.00  6.40           N  
+ANISOU  141  N   SER A  40      715    848    867    120    -30     48       N  
+ATOM    142  CA  SER A  40      10.681  14.438  11.239  1.00  7.05           C  
+ANISOU  142  CA  SER A  40      929    801    947    133   -133    139       C  
+ATOM    143  C   SER A  40      10.112  14.430   9.803  1.00  6.96           C  
+ANISOU  143  C   SER A  40      925    723    996     55   -107    195       C  
+ATOM    144  O   SER A  40      10.497  15.231   8.946  1.00  8.24           O  
+ANISOU  144  O   SER A  40     1195    964    970   -133   -190    312       O  
+ATOM    145  CB  SER A  40      11.895  15.334  11.388  1.00  7.34           C  
+ANISOU  145  CB  SER A  40     1110    742    935     72   -116    191       C  
+ATOM    146  OG  SER A  40      11.513  16.700  11.388  1.00  8.73           O  
+ANISOU  146  OG  SER A  40     1257    901   1157    -42   -248     33       O  
+ATOM    147  N   GLY A  41       9.203  13.486   9.559  1.00  7.95           N  
+ANISOU  147  N   GLY A  41      962   1008   1049    -59   -109    242       N  
+ATOM    148  CA  GLY A  41       8.703  13.183   8.213  1.00  7.58           C  
+ANISOU  148  CA  GLY A  41     1030    941    907    -32   -173    253       C  
+ATOM    149  C   GLY A  41       9.406  11.973   7.607  1.00  7.84           C  
+ANISOU  149  C   GLY A  41     1025   1071    883    -83   -128    167       C  
+ATOM    150  O   GLY A  41       8.989  11.468   6.585  1.00 10.87           O  
+ANISOU  150  O   GLY A  41     1379   1602   1149    243   -337   -136       O  
+ATOM    151  N   TYR A  42      10.480  11.522   8.253  1.00  8.35           N  
+ANISOU  151  N   TYR A  42      955   1265    951     30    -93     93       N  
+ATOM    152  CA  TYR A  42      11.292  10.358   7.881  1.00  7.89           C  
+ANISOU  152  CA  TYR A  42     1055   1097    845      7   -104    115       C  
+ATOM    153  C   TYR A  42      12.112  10.033   9.127  1.00  7.41           C  
+ANISOU  153  C   TYR A  42      899   1121    795      2    -83     70       C  
+ATOM    154  O   TYR A  42      12.325  10.899   9.967  1.00  6.64           O  
+ANISOU  154  O   TYR A  42      818    901    802     64    -88     62       O  
+ATOM    155  CB  TYR A  42      12.184  10.683   6.679  1.00  8.19           C  
+ANISOU  155  CB  TYR A  42     1057   1168    884     93   -152     56       C  
+ATOM    156  CG  TYR A  42      13.161  11.811   6.886  1.00  9.01           C  
+ANISOU  156  CG  TYR A  42     1167   1265    991     57    -36    127       C  
+ATOM    157  CD1 TYR A  42      14.487  11.543   7.257  1.00  8.24           C  
+ANISOU  157  CD1 TYR A  42      994   1161    973     99    131     62       C  
+ATOM    158  CD2 TYR A  42      12.786  13.131   6.722  1.00  9.96           C  
+ANISOU  158  CD2 TYR A  42     1107   1419   1255     97    -39    377       C  
+ATOM    159  CE1 TYR A  42      15.407  12.577   7.464  1.00  9.01           C  
+ANISOU  159  CE1 TYR A  42     1042   1297   1084    -21    -44    276       C  
+ATOM    160  CE2 TYR A  42      13.691  14.152   6.934  1.00  9.67           C  
+ANISOU  160  CE2 TYR A  42     1126   1032   1516     96   -115    208       C  
+ATOM    161  CZ  TYR A  42      15.013  13.879   7.303  1.00  8.15           C  
+ANISOU  161  CZ  TYR A  42      968   1091   1035     66     96    303       C  
+ATOM    162  OH  TYR A  42      15.972  14.874   7.534  1.00  8.67           O  
+ANISOU  162  OH  TYR A  42     1063   1105   1125     53    169    199       O  
+ATOM    163  N   HIS A  43      12.589   8.807   9.208  1.00  7.15           N  
+ANISOU  163  N   HIS A  43      946    949    821     -1    -90    -15       N  
+ATOM    164  CA  HIS A  43      13.476   8.399  10.295  1.00  6.39           C  
+ANISOU  164  CA  HIS A  43      804    848    776    -86    -32     35       C  
+ATOM    165  C   HIS A  43      14.844   9.003  10.089  1.00  6.96           C  
+ANISOU  165  C   HIS A  43      832    876    936     47    -88      0       C  
+ATOM    166  O   HIS A  43      15.455   8.803   9.050  1.00  6.73           O  
+ANISOU  166  O   HIS A  43      887    862    807   -105    -26     73       O  
+ATOM    167  CB  HIS A  43      13.560   6.860  10.317  1.00  7.01           C  
+ANISOU  167  CB  HIS A  43      829    922    912    -30    -83     69       C  
+ATOM    168  CG  HIS A  43      14.659   6.351  11.176  1.00  5.70           C  
+ANISOU  168  CG  HIS A  43      710    732    722     -5   -119     -3       C  
+ATOM    169  ND1 HIS A  43      14.492   6.092  12.521  1.00  6.38           N  
+ANISOU  169  ND1 HIS A  43      740    693    987    -14    -61    -48       N  
+ATOM    170  CD2 HIS A  43      15.976   6.185  10.893  1.00  6.69           C  
+ANISOU  170  CD2 HIS A  43      922    823    795    -21    -23    121       C  
+ATOM    171  CE1 HIS A  43      15.668   5.756  13.016  1.00  5.92           C  
+ANISOU  171  CE1 HIS A  43      914    602    731     13   -162    107       C  
+ATOM    172  NE2 HIS A  43      16.589   5.809  12.060  1.00  6.71           N  
+ANISOU  172  NE2 HIS A  43      813    785    951     22     23     97       N  
+ATOM    173  N   PHE A  44      15.354   9.721  11.083  1.00  6.22           N  
+ANISOU  173  N   PHE A  44      801    823    738      0    -31      6       N  
+ATOM    174  CA  PHE A  44      16.676  10.344  10.966  1.00  6.19           C  
+ANISOU  174  CA  PHE A  44      775    844    733     10    -19     21       C  
+ATOM    175  C   PHE A  44      17.665   9.945  12.066  1.00  5.78           C  
+ANISOU  175  C   PHE A  44      725    837    634     40    -95    -43       C  
+ATOM    176  O   PHE A  44      18.850  10.139  11.890  1.00  6.86           O  
+ANISOU  176  O   PHE A  44      817    946    843    -31    -25      3       O  
+ATOM    177  CB  PHE A  44      16.571  11.887  10.883  1.00  6.70           C  
+ANISOU  177  CB  PHE A  44      737    943    865    -47    -50     65       C  
+ATOM    178  CG  PHE A  44      16.090  12.545  12.129  1.00  6.17           C  
+ANISOU  178  CG  PHE A  44      967    611    766    107    -86    113       C  
+ATOM    179  CD1 PHE A  44      16.998  13.039  13.052  1.00  7.73           C  
+ANISOU  179  CD1 PHE A  44      967    932   1036    -40   -202    201       C  
+ATOM    180  CD2 PHE A  44      14.736  12.692  12.396  1.00  6.79           C  
+ANISOU  180  CD2 PHE A  44      951    646    982    -25    -81    203       C  
+ATOM    181  CE1 PHE A  44      16.570  13.609  14.203  1.00  7.31           C  
+ANISOU  181  CE1 PHE A  44     1018    724   1036     -1   -250    108       C  
+ATOM    182  CE2 PHE A  44      14.307  13.273  13.558  1.00  7.10           C  
+ANISOU  182  CE2 PHE A  44      885    781   1032     76    -82     75       C  
+ATOM    183  CZ  PHE A  44      15.229  13.722  14.462  1.00  7.58           C  
+ANISOU  183  CZ  PHE A  44     1078    654   1148     43    -53     41       C  
+ATOM    184  N   CYS A  45      17.184   9.432  13.205  1.00  5.36           N  
+ANISOU  184  N   CYS A  45      707    648    682     58    -44     83       N  
+ATOM    185  CA  CYS A  45      18.055   9.065  14.313  1.00  5.58           C  
+ANISOU  185  CA  CYS A  45      678    777    665    121    -81     15       C  
+ATOM    186  C   CYS A  45      17.266   8.114  15.185  1.00  4.63           C  
+ANISOU  186  C   CYS A  45      540    537    680    104    -66    -45       C  
+ATOM    187  O   CYS A  45      16.057   8.015  15.085  1.00  5.92           O  
+ANISOU  187  O   CYS A  45      681    821    745    142    -90    128       O  
+ATOM    188  CB  CYS A  45      18.464  10.278  15.158  1.00  5.65           C  
+ANISOU  188  CB  CYS A  45      811    721    614     83   -101    121       C  
+ATOM    189  SG  CYS A  45      19.915  11.190  14.514  1.00  5.70           S  
+ANISOU  189  SG  CYS A  45      705    650    810      1    -56    -18       S  
+ATOM    190  N   GLY A  46      17.991   7.394  16.026  1.00  4.92           N  
+ANISOU  190  N   GLY A  46      549    659    660     22    -85     95       N  
+ATOM    191  CA  GLY A  46      17.400   6.611  17.073  1.00  5.46           C  
+ANISOU  191  CA  GLY A  46      607    740    727    -26    -15     52       C  
+ATOM    192  C   GLY A  46      17.475   7.309  18.425  1.00  5.20           C  
+ANISOU  192  C   GLY A  46      531    667    776     20    -25     73       C  
+ATOM    193  O   GLY A  46      17.925   8.433  18.557  1.00  5.69           O  
+ANISOU  193  O   GLY A  46      685    784    691     14    -84     48       O  
+ATOM    194  N   GLY A  47      17.007   6.604  19.438  1.00  5.01           N  
+ANISOU  194  N   GLY A  47      668    498    735    -83      9     11       N  
+ATOM    195  CA  GLY A  47      17.040   7.022  20.816  1.00  5.38           C  
+ANISOU  195  CA  GLY A  47      626    730    688    -79     33     35       C  
+ATOM    196  C   GLY A  47      16.710   5.875  21.704  1.00  5.20           C  
+ANISOU  196  C   GLY A  47      642    661    671    -12    -31     37       C  
+ATOM    197  O   GLY A  47      16.334   4.791  21.242  1.00  5.76           O  
+ANISOU  197  O   GLY A  47      754    759    675    -79    -55     83       O  
+ATOM    198  N   SER A  48      16.822   6.119  23.008  1.00  5.57           N  
+ANISOU  198  N   SER A  48      701    716    697     -4     70     35       N  
+ATOM    199  CA  SER A  48      16.548   5.121  24.024  1.00  6.89           C  
+ANISOU  199  CA  SER A  48      819    851    945    -11     78    192       C  
+ATOM    200  C   SER A  48      15.609   5.679  25.091  1.00  6.03           C  
+ANISOU  200  C   SER A  48      800    600    891    -22    133    118       C  
+ATOM    201  O   SER A  48      15.856   6.729  25.659  1.00  6.66           O  
+ANISOU  201  O   SER A  48      972    726    831     14    161    -12       O  
+ATOM    202  CB  SER A  48      17.852   4.705  24.724  1.00  6.95           C  
+ANISOU  202  CB  SER A  48      821    846    971    -78     85    163       C  
+ATOM    203  OG  SER A  48      18.749   4.114  23.804  1.00  7.41           O  
+ANISOU  203  OG  SER A  48      882   1089    842    260      3    137       O  
+ATOM    204  N   LEU A  49      14.519   4.961  25.347  1.00  6.50           N  
+ANISOU  204  N   LEU A  49      853    851    763    -41     84    105       N  
+ATOM    205  CA  LEU A  49      13.565   5.367  26.356  1.00  7.00           C  
+ANISOU  205  CA  LEU A  49      872    913    875    -43     74    198       C  
+ATOM    206  C   LEU A  49      14.112   5.085  27.744  1.00  7.54           C  
+ANISOU  206  C   LEU A  49      936   1047    879    -82     71    221       C  
+ATOM    207  O   LEU A  49      14.436   3.946  28.044  1.00  7.77           O  
+ANISOU  207  O   LEU A  49      977   1067    906     -2    179    147       O  
+ATOM    208  CB  LEU A  49      12.269   4.615  26.153  1.00  7.04           C  
+ANISOU  208  CB  LEU A  49      790    983    900    -48    149    205       C  
+ATOM    209  CG  LEU A  49      11.059   5.046  26.972  1.00  7.65           C  
+ANISOU  209  CG  LEU A  49      918   1109    880    -10     88    128       C  
+ATOM    210  CD1 LEU A  49      10.611   6.446  26.555  1.00  8.67           C  
+ANISOU  210  CD1 LEU A  49      912   1095   1287     55     86    304       C  
+ATOM    211  CD2 LEU A  49       9.930   4.011  26.790  1.00  9.39           C  
+ANISOU  211  CD2 LEU A  49     1002   1232   1334   -150    176    256       C  
+ATOM    212  N   ILE A  50      14.240   6.112  28.576  1.00  7.47           N  
+ANISOU  212  N   ILE A  50      829   1114    895    -21     40    248       N  
+ATOM    213  CA  ILE A  50      14.780   5.904  29.935  1.00  8.51           C  
+ANISOU  213  CA  ILE A  50     1110   1266    856    -39     75    160       C  
+ATOM    214  C   ILE A  50      13.744   6.025  31.071  1.00  8.95           C  
+ANISOU  214  C   ILE A  50     1084   1339    975     31    104    155       C  
+ATOM    215  O   ILE A  50      14.027   5.603  32.178  1.00  9.79           O  
+ANISOU  215  O   ILE A  50     1192   1498   1030     43    143    272       O  
+ATOM    216  CB  ILE A  50      16.023   6.769  30.210  1.00  8.63           C  
+ANISOU  216  CB  ILE A  50     1075   1272    931    -61    -19    144       C  
+ATOM    217  CG1 ILE A  50      15.712   8.256  30.094  1.00  9.20           C  
+ANISOU  217  CG1 ILE A  50     1175   1375    942    123     63    154       C  
+ATOM    218  CG2 ILE A  50      17.201   6.322  29.313  1.00 10.16           C  
+ANISOU  218  CG2 ILE A  50     1193   1586   1078     70     98     94       C  
+ATOM    219  CD1 ILE A  50      16.761   9.117  30.791  1.00 11.54           C  
+ANISOU  219  CD1 ILE A  50     1442   1541   1401   -205   -201    -21       C  
+ATOM    220  N   ASN A  51      12.572   6.582  30.800  1.00  9.16           N  
+ANISOU  220  N   ASN A  51     1153   1425    901     -9    151    301       N  
+ATOM    221  CA  ASN A  51      11.424   6.528  31.689  1.00  9.38           C  
+ANISOU  221  CA  ASN A  51     1169   1429    964     57    195     85       C  
+ATOM    222  C   ASN A  51      10.222   6.904  30.829  1.00  9.12           C  
+ANISOU  222  C   ASN A  51      987   1357   1118    -26    204     76       C  
+ATOM    223  O   ASN A  51      10.351   7.095  29.620  1.00  9.84           O  
+ANISOU  223  O   ASN A  51     1032   1595   1108    137     96     36       O  
+ATOM    224  CB  ASN A  51      11.623   7.405  32.933  1.00  9.53           C  
+ANISOU  224  CB  ASN A  51     1199   1474    947    177    147     95       C  
+ATOM    225  CG  ASN A  51      11.840   8.856  32.592  1.00 11.16           C  
+ANISOU  225  CG  ASN A  51     1646   1540   1053   -214     59     10       C  
+ATOM    226  OD1 ASN A  51      11.080   9.439  31.819  1.00 10.71           O  
+ANISOU  226  OD1 ASN A  51     1369   1542   1157   -267    123    142       O  
+ATOM    227  ND2 ASN A  51      12.906   9.450  33.143  1.00 14.90           N  
+ANISOU  227  ND2 ASN A  51     1832   2132   1697   -378   -241    187       N  
+ATOM    228  N   SER A  52       9.034   6.980  31.403  1.00  9.95           N  
+ANISOU  228  N   SER A  52     1085   1549   1147     -5    249     53       N  
+ATOM    229  CA  SER A  52       7.852   7.176  30.583  1.00  9.97           C  
+ANISOU  229  CA  SER A  52     1104   1450   1233   -110    244    133       C  
+ATOM    230  C   SER A  52       7.811   8.527  29.897  1.00 10.82           C  
+ANISOU  230  C   SER A  52     1214   1516   1381    -66    224     65       C  
+ATOM    231  O   SER A  52       6.984   8.695  29.010  1.00 11.02           O  
+ANISOU  231  O   SER A  52     1173   1543   1471    -45    132    263       O  
+ATOM    232  CB  SER A  52       6.573   7.013  31.410  1.00 11.25           C  
+ANISOU  232  CB  SER A  52     1170   1662   1440   -110    301    197       C  
+ATOM    233  OG  SER A  52       6.490   8.061  32.366  1.00 13.90           O  
+ANISOU  233  OG  SER A  52     1511   2181   1590    -77    546    113       O  
+ATOM    234  N   GLN A  53       8.644   9.486  30.301  1.00  9.80           N  
+ANISOU  234  N   GLN A  53     1047   1446   1229    -45    242     63       N  
+ATOM    235  C   GLN A  53       9.856  11.299  29.029  1.00  8.93           C  
+ANISOU  235  C   GLN A  53      904   1302   1183    -30    245     41       C  
+ATOM    236  O   GLN A  53       9.850  12.396  28.499  1.00  9.76           O  
+ANISOU  236  O   GLN A  53      965   1317   1425   -135    232     24       O  
+ATOM    237  CA AGLN A  53       8.562  10.795  29.635  0.50 10.28           C  
+ANISOU  237  CA AGLN A  53     1108   1419   1376     30    237     51       C  
+ATOM    238  CB AGLN A  53       8.042  11.897  30.561  0.50 10.07           C  
+ANISOU  238  CB AGLN A  53     1087   1404   1332    102    240     84       C  
+ATOM    239  CG AGLN A  53       6.733  11.668  31.251  0.50 12.04           C  
+ANISOU  239  CG AGLN A  53     1297   1739   1539     54    238    -97       C  
+ATOM    240  CD AGLN A  53       6.477  12.770  32.248  0.50 12.73           C  
+ANISOU  240  CD AGLN A  53     1520   1786   1531    140    238    -67       C  
+ATOM    241  OE1AGLN A  53       5.920  13.798  31.895  0.50 17.05           O  
+ANISOU  241  OE1AGLN A  53     2374   1969   2134    123     50     25       O  
+ATOM    242  NE2AGLN A  53       6.970  12.597  33.482  0.50 16.52           N  
+ANISOU  242  NE2AGLN A  53     2142   2389   1746    103    126   -190       N  
+ATOM    243  CA BGLN A  53       8.631  10.871  29.855  0.50 10.20           C  
+ANISOU  243  CA BGLN A  53     1126   1391   1356    -31    197     24       C  
+ATOM    244  CB BGLN A  53       8.555  11.795  31.103  0.50 10.97           C  
+ANISOU  244  CB BGLN A  53     1225   1488   1455    -23    137    -36       C  
+ATOM    245  CG BGLN A  53       7.168  12.039  31.624  0.50 12.60           C  
+ANISOU  245  CG BGLN A  53     1475   1597   1713    -81    160   -113       C  
+ATOM    246  CD BGLN A  53       6.372  12.923  30.702  0.50 15.08           C  
+ANISOU  246  CD BGLN A  53     1855   2060   1814   -127    -70    -68       C  
+ATOM    247  OE1BGLN A  53       5.212  13.194  30.953  0.50 18.16           O  
+ANISOU  247  OE1BGLN A  53     2263   2335   2298     63    -59     27       O  
+ATOM    248  NE2BGLN A  53       6.994  13.365  29.614  0.50 15.75           N  
+ANISOU  248  NE2BGLN A  53     1764   2221   1999    113     59     -6       N  
+ATOM    249  N   TRP A  54      10.917  10.483  29.001  1.00  8.22           N  
+ANISOU  249  N   TRP A  54     1069   1044   1007   -103    204     72       N  
+ATOM    250  CA  TRP A  54      12.231  10.937  28.533  1.00  7.22           C  
+ANISOU  250  CA  TRP A  54      852   1016    874    -46    170     72       C  
+ATOM    251  C   TRP A  54      12.968   9.923  27.685  1.00  7.76           C  
+ANISOU  251  C   TRP A  54      958   1022    969    -77    137    107       C  
+ATOM    252  O   TRP A  54      12.985   8.727  28.006  1.00  7.63           O  
+ANISOU  252  O   TRP A  54      977   1052    868    -60    160     77       O  
+ATOM    253  CB  TRP A  54      13.105  11.343  29.725  1.00  8.45           C  
+ANISOU  253  CB  TRP A  54     1010   1191   1008    -44    212      7       C  
+ATOM    254  CG  TRP A  54      12.677  12.588  30.409  1.00  8.95           C  
+ANISOU  254  CG  TRP A  54     1141   1307    949   -148    186   -193       C  
+ATOM    255  CD1 TRP A  54      11.845  12.677  31.494  1.00  9.48           C  
+ANISOU  255  CD1 TRP A  54     1225   1188   1189   -101    147   -132       C  
+ATOM    256  CD2 TRP A  54      13.047  13.928  30.085  1.00  9.12           C  
+ANISOU  256  CD2 TRP A  54     1094   1268   1101    -91    162   -308       C  
+ATOM    257  NE1 TRP A  54      11.674  13.967  31.849  1.00 10.77           N  
+ANISOU  257  NE1 TRP A  54     1418   1413   1259    -82    378   -302       N  
+ATOM    258  CE2 TRP A  54      12.411  14.770  31.027  1.00  9.57           C  
+ANISOU  258  CE2 TRP A  54     1257   1265   1114    -36    165   -123       C  
+ATOM    259  CE3 TRP A  54      13.856  14.503  29.104  1.00  9.21           C  
+ANISOU  259  CE3 TRP A  54     1069   1396   1031    -37     50   -131       C  
+ATOM    260  CZ2 TRP A  54      12.559  16.150  31.012  1.00 10.77           C  
+ANISOU  260  CZ2 TRP A  54     1288   1493   1311      6    164   -254       C  
+ATOM    261  CZ3 TRP A  54      14.005  15.875  29.098  1.00  9.63           C  
+ANISOU  261  CZ3 TRP A  54     1162   1347   1148    -61    191   -200       C  
+ATOM    262  CH2 TRP A  54      13.373  16.688  30.058  1.00  9.64           C  
+ANISOU  262  CH2 TRP A  54     1326   1115   1220    -82     86   -212       C  
+ATOM    263  N   VAL A  55      13.573  10.445  26.616  1.00  6.94           N  
+ANISOU  263  N   VAL A  55      894    896    846     28    196     23       N  
+ATOM    264  CA  VAL A  55      14.401   9.710  25.699  1.00  6.77           C  
+ANISOU  264  CA  VAL A  55      827    853    890     -8     42     13       C  
+ATOM    265  C   VAL A  55      15.807  10.293  25.693  1.00  6.79           C  
+ANISOU  265  C   VAL A  55      856    847    874    -10    103     30       C  
+ATOM    266  O   VAL A  55      15.994  11.505  25.651  1.00  7.97           O  
+ANISOU  266  O   VAL A  55     1054    915   1059    -27     43    -76       O  
+ATOM    267  CB  VAL A  55      13.760   9.750  24.276  1.00  6.64           C  
+ANISOU  267  CB  VAL A  55      794    905    820     97    104     -9       C  
+ATOM    268  CG1 VAL A  55      14.722   9.292  23.214  1.00  7.80           C  
+ANISOU  268  CG1 VAL A  55      952   1100    910     64     84     33       C  
+ATOM    269  CG2 VAL A  55      12.470   8.953  24.255  1.00  8.13           C  
+ANISOU  269  CG2 VAL A  55      887   1128   1074   -115     26    139       C  
+ATOM    270  N   VAL A  56      16.792   9.391  25.649  1.00  6.69           N  
+ANISOU  270  N   VAL A  56      813   1016    712   -118     39     83       N  
+ATOM    271  CA  VAL A  56      18.192   9.779  25.424  1.00  7.59           C  
+ANISOU  271  CA  VAL A  56      871   1103    908   -131      7     -8       C  
+ATOM    272  C   VAL A  56      18.557   9.570  23.968  1.00  6.29           C  
+ANISOU  272  C   VAL A  56      747    835    807    -45     -1    -41       C  
+ATOM    273  O   VAL A  56      18.245   8.543  23.410  1.00  6.98           O  
+ANISOU  273  O   VAL A  56      879    914    859   -164    213    -41       O  
+ATOM    274  CB  VAL A  56      19.145   8.915  26.306  1.00  8.75           C  
+ANISOU  274  CB  VAL A  56      902   1561    858   -142    -19    100       C  
+ATOM    275  CG1 VAL A  56      20.637   9.061  25.886  1.00  9.79           C  
+ANISOU  275  CG1 VAL A  56      983   1393   1344     54    -44     47       C  
+ATOM    276  CG2 VAL A  56      18.995   9.269  27.754  1.00 11.21           C  
+ANISOU  276  CG2 VAL A  56     1355   1721   1182      4    -15    -18       C  
+ATOM    277  N   SER A  57      19.196  10.573  23.384  1.00  6.15           N  
+ANISOU  277  N   SER A  57      831    806    699     -9    -11    -32       N  
+ATOM    278  CA  SER A  57      19.702  10.480  22.010  1.00  5.53           C  
+ANISOU  278  CA  SER A  57      806    596    696    111    -81      6       C  
+ATOM    279  C   SER A  57      21.021  11.246  21.945  1.00  5.55           C  
+ANISOU  279  C   SER A  57      732    600    777    151     -3    -83       C  
+ATOM    280  O   SER A  57      21.646  11.548  22.978  1.00  5.84           O  
+ANISOU  280  O   SER A  57      710    789    717     -9    -10    -72       O  
+ATOM    281  CB  SER A  57      18.615  10.965  21.052  1.00  5.68           C  
+ANISOU  281  CB  SER A  57      671    616    868     31    -67    -77       C  
+ATOM    282  OG  SER A  57      18.984  10.769  19.687  1.00  5.99           O  
+ANISOU  282  OG  SER A  57      684    846    746     81     32     18       O  
+ATOM    283  N   ALA A  58      21.487  11.453  20.725  1.00  5.90           N  
+ANISOU  283  N   ALA A  58      822    682    737    -30    -98    -17       N  
+ATOM    284  CA  ALA A  58      22.735  12.199  20.471  1.00  5.01           C  
+ANISOU  284  CA  ALA A  58      631    633    638    -32    -51    -58       C  
+ATOM    285  C   ALA A  58      22.432  13.671  20.225  1.00  5.29           C  
+ANISOU  285  C   ALA A  58      674    643    691     30    -91     43       C  
+ATOM    286  O   ALA A  58      21.472  14.001  19.528  1.00  5.62           O  
+ANISOU  286  O   ALA A  58      686    650    800     84   -103     47       O  
+ATOM    287  CB  ALA A  58      23.443  11.608  19.268  1.00  6.13           C  
+ANISOU  287  CB  ALA A  58      877    714    738     13     10    -44       C  
+ATOM    288  N   ALA A  59      23.264  14.563  20.765  1.00  5.26           N  
+ANISOU  288  N   ALA A  59      690    631    678    103   -141      0       N  
+ATOM    289  CA  ALA A  59      23.123  15.992  20.497  1.00  5.43           C  
+ANISOU  289  CA  ALA A  59      648    657    757    136     -5      0       C  
+ATOM    290  C   ALA A  59      23.199  16.336  19.010  1.00  5.66           C  
+ANISOU  290  C   ALA A  59      642    579    929      6   -163    -98       C  
+ATOM    291  O   ALA A  59      22.498  17.260  18.584  1.00  6.04           O  
+ANISOU  291  O   ALA A  59      713    660    921    111    -89    -47       O  
+ATOM    292  CB  ALA A  59      24.130  16.781  21.298  1.00  6.41           C  
+ANISOU  292  CB  ALA A  59      741    778    914    -31    -22    -24       C  
+ATOM    293  N   HIS A  60      23.998  15.606  18.224  1.00  5.37           N  
+ANISOU  293  N   HIS A  60      711    610    720    132    -42     75       N  
+ATOM    294  CA  HIS A  60      24.096  15.929  16.817  1.00  6.27           C  
+ANISOU  294  CA  HIS A  60      767    707    906     53    -65     92       C  
+ATOM    295  C   HIS A  60      22.834  15.597  16.053  1.00  6.14           C  
+ANISOU  295  C   HIS A  60      949    565    816    -42    -16    -28       C  
+ATOM    296  O   HIS A  60      22.713  16.014  14.899  1.00  6.93           O  
+ANISOU  296  O   HIS A  60      991    786    855    153    -31    176       O  
+ATOM    297  CB  HIS A  60      25.330  15.312  16.171  1.00  6.50           C  
+ANISOU  297  CB  HIS A  60      803    809    857     -8     68    -74       C  
+ATOM    298  CG  HIS A  60      25.196  13.849  15.913  1.00  5.71           C  
+ANISOU  298  CG  HIS A  60      747    650    771    258     23    176       C  
+ATOM    299  ND1 HIS A  60      25.779  12.901  16.713  1.00  6.24           N  
+ANISOU  299  ND1 HIS A  60      826    786    758      9    -51      1       N  
+ATOM    300  CD2 HIS A  60      24.541  13.178  14.941  1.00  5.82           C  
+ANISOU  300  CD2 HIS A  60      725    657    827     77   -158      0       C  
+ATOM    301  CE1 HIS A  60      25.452  11.705  16.233  1.00  5.60           C  
+ANISOU  301  CE1 HIS A  60      842    619    664     85     -2     21       C  
+ATOM    302  NE2 HIS A  60      24.723  11.842  15.151  1.00  6.73           N  
+ANISOU  302  NE2 HIS A  60      918    697    941     29    -24      7       N  
+ATOM    303  N   CYS A  61      21.897  14.882  16.682  1.00  5.57           N  
+ANISOU  303  N   CYS A  61      885    467    762    -20   -185     86       N  
+ATOM    304  CA  CYS A  61      20.583  14.635  16.061  1.00  6.10           C  
+ANISOU  304  CA  CYS A  61      803    618    894    101   -228      7       C  
+ATOM    305  C   CYS A  61      19.593  15.751  16.278  1.00  7.37           C  
+ANISOU  305  C   CYS A  61      891    790   1116     91   -238    -63       C  
+ATOM    306  O   CYS A  61      18.482  15.660  15.777  1.00  8.37           O  
+ANISOU  306  O   CYS A  61      910    797   1473    191   -449   -205       O  
+ATOM    307  CB  CYS A  61      19.969  13.359  16.646  1.00  5.66           C  
+ANISOU  307  CB  CYS A  61      677    667    807    187   -122   -100       C  
+ATOM    308  SG  CYS A  61      20.829  11.806  16.235  1.00  6.13           S  
+ANISOU  308  SG  CYS A  61      789    658    881     80   -161    -41       S  
+ATOM    309  N   TYR A  62      19.972  16.788  17.012  1.00  6.74           N  
+ANISOU  309  N   TYR A  62      784    769   1008     70   -157   -118       N  
+ATOM    310  CA  TYR A  62      19.038  17.873  17.259  1.00  6.74           C  
+ANISOU  310  CA  TYR A  62      842    737    982     44      0    -50       C  
+ATOM    311  C   TYR A  62      18.508  18.474  15.960  1.00  6.81           C  
+ANISOU  311  C   TYR A  62      890    707    991     81   -143   -144       C  
+ATOM    312  O   TYR A  62      19.265  18.794  15.057  1.00  7.51           O  
+ANISOU  312  O   TYR A  62      923    851   1077    133   -146    -57       O  
+ATOM    313  CB  TYR A  62      19.721  18.973  18.073  1.00  6.89           C  
+ANISOU  313  CB  TYR A  62      841    809    968    137   -116    -77       C  
+ATOM    314  CG  TYR A  62      18.770  20.122  18.329  1.00  6.70           C  
+ANISOU  314  CG  TYR A  62      810    730   1003     58    -76    -60       C  
+ATOM    315  CD1 TYR A  62      17.887  20.070  19.383  1.00  7.68           C  
+ANISOU  315  CD1 TYR A  62     1044    754   1118     10    -23    -67       C  
+ATOM    316  CD2 TYR A  62      18.700  21.223  17.479  1.00  7.44           C  
+ANISOU  316  CD2 TYR A  62      915    790   1120     76     36   -119       C  
+ATOM    317  CE1 TYR A  62      16.941  21.093  19.579  1.00  7.48           C  
+ANISOU  317  CE1 TYR A  62     1069    725   1049     48    197    -25       C  
+ATOM    318  CE2 TYR A  62      17.760  22.239  17.687  1.00  8.43           C  
+ANISOU  318  CE2 TYR A  62     1237    700   1263    257    208     39       C  
+ATOM    319  CZ  TYR A  62      16.920  22.157  18.734  1.00  7.44           C  
+ANISOU  319  CZ  TYR A  62      960    743   1122    104    115    -16       C  
+ATOM    320  OH  TYR A  62      15.958  23.082  18.961  1.00  9.54           O  
+ANISOU  320  OH  TYR A  62     1169    806   1649    273    332    -24       O  
+ATOM    321  N   LYS A  63      17.210  18.698  15.912  1.00  7.42           N  
+ANISOU  321  N   LYS A  63     1020    779   1016     85   -199   -143       N  
+ATOM    322  CA  LYS A  63      16.571  19.490  14.854  1.00  7.68           C  
+ANISOU  322  CA  LYS A  63     1066    809   1041     88   -274     -5       C  
+ATOM    323  C   LYS A  63      15.213  19.874  15.381  1.00  8.34           C  
+ANISOU  323  C   LYS A  63     1088    881   1199     91   -306    -35       C  
+ATOM    324  O   LYS A  63      14.761  19.378  16.416  1.00  8.71           O  
+ANISOU  324  O   LYS A  63     1085   1066   1156    243   -319   -175       O  
+ATOM    325  CB  LYS A  63      16.428  18.737  13.532  1.00  7.72           C  
+ANISOU  325  CB  LYS A  63      948    865   1117    184   -245     75       C  
+ATOM    326  CG  LYS A  63      15.441  17.568  13.560  1.00  7.48           C  
+ANISOU  326  CG  LYS A  63     1002    654   1186    209    -77     85       C  
+ATOM    327  CD  LYS A  63      15.371  16.789  12.249  1.00  8.52           C  
+ANISOU  327  CD  LYS A  63     1065    958   1215    186   -326   -121       C  
+ATOM    328  CE  LYS A  63      15.079  17.661  10.996  1.00  8.81           C  
+ANISOU  328  CE  LYS A  63     1131    964   1251     53   -216   -186       C  
+ATOM    329  NZ  LYS A  63      13.781  18.430  11.107  1.00  8.64           N  
+ANISOU  329  NZ  LYS A  63     1023    942   1315    108   -171    -61       N  
+ATOM    330  N   SER A  64      14.548  20.781  14.672  1.00  8.94           N  
+ANISOU  330  N   SER A  64     1032    986   1378    140   -336      3       N  
+ATOM    331  CA  SER A  64      13.162  21.130  14.927  1.00  9.35           C  
+ANISOU  331  CA  SER A  64     1132   1011   1409     95   -287    -37       C  
+ATOM    332  C   SER A  64      12.228  20.035  14.417  1.00  8.75           C  
+ANISOU  332  C   SER A  64     1020    899   1404    238   -237    -49       C  
+ATOM    333  O   SER A  64      12.470  19.418  13.404  1.00  8.92           O  
+ANISOU  333  O   SER A  64     1096    888   1405    102   -262    -81       O  
+ATOM    334  CB  SER A  64      12.780  22.473  14.253  1.00  8.88           C  
+ANISOU  334  CB  SER A  64     1051    883   1439    100   -316   -145       C  
+ATOM    335  OG  SER A  64      13.338  23.554  14.997  1.00 11.34           O  
+ANISOU  335  OG  SER A  64     1319   1041   1948    131   -426   -260       O  
+ATOM    336  N   GLY A  65      11.116  19.863  15.107  1.00  8.24           N  
+ANISOU  336  N   GLY A  65     1098    796   1234     46   -177     91       N  
+ATOM    337  CA  GLY A  65      10.016  19.072  14.579  1.00  8.43           C  
+ANISOU  337  CA  GLY A  65     1048    878   1278     50   -188     54       C  
+ATOM    338  C   GLY A  65      10.224  17.580  14.711  1.00  8.68           C  
+ANISOU  338  C   GLY A  65     1223    861   1214     -8   -180     23       C  
+ATOM    339  O   GLY A  65      10.140  16.844  13.713  1.00  8.89           O  
+ANISOU  339  O   GLY A  65     1376    963   1038     88   -129     38       O  
+ATOM    340  N   ILE A  66      10.465  17.131  15.936  1.00  7.53           N  
+ANISOU  340  N   ILE A  66     1103    782    975    107     36    -65       N  
+ATOM    341  CA  ILE A  66      10.727  15.713  16.182  1.00  8.39           C  
+ANISOU  341  CA  ILE A  66     1138    940   1110    178      9      5       C  
+ATOM    342  C   ILE A  66       9.497  15.032  16.755  1.00  8.12           C  
+ANISOU  342  C   ILE A  66     1105   1003    976    127      8      9       C  
+ATOM    343  O   ILE A  66       8.910  15.504  17.734  1.00  8.83           O  
+ANISOU  343  O   ILE A  66     1203   1033   1119    231     63   -126       O  
+ATOM    344  CB  ILE A  66      11.902  15.538  17.176  1.00  8.12           C  
+ANISOU  344  CB  ILE A  66     1074    954   1055    189    -20     17       C  
+ATOM    345  CG1 ILE A  66      13.175  16.147  16.582  1.00  9.24           C  
+ANISOU  345  CG1 ILE A  66     1168   1186   1155    153    -36    160       C  
+ATOM    346  CG2 ILE A  66      12.113  14.047  17.499  1.00  9.57           C  
+ANISOU  346  CG2 ILE A  66     1303    958   1372    168    -94    117       C  
+ATOM    347  CD1 ILE A  66      14.414  16.053  17.474  1.00 10.62           C  
+ANISOU  347  CD1 ILE A  66     1171   1270   1593    135   -125    142       C  
+ATOM    348  N   GLN A  67       9.143  13.906  16.152  1.00  7.94           N  
+ANISOU  348  N   GLN A  67     1041   1004    969    156     40    -40       N  
+ATOM    349  CA  GLN A  67       8.167  12.979  16.681  1.00  8.52           C  
+ANISOU  349  CA  GLN A  67     1047   1048   1142    174     60    -12       C  
+ATOM    350  C   GLN A  67       8.899  11.721  17.099  1.00  8.18           C  
+ANISOU  350  C   GLN A  67     1016   1023   1068    105     64     40       C  
+ATOM    351  O   GLN A  67       9.680  11.146  16.353  1.00  9.28           O  
+ANISOU  351  O   GLN A  67     1301   1074   1149    297    198    153       O  
+ATOM    352  CB  GLN A  67       7.089  12.653  15.652  1.00  8.91           C  
+ANISOU  352  CB  GLN A  67     1154   1045   1183    122     77     37       C  
+ATOM    353  CG  GLN A  67       6.011  11.756  16.212  1.00 10.81           C  
+ANISOU  353  CG  GLN A  67     1210   1473   1423     66     -2    157       C  
+ATOM    354  CD  GLN A  67       4.980  11.346  15.189  1.00 11.56           C  
+ANISOU  354  CD  GLN A  67     1344   1370   1676    113    -52    143       C  
+ATOM    355  OE1 GLN A  67       5.305  10.692  14.192  1.00 12.06           O  
+ANISOU  355  OE1 GLN A  67     1437   1608   1535    318   -163    262       O  
+ATOM    356  NE2 GLN A  67       3.734  11.755  15.406  1.00 12.33           N  
+ANISOU  356  NE2 GLN A  67     1132   1526   2024    107   -119    382       N  
+ATOM    357  N   VAL A  68       8.640  11.302  18.325  1.00  7.64           N  
+ANISOU  357  N   VAL A  68      859    878   1166    154    144    118       N  
+ATOM    358  CA  VAL A  68       9.182  10.046  18.856  1.00  7.34           C  
+ANISOU  358  CA  VAL A  68      760    943   1085     23    103     71       C  
+ATOM    359  C   VAL A  68       8.236   8.923  18.531  1.00  6.99           C  
+ANISOU  359  C   VAL A  68      723    943    988      4     69    133       C  
+ATOM    360  O   VAL A  68       7.046   9.007  18.780  1.00  7.85           O  
+ANISOU  360  O   VAL A  68      803    984   1194     -2    138    -43       O  
+ATOM    361  CB  VAL A  68       9.417  10.153  20.361  1.00  7.81           C  
+ANISOU  361  CB  VAL A  68      771    994   1203     29     17    108       C  
+ATOM    362  CG1 VAL A  68       9.983   8.850  20.902  1.00 10.33           C  
+ANISOU  362  CG1 VAL A  68     1447   1173   1303   -154   -296    261       C  
+ATOM    363  CG2 VAL A  68      10.358  11.362  20.688  1.00  8.67           C  
+ANISOU  363  CG2 VAL A  68      970   1119   1205   -123    111   -117       C  
+ATOM    364  N   ARG A  69       8.784   7.850  17.973  1.00  7.36           N  
+ANISOU  364  N   ARG A  69      709    921   1166    -81     13     56       N  
+ATOM    365  CA  ARG A  69       8.012   6.655  17.632  1.00  6.93           C  
+ANISOU  365  CA  ARG A  69      593    936   1103    -24     12    115       C  
+ATOM    366  C   ARG A  69       8.540   5.485  18.429  1.00  7.51           C  
+ANISOU  366  C   ARG A  69      741   1038   1073     -3    -89    127       C  
+ATOM    367  O   ARG A  69       9.676   5.035  18.249  1.00  6.55           O  
+ANISOU  367  O   ARG A  69      604    838   1044    110     72    124       O  
+ATOM    368  CB  ARG A  69       8.032   6.376  16.131  1.00  7.33           C  
+ANISOU  368  CB  ARG A  69      646    886   1253    -44    101    135       C  
+ATOM    369  CG  ARG A  69       7.423   7.543  15.351  1.00  7.70           C  
+ANISOU  369  CG  ARG A  69      679   1000   1246    170     16    205       C  
+ATOM    370  CD  ARG A  69       7.280   7.254  13.888  1.00  8.90           C  
+ANISOU  370  CD  ARG A  69      899   1247   1234     33    -21    268       C  
+ATOM    371  NE  ARG A  69       6.492   8.320  13.290  1.00  9.23           N  
+ANISOU  371  NE  ARG A  69     1031   1177   1298    152    -43    217       N  
+ATOM    372  CZ  ARG A  69       5.864   8.204  12.135  1.00 10.74           C  
+ANISOU  372  CZ  ARG A  69     1188   1597   1293     92     26    315       C  
+ATOM    373  NH1 ARG A  69       6.058   7.172  11.335  1.00 10.90           N  
+ANISOU  373  NH1 ARG A  69     1242   1757   1140    273   -260    304       N  
+ATOM    374  NH2 ARG A  69       5.046   9.168  11.761  1.00 11.98           N  
+ANISOU  374  NH2 ARG A  69     1445   1689   1418    539    -19    286       N  
+ATOM    375  N   LEU A  70       7.722   5.056  19.376  1.00  7.15           N  
+ANISOU  375  N   LEU A  70      657    957   1103     46     18    134       N  
+ATOM    376  C   LEU A  70       7.300   2.714  19.801  1.00  7.27           C  
+ANISOU  376  C   LEU A  70      714   1005   1040    -19     46    144       C  
+ATOM    377  O   LEU A  70       6.332   2.801  19.041  1.00  7.05           O  
+ANISOU  377  O   LEU A  70      671    933   1074    -53    -62     97       O  
+ATOM    378  CA ALEU A  70       8.011   3.951  20.298  0.50  7.09           C  
+ANISOU  378  CA ALEU A  70      725    990    978     12     -5    101       C  
+ATOM    379  CB ALEU A  70       7.497   4.271  21.717  0.50  7.51           C  
+ANISOU  379  CB ALEU A  70      786    998   1066    -40    -19     51       C  
+ATOM    380  CG ALEU A  70       7.923   5.588  22.371  0.50  8.20           C  
+ANISOU  380  CG ALEU A  70     1082   1081    950    -77      8     11       C  
+ATOM    381  CD1ALEU A  70       7.323   5.717  23.784  0.50 10.62           C  
+ANISOU  381  CD1ALEU A  70     1563   1545    927     -5     18     66       C  
+ATOM    382  CD2ALEU A  70       9.440   5.696  22.430  0.50 10.33           C  
+ANISOU  382  CD2ALEU A  70     1213   1547   1161     48    -54    134       C  
+ATOM    383  CA BLEU A  70       8.018   3.955  20.281  0.50  6.83           C  
+ANISOU  383  CA BLEU A  70      665    952    976     30     -5     95       C  
+ATOM    384  CB BLEU A  70       7.541   4.329  21.687  0.50  6.99           C  
+ANISOU  384  CB BLEU A  70      673    898   1083    -19      2     48       C  
+ATOM    385  CG BLEU A  70       8.086   5.685  22.156  0.50  6.48           C  
+ANISOU  385  CG BLEU A  70      656    833    972     65    -61      0       C  
+ATOM    386  CD1BLEU A  70       7.068   6.855  21.990  0.50  7.48           C  
+ANISOU  386  CD1BLEU A  70      758    971   1112     -9    100    -69       C  
+ATOM    387  CD2BLEU A  70       8.573   5.533  23.592  0.50  6.96           C  
+ANISOU  387  CD2BLEU A  70      547    723   1373    160    136    122       C  
+ATOM    388  N   GLY A  71       7.761   1.539  20.219  1.00  7.10           N  
+ANISOU  388  N   GLY A  71      665    971   1059   -108    -64    163       N  
+ATOM    389  CA  GLY A  71       7.069   0.310  19.875  1.00  7.60           C  
+ANISOU  389  CA  GLY A  71      826    970   1092    -81      0    157       C  
+ATOM    390  C   GLY A  71       7.179  -0.099  18.436  1.00  7.55           C  
+ANISOU  390  C   GLY A  71      818    978   1073    -26    -34    158       C  
+ATOM    391  O   GLY A  71       6.409  -0.932  17.969  1.00  8.07           O  
+ANISOU  391  O   GLY A  71      841    999   1224   -210    -46     62       O  
+ATOM    392  N   GLU A  72       8.136   0.467  17.708  1.00  6.87           N  
+ANISOU  392  N   GLU A  72      733    908    968    -80     -8     82       N  
+ATOM    393  CA  GLU A  72       8.297   0.147  16.286  1.00  6.92           C  
+ANISOU  393  CA  GLU A  72      728    906    994    -13   -135     16       C  
+ATOM    394  C   GLU A  72       9.096  -1.115  16.069  1.00  6.99           C  
+ANISOU  394  C   GLU A  72      776    896    984    -52    -16     75       C  
+ATOM    395  O   GLU A  72      10.045  -1.413  16.798  1.00  7.60           O  
+ANISOU  395  O   GLU A  72      806    930   1151    -34   -153    130       O  
+ATOM    396  CB  GLU A  72       9.035   1.278  15.570  1.00  7.23           C  
+ANISOU  396  CB  GLU A  72      876    881    987    -25    -16    -44       C  
+ATOM    397  CG  GLU A  72       8.200   2.497  15.322  1.00  7.40           C  
+ANISOU  397  CG  GLU A  72      812    972   1027     19    -94    139       C  
+ATOM    398  CD  GLU A  72       7.283   2.373  14.122  1.00  9.10           C  
+ANISOU  398  CD  GLU A  72     1047   1111   1298   -148   -250    112       C  
+ATOM    399  OE1 GLU A  72       6.993   1.220  13.723  1.00  9.19           O  
+ANISOU  399  OE1 GLU A  72     1043   1133   1313    -27   -234    269       O  
+ATOM    400  OE2 GLU A  72       6.838   3.412  13.604  1.00  9.65           O  
+ANISOU  400  OE2 GLU A  72     1146   1013   1506     79   -290    465       O  
+ATOM    401  N   ASP A  73       8.716  -1.852  15.025  1.00  7.18           N  
+ANISOU  401  N   ASP A  73      781    803   1143    -18   -118      4       N  
+ATOM    402  CA  ASP A  73       9.598  -2.812  14.394  1.00  6.91           C  
+ANISOU  402  CA  ASP A  73      786    849    987    -36   -147     71       C  
+ATOM    403  C   ASP A  73       9.798  -2.412  12.962  1.00  7.33           C  
+ANISOU  403  C   ASP A  73      816    898   1070    -20   -107     91       C  
+ATOM    404  O   ASP A  73      10.810  -1.827  12.646  1.00  8.96           O  
+ANISOU  404  O   ASP A  73      932   1231   1239   -239   -230    100       O  
+ATOM    405  CB  ASP A  73       9.153  -4.262  14.554  1.00  7.29           C  
+ANISOU  405  CB  ASP A  73      863    959    947    -10   -127    117       C  
+ATOM    406  CG  ASP A  73      10.222  -5.218  14.085  1.00  8.75           C  
+ANISOU  406  CG  ASP A  73      986   1143   1197    100   -156    145       C  
+ATOM    407  OD1 ASP A  73      11.418  -4.980  14.421  1.00  8.16           O  
+ANISOU  407  OD1 ASP A  73      852    948   1299    -13   -140    -16       O  
+ATOM    408  OD2 ASP A  73       9.892  -6.168  13.360  1.00  9.73           O  
+ANISOU  408  OD2 ASP A  73      993   1232   1470     13   -150   -112       O  
+ATOM    409  N   ASN A  74       8.821  -2.673  12.108  1.00  7.40           N  
+ANISOU  409  N   ASN A  74      789    933   1090    -94   -215     45       N  
+ATOM    410  CA  ASN A  74       8.833  -2.158  10.754  1.00  8.28           C  
+ANISOU  410  CA  ASN A  74      916   1046   1183    -70   -106      1       C  
+ATOM    411  C   ASN A  74       8.426  -0.679  10.799  1.00  8.44           C  
+ANISOU  411  C   ASN A  74     1019   1111   1076    -87   -222     48       C  
+ATOM    412  O   ASN A  74       7.281  -0.340  11.094  1.00  9.38           O  
+ANISOU  412  O   ASN A  74     1106   1184   1272    -80   -369     47       O  
+ATOM    413  CB  ASN A  74       7.880  -2.938   9.868  1.00  8.30           C  
+ANISOU  413  CB  ASN A  74     1002    907   1243   -157   -157     12       C  
+ATOM    414  CG  ASN A  74       8.018  -2.588   8.416  1.00  8.14           C  
+ANISOU  414  CG  ASN A  74      979    956   1157    -50   -161    -13       C  
+ATOM    415  OD1 ASN A  74       8.322  -1.466   8.065  1.00 10.32           O  
+ANISOU  415  OD1 ASN A  74     1536   1080   1304   -132   -404     39       O  
+ATOM    416  ND2 ASN A  74       7.793  -3.563   7.548  1.00 10.38           N  
+ANISOU  416  ND2 ASN A  74     1380   1250   1311   -342   -192   -128       N  
+ATOM    417  N   ILE A  75       9.378   0.222  10.564  1.00  8.62           N  
+ANISOU  417  N   ILE A  75     1121   1005   1148    -48   -241    104       N  
+ATOM    418  CA  ILE A  75       9.088   1.672  10.638  1.00  9.05           C  
+ANISOU  418  CA  ILE A  75     1286    990   1162   -123   -200    143       C  
+ATOM    419  C   ILE A  75       8.319   2.173   9.432  1.00 10.27           C  
+ANISOU  419  C   ILE A  75     1509   1204   1187    -23   -258    108       C  
+ATOM    420  O   ILE A  75       7.906   3.312   9.421  1.00 11.17           O  
+ANISOU  420  O   ILE A  75     1613   1235   1393    -22   -390    132       O  
+ATOM    421  CB  ILE A  75      10.323   2.524  10.876  1.00  9.51           C  
+ANISOU  421  CB  ILE A  75     1329   1111   1172    -56    -82     87       C  
+ATOM    422  CG1 ILE A  75      11.434   2.188   9.889  1.00  9.90           C  
+ANISOU  422  CG1 ILE A  75     1294   1082   1385   -141    -80    -99       C  
+ATOM    423  CG2 ILE A  75      10.804   2.373  12.333  1.00 10.63           C  
+ANISOU  423  CG2 ILE A  75     1153   1512   1373     38   -352    261       C  
+ATOM    424  CD1 ILE A  75      12.518   3.279   9.826  1.00 11.17           C  
+ANISOU  424  CD1 ILE A  75     1579   1161   1500   -388    153   -135       C  
+ATOM    425  N   ASN A  76       8.108   1.307   8.444  1.00 10.60           N  
+ANISOU  425  N   ASN A  76     1673   1133   1219   -103   -375    102       N  
+ATOM    426  CA  ASN A  76       7.321   1.653   7.248  1.00 12.25           C  
+ANISOU  426  CA  ASN A  76     1823   1540   1290     25   -296    148       C  
+ATOM    427  C   ASN A  76       5.959   0.996   7.195  1.00 12.71           C  
+ANISOU  427  C   ASN A  76     1806   1735   1288      4   -359     45       C  
+ATOM    428  O   ASN A  76       5.217   1.215   6.227  1.00 14.21           O  
+ANISOU  428  O   ASN A  76     1977   2239   1182     21   -574    192       O  
+ATOM    429  CB  ASN A  76       8.133   1.298   6.006  1.00 13.01           C  
+ANISOU  429  CB  ASN A  76     1898   1646   1399    -58   -320    143       C  
+ATOM    430  CG  ASN A  76       9.406   2.068   5.923  1.00 14.84           C  
+ANISOU  430  CG  ASN A  76     2165   1890   1581      0   -320    357       C  
+ATOM    431  OD1 ASN A  76      10.490   1.518   5.669  1.00 18.62           O  
+ANISOU  431  OD1 ASN A  76     2284   2722   2069   -126   -343    409       O  
+ATOM    432  ND2 ASN A  76       9.286   3.353   6.124  1.00 16.76           N  
+ANISOU  432  ND2 ASN A  76     2524   1954   1889   -266   -252    135       N  
+ATOM    433  N   VAL A  77       5.572   0.249   8.219  1.00 11.31           N  
+ANISOU  433  N   VAL A  77     1466   1608   1223      7   -460    -61       N  
+ATOM    434  CA  VAL A  77       4.257  -0.377   8.309  1.00 11.28           C  
+ANISOU  434  CA  VAL A  77     1418   1566   1302     65   -410   -109       C  
+ATOM    435  C   VAL A  77       3.728  -0.227   9.723  1.00 10.57           C  
+ANISOU  435  C   VAL A  77     1309   1352   1355     -1   -408    -80       C  
+ATOM    436  O   VAL A  77       4.454  -0.447  10.698  1.00  9.95           O  
+ANISOU  436  O   VAL A  77     1152   1145   1481     69   -478    -45       O  
+ATOM    437  CB  VAL A  77       4.365  -1.904   7.971  1.00 11.57           C  
+ANISOU  437  CB  VAL A  77     1340   1657   1398    -60   -428   -209       C  
+ATOM    438  CG1 VAL A  77       3.012  -2.597   8.208  1.00 12.96           C  
+ANISOU  438  CG1 VAL A  77     1359   1613   1950    -55   -262   -362       C  
+ATOM    439  CG2 VAL A  77       4.890  -2.098   6.555  1.00 13.83           C  
+ANISOU  439  CG2 VAL A  77     1576   2052   1627     34   -277   -203       C  
+ATOM    440  N   VAL A  78       2.459   0.165   9.827  1.00 11.81           N  
+ANISOU  440  N   VAL A  78     1381   1543   1562    200   -374      9       N  
+ATOM    441  CA  VAL A  78       1.763   0.169  11.097  1.00 12.73           C  
+ANISOU  441  CA  VAL A  78     1456   1674   1705    262   -343     14       C  
+ATOM    442  C   VAL A  78       1.422  -1.224  11.510  1.00 12.67           C  
+ANISOU  442  C   VAL A  78     1387   1607   1821     88   -301    -98       C  
+ATOM    443  O   VAL A  78       0.599  -1.904  10.869  1.00 14.63           O  
+ANISOU  443  O   VAL A  78     1495   1993   2071    -13   -489   -188       O  
+ATOM    444  CB  VAL A  78       0.513   1.068  11.040  1.00 14.28           C  
+ANISOU  444  CB  VAL A  78     1717   1810   1896    430   -278     87       C  
+ATOM    445  CG1 VAL A  78      -0.347   0.921  12.297  1.00 17.42           C  
+ANISOU  445  CG1 VAL A  78     2088   2323   2207    576   -120    163       C  
+ATOM    446  CG2 VAL A  78       0.969   2.515  10.839  1.00 16.04           C  
+ANISOU  446  CG2 VAL A  78     2327   1949   1817    302   -214    -77       C  
+ATOM    447  N   GLU A  79       2.046  -1.678  12.588  1.00 12.16           N  
+ANISOU  447  N   GLU A  79     1253   1448   1916    -60   -239    -66       N  
+ATOM    448  CA  GLU A  79       1.863  -3.034  13.054  1.00 12.01           C  
+ANISOU  448  CA  GLU A  79     1239   1279   2046   -104   -142   -130       C  
+ATOM    449  C   GLU A  79       1.024  -3.117  14.333  1.00 13.46           C  
+ANISOU  449  C   GLU A  79     1434   1491   2187    -87     20    -45       C  
+ATOM    450  O   GLU A  79       0.601  -4.202  14.709  1.00 16.54           O  
+ANISOU  450  O   GLU A  79     1840   1654   2790   -252    311    -58       O  
+ATOM    451  CB  GLU A  79       3.202  -3.721  13.244  1.00 11.31           C  
+ANISOU  451  CB  GLU A  79     1112   1233   1950    -84   -101   -102       C  
+ATOM    452  CG  GLU A  79       3.976  -3.875  11.942  1.00 10.63           C  
+ANISOU  452  CG  GLU A  79     1171   1049   1818   -197   -248    -50       C  
+ATOM    453  CD  GLU A  79       5.313  -4.559  12.124  1.00 12.25           C  
+ANISOU  453  CD  GLU A  79     1227   1172   2255     45   -269   -106       C  
+ATOM    454  OE1 GLU A  79       6.246  -3.917  12.611  1.00 10.54           O  
+ANISOU  454  OE1 GLU A  79     1036   1249   1719   -123   -125    175       O  
+ATOM    455  OE2 GLU A  79       5.422  -5.741  11.771  1.00 17.01           O  
+ANISOU  455  OE2 GLU A  79     1698   1552   3213     25   -639   -535       O  
+ATOM    456  N   GLY A  80       0.748  -1.987  14.959  1.00 11.95           N  
+ANISOU  456  N   GLY A  80     1283   1493   1764   -141    -41    -49       N  
+ATOM    457  CA  GLY A  80      -0.176  -1.899  16.090  1.00 12.53           C  
+ANISOU  457  CA  GLY A  80     1303   1657   1797   -171     40     46       C  
+ATOM    458  C   GLY A  80       0.405  -1.665  17.475  1.00 12.00           C  
+ANISOU  458  C   GLY A  80     1200   1563   1795   -158     26     77       C  
+ATOM    459  O   GLY A  80      -0.334  -1.492  18.446  1.00 12.81           O  
+ANISOU  459  O   GLY A  80     1238   1691   1936   -136     43    -34       O  
+ATOM    460  N   ASN A  81       1.725  -1.682  17.591  1.00 11.64           N  
+ANISOU  460  N   ASN A  81     1208   1420   1793   -187    -35    134       N  
+ATOM    461  CA  ASN A  81       2.357  -1.455  18.883  1.00 11.21           C  
+ANISOU  461  CA  ASN A  81     1225   1456   1579   -101    -19    120       C  
+ATOM    462  C   ASN A  81       3.014  -0.111  18.963  1.00  9.78           C  
+ANISOU  462  C   ASN A  81     1064   1252   1400   -116    -82    196       C  
+ATOM    463  O   ASN A  81       3.589   0.236  19.992  1.00 10.17           O  
+ANISOU  463  O   ASN A  81     1109   1451   1303   -112      2    179       O  
+ATOM    464  CB  ASN A  81       3.338  -2.588  19.192  1.00 12.43           C  
+ANISOU  464  CB  ASN A  81     1573   1445   1702    -82      4    128       C  
+ATOM    465  CG  ASN A  81       2.624  -3.909  19.329  1.00 15.15           C  
+ANISOU  465  CG  ASN A  81     1835   1739   2180    -74    149    125       C  
+ATOM    466  OD1 ASN A  81       2.885  -4.852  18.572  1.00 17.82           O  
+ANISOU  466  OD1 ASN A  81     2118   1998   2654    138     34    -29       O  
+ATOM    467  ND2 ASN A  81       1.678  -3.963  20.252  1.00 14.76           N  
+ANISOU  467  ND2 ASN A  81     1908   1320   2379   -179    194    375       N  
+ATOM    468  N   GLU A  82       2.886   0.678  17.901  1.00  9.10           N  
+ANISOU  468  N   GLU A  82      971   1186   1299     36   -146    169       N  
+ATOM    469  CA  GLU A  82       3.503   2.001  17.879  1.00  8.47           C  
+ANISOU  469  CA  GLU A  82      754   1068   1393    -76   -124     54       C  
+ATOM    470  C   GLU A  82       2.821   2.953  18.827  1.00  8.82           C  
+ANISOU  470  C   GLU A  82      751   1050   1548     29    -52     16       C  
+ATOM    471  O   GLU A  82       1.614   2.928  18.965  1.00 11.11           O  
+ANISOU  471  O   GLU A  82      734   1504   1981     53     39   -191       O  
+ATOM    472  CB  GLU A  82       3.464   2.612  16.483  1.00  9.24           C  
+ANISOU  472  CB  GLU A  82      992   1103   1413   -122   -173     48       C  
+ATOM    473  CG  GLU A  82       4.194   1.831  15.387  1.00  9.30           C  
+ANISOU  473  CG  GLU A  82     1043   1041   1450   -200   -148    140       C  
+ATOM    474  CD  GLU A  82       3.363   0.762  14.670  1.00 10.21           C  
+ANISOU  474  CD  GLU A  82     1043   1288   1544      9   -156    133       C  
+ATOM    475  OE1 GLU A  82       2.237   0.453  15.087  1.00 10.69           O  
+ANISOU  475  OE1 GLU A  82     1131   1400   1531   -205   -330     68       O  
+ATOM    476  OE2 GLU A  82       3.877   0.250  13.655  1.00 10.01           O  
+ANISOU  476  OE2 GLU A  82     1130   1196   1476     69   -251    122       O  
+ATOM    477  N   GLN A  83       3.613   3.805  19.431  1.00  8.23           N  
+ANISOU  477  N   GLN A  83      650   1046   1431     20     -2     54       N  
+ATOM    478  CA  GLN A  83       3.121   5.005  20.103  1.00  8.29           C  
+ANISOU  478  CA  GLN A  83      752   1048   1347     70      8     86       C  
+ATOM    479  C   GLN A  83       3.829   6.174  19.452  1.00  8.42           C  
+ANISOU  479  C   GLN A  83      764   1025   1409     21     25      5       C  
+ATOM    480  O   GLN A  83       5.047   6.176  19.303  1.00  9.84           O  
+ANISOU  480  O   GLN A  83      686   1234   1816    117    106    291       O  
+ATOM    481  CB  GLN A  83       3.359   4.976  21.624  1.00  8.22           C  
+ANISOU  481  CB  GLN A  83      807    949   1366     42     48     31       C  
+ATOM    482  CG  GLN A  83       2.760   3.759  22.286  1.00  9.65           C  
+ANISOU  482  CG  GLN A  83     1042   1195   1429    -70     -6     78       C  
+ATOM    483  CD  GLN A  83       2.948   3.697  23.781  1.00 10.26           C  
+ANISOU  483  CD  GLN A  83     1032   1446   1417    -89     35     23       C  
+ATOM    484  OE1 GLN A  83       3.086   4.712  24.452  1.00 11.75           O  
+ANISOU  484  OE1 GLN A  83     1582   1646   1236   -248     28     71       O  
+ATOM    485  NE2 GLN A  83       2.980   2.487  24.309  1.00 11.80           N  
+ANISOU  485  NE2 GLN A  83     1307   1380   1794   -122    -63    211       N  
+ATOM    486  N   PHE A  84       3.047   7.157  19.031  1.00  7.78           N  
+ANISOU  486  N   PHE A  84      689   1058   1208    154     46     91       N  
+ATOM    487  CA  PHE A  84       3.546   8.332  18.289  1.00  9.10           C  
+ANISOU  487  CA  PHE A  84      887   1139   1431     52     80      2       C  
+ATOM    488  C   PHE A  84       3.382   9.512  19.239  1.00  8.44           C  
+ANISOU  488  C   PHE A  84      825   1011   1370     50    -22    -29       C  
+ATOM    489  O   PHE A  84       2.255   9.886  19.581  1.00  9.12           O  
+ANISOU  489  O   PHE A  84      802    948   1713     93     17   -172       O  
+ATOM    490  CB  PHE A  84       2.695   8.572  17.014  1.00  9.46           C  
+ANISOU  490  CB  PHE A  84     1208   1109   1278    117     18     79       C  
+ATOM    491  CG  PHE A  84       2.556   7.361  16.078  1.00 11.52           C  
+ANISOU  491  CG  PHE A  84     1373   1485   1518    219    -44    139       C  
+ATOM    492  CD1 PHE A  84       3.429   7.228  15.036  1.00 12.72           C  
+ANISOU  492  CD1 PHE A  84     1250   1767   1816   -187    234    111       C  
+ATOM    493  CD2 PHE A  84       1.535   6.391  16.239  1.00 11.72           C  
+ANISOU  493  CD2 PHE A  84     1382   1586   1483     81   -125     -6       C  
+ATOM    494  CE1 PHE A  84       3.378   6.128  14.144  1.00 11.91           C  
+ANISOU  494  CE1 PHE A  84     1617   1555   1352    151    -26     55       C  
+ATOM    495  CE2 PHE A  84       1.412   5.306  15.377  1.00 11.12           C  
+ANISOU  495  CE2 PHE A  84     1448   1425   1351     27   -237     57       C  
+ATOM    496  CZ  PHE A  84       2.353   5.148  14.329  1.00 11.25           C  
+ANISOU  496  CZ  PHE A  84     1492   1471   1308     53   -171    -84       C  
+ATOM    497  N   ILE A  85       4.487  10.125  19.654  1.00  8.34           N  
+ANISOU  497  N   ILE A  85      734   1185   1247     16     97    -59       N  
+ATOM    498  CA  ILE A  85       4.423  11.174  20.664  1.00  9.04           C  
+ANISOU  498  CA  ILE A  85      857   1264   1312    -10     47     -7       C  
+ATOM    499  C   ILE A  85       5.374  12.277  20.262  1.00  8.51           C  
+ANISOU  499  C   ILE A  85      914   1039   1280     14      4    -32       C  
+ATOM    500  O   ILE A  85       6.538  12.027  20.004  1.00  9.02           O  
+ANISOU  500  O   ILE A  85      891   1107   1429     54    166    -86       O  
+ATOM    501  CB  ILE A  85       4.785  10.634  22.069  1.00  9.84           C  
+ANISOU  501  CB  ILE A  85      960   1374   1403   -163     63      5       C  
+ATOM    502  CG1 ILE A  85       3.899   9.454  22.486  1.00 11.25           C  
+ANISOU  502  CG1 ILE A  85     1283   1440   1549    -61     19    110       C  
+ATOM    503  CG2 ILE A  85       4.692  11.772  23.073  1.00 12.28           C  
+ANISOU  503  CG2 ILE A  85     1482   1730   1452   -245    109    -34       C  
+ATOM    504  CD1 ILE A  85       4.300   8.782  23.808  1.00 12.47           C  
+ANISOU  504  CD1 ILE A  85     1496   1673   1566   -125     23    241       C  
+ATOM    505  N   SER A  86       4.913  13.521  20.290  1.00  9.35           N  
+ANISOU  505  N   SER A  86     1014   1001   1534     49    103    -92       N  
+ATOM    506  CA  SER A  86       5.770  14.627  19.932  1.00 11.00           C  
+ANISOU  506  CA  SER A  86     1290   1247   1640    -39     87    -78       C  
+ATOM    507  C   SER A  86       6.812  14.872  21.011  1.00  9.85           C  
+ANISOU  507  C   SER A  86     1361   1019   1363    -72     70   -108       C  
+ATOM    508  O   SER A  86       6.560  14.742  22.199  1.00 10.99           O  
+ANISOU  508  O   SER A  86     1403   1346   1425   -181    207   -195       O  
+ATOM    509  CB  SER A  86       4.938  15.886  19.721  1.00 12.17           C  
+ANISOU  509  CB  SER A  86     1495   1265   1861    -56      5    -94       C  
+ATOM    510  OG  SER A  86       4.100  15.769  18.594  1.00 16.78           O  
+ANISOU  510  OG  SER A  86     1980   1876   2516    193   -201     82       O  
+ATOM    511  N   ALA A  87       7.991  15.289  20.579  1.00 10.51           N  
+ANISOU  511  N   ALA A  87     1338   1250   1402    -59     38    -25       N  
+ATOM    512  CA  ALA A  87       9.001  15.820  21.475  1.00 10.76           C  
+ANISOU  512  CA  ALA A  87     1495   1241   1353   -125     -3     94       C  
+ATOM    513  C   ALA A  87       8.637  17.208  21.903  1.00 11.84           C  
+ANISOU  513  C   ALA A  87     1815   1214   1466    -97   -151    114       C  
+ATOM    514  O   ALA A  87       8.732  18.127  21.075  1.00 16.09           O  
+ANISOU  514  O   ALA A  87     2919   1329   1865    -93   -211    138       O  
+ATOM    515  CB  ALA A  87      10.375  15.893  20.763  1.00 11.87           C  
+ANISOU  515  CB  ALA A  87     1568   1761   1180   -336      0    222       C  
+ATOM    516  N   SER A  88       8.321  17.404  23.182  1.00 10.18           N  
+ANISOU  516  N   SER A  88     1212   1111   1543    -11      6     86       N  
+ATOM    517  CA  SER A  88       8.005  18.735  23.716  1.00 10.71           C  
+ANISOU  517  CA  SER A  88     1264   1191   1612     26    -82     42       C  
+ATOM    518  C   SER A  88       9.236  19.547  24.082  1.00 10.09           C  
+ANISOU  518  C   SER A  88     1238   1016   1579     61     27    111       C  
+ATOM    519  O   SER A  88       9.169  20.778  24.045  1.00 11.46           O  
+ANISOU  519  O   SER A  88     1236    979   2140     83   -163     15       O  
+ATOM    520  CB  SER A  88       7.084  18.632  24.916  1.00 11.28           C  
+ANISOU  520  CB  SER A  88     1224   1384   1676    -20   -114    -68       C  
+ATOM    521  OG  SER A  88       7.681  17.864  25.935  1.00 12.97           O  
+ANISOU  521  OG  SER A  88     1452   1571   1906     12    272     96       O  
+ATOM    522  N   LYS A  89      10.330  18.869  24.404  1.00  9.12           N  
+ANISOU  522  N   LYS A  89     1074    872   1517      0     57    118       N  
+ATOM    523  CA  LYS A  89      11.610  19.511  24.688  1.00  9.49           C  
+ANISOU  523  CA  LYS A  89     1127   1072   1404     29     58    111       C  
+ATOM    524  C   LYS A  89      12.694  18.644  24.081  1.00  8.69           C  
+ANISOU  524  C   LYS A  89      985   1044   1272      8     50     55       C  
+ATOM    525  O   LYS A  89      12.589  17.438  24.096  1.00  9.45           O  
+ANISOU  525  O   LYS A  89     1106   1134   1350    -36    134     18       O  
+ATOM    526  CB  LYS A  89      11.837  19.690  26.184  1.00 10.14           C  
+ANISOU  526  CB  LYS A  89     1101   1280   1469     18    130     55       C  
+ATOM    527  CG  LYS A  89      10.730  20.472  26.866  1.00 11.91           C  
+ANISOU  527  CG  LYS A  89     1421   1347   1755     66    -21      1       C  
+ATOM    528  CD  LYS A  89      11.049  20.803  28.326  1.00 13.40           C  
+ANISOU  528  CD  LYS A  89     1658   1711   1720     80    114    -35       C  
+ATOM    529  CE  LYS A  89       9.883  21.505  29.016  1.00 15.88           C  
+ANISOU  529  CE  LYS A  89     1942   2191   1901    202    167    -94       C  
+ATOM    530  NZ  LYS A  89      10.266  22.040  30.338  1.00 16.37           N  
+ANISOU  530  NZ  LYS A  89     2142   2175   1901     66     79    -98       N  
+ATOM    531  N   SER A  90      13.711  19.294  23.532  1.00  8.41           N  
+ANISOU  531  N   SER A  90      917   1018   1257      0    -12    212       N  
+ATOM    532  C   SER A  90      16.075  19.419  23.457  1.00  7.88           C  
+ANISOU  532  C   SER A  90      947    968   1078    -99     61     84       C  
+ATOM    533  O   SER A  90      16.320  20.536  23.003  1.00  8.38           O  
+ANISOU  533  O   SER A  90      973   1043   1165   -181    -87     78       O  
+ATOM    534  CA ASER A  90      14.884  18.610  22.986  0.50  7.93           C  
+ANISOU  534  CA ASER A  90      886   1061   1065   -113     -4     90       C  
+ATOM    535  CB ASER A  90      14.856  18.521  21.454  0.50  8.36           C  
+ANISOU  535  CB ASER A  90      947   1147   1079   -207    -90    126       C  
+ATOM    536  OG ASER A  90      13.780  17.714  20.966  0.50  7.99           O  
+ANISOU  536  OG ASER A  90      819   1285    931   -351    -31    110       O  
+ATOM    537  CA BSER A  90      14.863  18.664  22.936  0.50  8.41           C  
+ANISOU  537  CA BSER A  90      968   1042   1182    -81      0     82       C  
+ATOM    538  CB BSER A  90      14.743  18.840  21.429  0.50  8.94           C  
+ANISOU  538  CB BSER A  90     1115   1026   1254   -101    -63    104       C  
+ATOM    539  OG BSER A  90      14.094  20.073  21.112  0.50 10.97           O  
+ANISOU  539  OG BSER A  90     1254   1232   1678    -45   -127    101       O  
+ATOM    540  N   ILE A  91      16.797  18.814  24.395  1.00  7.56           N  
+ANISOU  540  N   ILE A  91      871    939   1062    -42    -43     32       N  
+ATOM    541  CA  ILE A  91      17.777  19.509  25.227  1.00  7.60           C  
+ANISOU  541  CA  ILE A  91     1001    810   1075    -34     54    -55       C  
+ATOM    542  C   ILE A  91      19.157  18.893  25.019  1.00  6.99           C  
+ANISOU  542  C   ILE A  91     1005    633   1015    -43    -11   -139       C  
+ATOM    543  O   ILE A  91      19.456  17.823  25.535  1.00  7.12           O  
+ANISOU  543  O   ILE A  91      843    784   1075    -39     48    -94       O  
+ATOM    544  CB  ILE A  91      17.403  19.417  26.709  1.00  8.03           C  
+ANISOU  544  CB  ILE A  91      978    931   1141    -42      5   -116       C  
+ATOM    545  CG1 ILE A  91      15.985  19.940  26.941  1.00  8.71           C  
+ANISOU  545  CG1 ILE A  91     1036   1290    983    116     32   -104       C  
+ATOM    546  CG2 ILE A  91      18.429  20.170  27.548  1.00  8.82           C  
+ANISOU  546  CG2 ILE A  91     1200   1089   1059   -103     -3   -156       C  
+ATOM    547  CD1 ILE A  91      15.446  19.776  28.344  1.00 10.87           C  
+ANISOU  547  CD1 ILE A  91     1320   1643   1165      6     67     24       C  
+ATOM    548  N   VAL A  92      19.991  19.553  24.218  1.00  7.08           N  
+ANISOU  548  N   VAL A  92      836    799   1055     62     -1    -10       N  
+ATOM    549  CA  VAL A  92      21.354  19.116  24.026  1.00  6.98           C  
+ANISOU  549  CA  VAL A  92      840    825    985     45    -53   -112       C  
+ATOM    550  C   VAL A  92      22.168  19.408  25.280  1.00  7.10           C  
+ANISOU  550  C   VAL A  92      891    903    900      9     19   -124       C  
+ATOM    551  O   VAL A  92      21.903  20.344  26.029  1.00  7.43           O  
+ANISOU  551  O   VAL A  92      862    744   1216     38     -5   -253       O  
+ATOM    552  CB  VAL A  92      22.015  19.780  22.778  1.00  7.37           C  
+ANISOU  552  CB  VAL A  92      933    813   1053     37     -7    -16       C  
+ATOM    553  CG1 VAL A  92      21.248  19.493  21.514  1.00  7.98           C  
+ANISOU  553  CG1 VAL A  92      952    925   1152    -72    -66    -91       C  
+ATOM    554  CG2 VAL A  92      22.281  21.284  22.983  1.00  8.41           C  
+ANISOU  554  CG2 VAL A  92      955    783   1455    -40    -16    -83       C  
+ATOM    555  N   HIS A  93      23.230  18.646  25.495  1.00  6.67           N  
+ANISOU  555  N   HIS A  93      951    697    885    119   -101   -138       N  
+ATOM    556  CA  HIS A  93      24.161  18.999  26.551  1.00  6.89           C  
+ANISOU  556  CA  HIS A  93      894    825    899    133     -2    -43       C  
+ATOM    557  C   HIS A  93      24.714  20.393  26.266  1.00  6.82           C  
+ANISOU  557  C   HIS A  93      734    841   1017    149    -96    -52       C  
+ATOM    558  O   HIS A  93      25.170  20.640  25.158  1.00  6.88           O  
+ANISOU  558  O   HIS A  93      825    859    929     34   -118   -188       O  
+ATOM    559  CB  HIS A  93      25.294  17.973  26.594  1.00  7.17           C  
+ANISOU  559  CB  HIS A  93      908    741   1073     20    -87   -159       C  
+ATOM    560  CG  HIS A  93      26.065  18.039  27.856  1.00  7.59           C  
+ANISOU  560  CG  HIS A  93      884    908   1092    -45    -71    -88       C  
+ATOM    561  ND1 HIS A  93      26.927  19.074  28.143  1.00  9.37           N  
+ANISOU  561  ND1 HIS A  93     1155   1001   1403    155   -139   -130       N  
+ATOM    562  CD2 HIS A  93      26.042  17.231  28.935  1.00  8.23           C  
+ANISOU  562  CD2 HIS A  93      861   1171   1092    -33     63    -21       C  
+ATOM    563  CE1 HIS A  93      27.428  18.874  29.352  1.00  9.51           C  
+ANISOU  563  CE1 HIS A  93     1066   1285   1262    147   -231    -98       C  
+ATOM    564  NE2 HIS A  93      26.894  17.767  29.862  1.00  9.02           N  
+ANISOU  564  NE2 HIS A  93      970   1416   1040    101   -202   -103       N  
+ATOM    565  N   PRO A  94      24.711  21.316  27.247  1.00  7.53           N  
+ANISOU  565  N   PRO A  94      974    838   1047    100    -46    -42       N  
+ATOM    566  CA  PRO A  94      25.210  22.665  26.972  1.00  7.61           C  
+ANISOU  566  CA  PRO A  94     1038    907    944    -61   -125   -137       C  
+ATOM    567  C   PRO A  94      26.660  22.761  26.530  1.00  7.36           C  
+ANISOU  567  C   PRO A  94     1007    905    881     52   -155    -81       C  
+ATOM    568  O   PRO A  94      27.048  23.741  25.893  1.00  8.52           O  
+ANISOU  568  O   PRO A  94     1108    921   1205   -117   -147   -112       O  
+ATOM    569  CB  PRO A  94      24.977  23.389  28.294  1.00  8.87           C  
+ANISOU  569  CB  PRO A  94     1329   1052    987     45    -98   -151       C  
+ATOM    570  CG  PRO A  94      23.882  22.651  28.988  1.00 11.08           C  
+ANISOU  570  CG  PRO A  94     1686   1278   1243    -27    -27   -106       C  
+ATOM    571  CD  PRO A  94      24.113  21.207  28.579  1.00  8.43           C  
+ANISOU  571  CD  PRO A  94     1101    997   1104    -22   -111   -102       C  
+ATOM    572  N   SER A  95      27.445  21.734  26.861  1.00  8.32           N  
+ANISOU  572  N   SER A  95     1012    911   1235     54   -115   -109       N  
+ATOM    573  CA  SER A  95      28.842  21.675  26.458  1.00  8.38           C  
+ANISOU  573  CA  SER A  95      994    876   1315     -4   -164   -115       C  
+ATOM    574  C   SER A  95      29.074  20.738  25.299  1.00  7.85           C  
+ANISOU  574  C   SER A  95      825    806   1350     18    -80   -125       C  
+ATOM    575  O   SER A  95      30.210  20.453  24.963  1.00  8.21           O  
+ANISOU  575  O   SER A  95      760    939   1419     53    -87   -176       O  
+ATOM    576  CB  SER A  95      29.712  21.266  27.642  1.00  9.86           C  
+ANISOU  576  CB  SER A  95     1167   1114   1464     20   -242   -210       C  
+ATOM    577  OG  SER A  95      29.629  22.259  28.655  1.00 13.31           O  
+ANISOU  577  OG  SER A  95     1612   1804   1639    176   -488   -266       O  
+ATOM    578  N   TYR A  96      28.017  20.294  24.628  1.00  7.15           N  
+ANISOU  578  N   TYR A  96      816    768   1129     26   -116   -204       N  
+ATOM    579  CA  TYR A  96      28.194  19.589  23.366  1.00  7.02           C  
+ANISOU  579  CA  TYR A  96      816    686   1165      3    -38   -110       C  
+ATOM    580  C   TYR A  96      29.046  20.473  22.453  1.00  7.37           C  
+ANISOU  580  C   TYR A  96      724    694   1381     12    -79    -49       C  
+ATOM    581  O   TYR A  96      28.803  21.659  22.310  1.00  7.38           O  
+ANISOU  581  O   TYR A  96      836    600   1366     61    -78    -47       O  
+ATOM    582  CB  TYR A  96      26.812  19.315  22.747  1.00  6.88           C  
+ANISOU  582  CB  TYR A  96      847    638   1128     28    -48    -74       C  
+ATOM    583  CG  TYR A  96      26.848  18.919  21.291  1.00  7.20           C  
+ANISOU  583  CG  TYR A  96      767    878   1089   -178   -109   -122       C  
+ATOM    584  CD1 TYR A  96      27.511  17.784  20.865  1.00  6.84           C  
+ANISOU  584  CD1 TYR A  96      844    831    922    -50     -6     34       C  
+ATOM    585  CD2 TYR A  96      26.195  19.687  20.347  1.00  7.68           C  
+ANISOU  585  CD2 TYR A  96     1011    813   1092    -46    -11   -201       C  
+ATOM    586  CE1 TYR A  96      27.538  17.430  19.544  1.00  7.69           C  
+ANISOU  586  CE1 TYR A  96      905    826   1189   -122     21     32       C  
+ATOM    587  CE2 TYR A  96      26.221  19.358  19.016  1.00  7.26           C  
+ANISOU  587  CE2 TYR A  96     1005    756    997   -198    -75    122       C  
+ATOM    588  CZ  TYR A  96      26.896  18.221  18.615  1.00  7.29           C  
+ANISOU  588  CZ  TYR A  96      859    848   1060    -85     53    -64       C  
+ATOM    589  OH  TYR A  96      26.966  17.837  17.311  1.00  8.42           O  
+ANISOU  589  OH  TYR A  96     1152    960   1086   -199    120    -82       O  
+ATOM    590  N   ASN A  97      30.026  19.856  21.802  1.00  7.60           N  
+ANISOU  590  N   ASN A  97      839    746   1299    159    -22     27       N  
+ATOM    591  CA  ASN A  97      30.899  20.507  20.840  1.00  7.36           C  
+ANISOU  591  CA  ASN A  97      819    702   1274     50     11    -14       C  
+ATOM    592  C   ASN A  97      30.630  19.880  19.490  1.00  7.48           C  
+ANISOU  592  C   ASN A  97      887    683   1271      7     23    104       C  
+ATOM    593  O   ASN A  97      30.877  18.686  19.281  1.00  7.97           O  
+ANISOU  593  O   ASN A  97      978    653   1397     69     69    -38       O  
+ATOM    594  CB  ASN A  97      32.343  20.330  21.295  1.00  8.29           C  
+ANISOU  594  CB  ASN A  97      905    687   1556     66      2    -57       C  
+ATOM    595  CG  ASN A  97      33.358  20.962  20.369  1.00  8.35           C  
+ANISOU  595  CG  ASN A  97      812    741   1619    206     -8     28       C  
+ATOM    596  OD1 ASN A  97      33.240  20.912  19.159  1.00  9.19           O  
+ANISOU  596  OD1 ASN A  97      895    819   1777    -54    105    -19       O  
+ATOM    597  ND2 ASN A  97      34.358  21.601  20.969  1.00 10.40           N  
+ANISOU  597  ND2 ASN A  97      828   1098   2024    -89    -75    -17       N  
+ATOM    598  N   SER A  98      30.099  20.661  18.562  1.00  8.10           N  
+ANISOU  598  N   SER A  98      961    765   1350     95     27     64       N  
+ATOM    599  CA  SER A  98      29.684  20.095  17.287  1.00  9.16           C  
+ANISOU  599  CA  SER A  98     1095    971   1412     39     64     40       C  
+ATOM    600  C   SER A  98      30.839  19.755  16.375  1.00  9.68           C  
+ANISOU  600  C   SER A  98     1240    924   1512    145    113     72       C  
+ATOM    601  O   SER A  98      30.642  19.051  15.384  1.00 11.44           O  
+ANISOU  601  O   SER A  98     1412   1245   1687     -8    222   -120       O  
+ATOM    602  CB  SER A  98      28.718  21.023  16.548  1.00  9.16           C  
+ANISOU  602  CB  SER A  98     1125    935   1418     57     23     -4       C  
+ATOM    603  OG  SER A  98      29.303  22.249  16.189  1.00 10.61           O  
+ANISOU  603  OG  SER A  98     1302    767   1962     89   -134     92       O  
+ATOM    604  N   ASN A  99      32.038  20.222  16.691  1.00  9.59           N  
+ANISOU  604  N   ASN A  99     1216    861   1564    144    242     62       N  
+ATOM    605  CA  ASN A  99      33.216  19.866  15.896  1.00 10.21           C  
+ANISOU  605  CA  ASN A  99     1386    969   1522    196    266    152       C  
+ATOM    606  C   ASN A  99      33.854  18.579  16.379  1.00 10.30           C  
+ANISOU  606  C   ASN A  99     1409    828   1677    188    256     65       C  
+ATOM    607  O   ASN A  99      34.245  17.782  15.574  1.00 12.69           O  
+ANISOU  607  O   ASN A  99     1763   1371   1688    494    320    -64       O  
+ATOM    608  CB  ASN A  99      34.233  20.986  15.925  1.00 11.16           C  
+ANISOU  608  CB  ASN A  99     1458    953   1828    210    303    142       C  
+ATOM    609  CG  ASN A  99      35.376  20.719  14.957  1.00 15.11           C  
+ANISOU  609  CG  ASN A  99     1871   1927   1940    126    295    128       C  
+ATOM    610  OD1 ASN A  99      35.183  20.715  13.749  1.00 17.74           O  
+ANISOU  610  OD1 ASN A  99     2294   2294   2151     52    530    138       O  
+ATOM    611  ND2 ASN A  99      36.513  20.379  15.493  1.00 19.74           N  
+ANISOU  611  ND2 ASN A  99     1875   3033   2591    271    580    147       N  
+ATOM    612  N   THR A 100      33.988  18.396  17.676  1.00  9.13           N  
+ANISOU  612  N   THR A 100     1096    759   1615    234    236     12       N  
+ATOM    613  CA  THR A 100      34.666  17.219  18.222  1.00  8.72           C  
+ANISOU  613  CA  THR A 100     1052    734   1524    198    165     -3       C  
+ATOM    614  C   THR A 100      33.700  16.118  18.608  1.00  8.20           C  
+ANISOU  614  C   THR A 100     1037    774   1305    175     65   -164       C  
+ATOM    615  O   THR A 100      34.095  14.970  18.830  1.00  8.20           O  
+ANISOU  615  O   THR A 100      977    741   1395    246    106     43       O  
+ATOM    616  CB  THR A 100      35.470  17.598  19.460  1.00  9.17           C  
+ANISOU  616  CB  THR A 100     1081    761   1642    156     51    -73       C  
+ATOM    617  OG1 THR A 100      34.579  18.008  20.500  1.00  9.39           O  
+ANISOU  617  OG1 THR A 100      953    851   1761    102      8   -110       O  
+ATOM    618  CG2 THR A 100      36.528  18.648  19.166  1.00 10.51           C  
+ANISOU  618  CG2 THR A 100     1148    937   1906     -6     53    110       C  
+ATOM    619  N   LEU A 101      32.427  16.460  18.670  1.00  7.58           N  
+ANISOU  619  N   LEU A 101      920    764   1194    189     16    -41       N  
+ATOM    620  CA  LEU A 101      31.364  15.605  19.168  1.00  7.53           C  
+ANISOU  620  CA  LEU A 101      948    687   1224     96     14    -73       C  
+ATOM    621  C   LEU A 101      31.557  15.197  20.621  1.00  6.99           C  
+ANISOU  621  C   LEU A 101      719    679   1254    123    -17    -22       C  
+ATOM    622  O   LEU A 101      30.934  14.266  21.113  1.00  7.51           O  
+ANISOU  622  O   LEU A 101      963    647   1241    -71   -127     69       O  
+ATOM    623  CB  LEU A 101      31.126  14.387  18.260  1.00  8.20           C  
+ANISOU  623  CB  LEU A 101      994    811   1308    131     21    -59       C  
+ATOM    624  CG  LEU A 101      30.753  14.766  16.838  1.00  9.35           C  
+ANISOU  624  CG  LEU A 101     1262    886   1404     33    -59   -125       C  
+ATOM    625  CD1 LEU A 101      30.623  13.516  15.951  1.00 12.27           C  
+ANISOU  625  CD1 LEU A 101     1847   1055   1759     37   -107   -166       C  
+ATOM    626  CD2 LEU A 101      29.471  15.591  16.739  1.00 12.10           C  
+ANISOU  626  CD2 LEU A 101     1626   1208   1761    373    -80   -241       C  
+ATOM    627  N   ASN A 102      32.326  15.943  21.376  1.00  7.07           N  
+ANISOU  627  N   ASN A 102      692    651   1344     43     86    -13       N  
+ATOM    628  CA  ASN A 102      32.356  15.739  22.807  1.00  7.39           C  
+ANISOU  628  CA  ASN A 102      790    769   1246     91    -85    -47       C  
+ATOM    629  C   ASN A 102      30.997  16.117  23.424  1.00  6.58           C  
+ANISOU  629  C   ASN A 102      719    745   1035     52   -118    -77       C  
+ATOM    630  O   ASN A 102      30.337  17.061  23.010  1.00  7.03           O  
+ANISOU  630  O   ASN A 102      853    652   1164     64    -53    -60       O  
+ATOM    631  CB  ASN A 102      33.477  16.594  23.408  1.00  7.94           C  
+ANISOU  631  CB  ASN A 102      699    905   1410     -2     58    -10       C  
+ATOM    632  CG  ASN A 102      33.886  16.155  24.782  1.00  8.79           C  
+ANISOU  632  CG  ASN A 102      892    929   1516      5   -119   -140       C  
+ATOM    633  OD1 ASN A 102      33.686  15.014  25.209  1.00  9.15           O  
+ANISOU  633  OD1 ASN A 102      873   1075   1528     31   -246   -127       O  
+ATOM    634  ND2 ASN A 102      34.569  17.040  25.475  1.00 11.45           N  
+ANISOU  634  ND2 ASN A 102     1372   1153   1822   -117   -465   -203       N  
+ATOM    635  N   ASN A 103      30.609  15.373  24.432  1.00  6.45           N  
+ANISOU  635  N   ASN A 103      818    689    941    133   -145    -32       N  
+ATOM    636  CA  ASN A 103      29.331  15.554  25.111  1.00  6.08           C  
+ANISOU  636  CA  ASN A 103      772    737    800     66   -106    -31       C  
+ATOM    637  C   ASN A 103      28.154  15.403  24.163  1.00  6.33           C  
+ANISOU  637  C   ASN A 103      810    762    830     50    -54     70       C  
+ATOM    638  O   ASN A 103      27.208  16.179  24.185  1.00  6.50           O  
+ANISOU  638  O   ASN A 103      787    696    987    105   -174    -63       O  
+ATOM    639  CB  ASN A 103      29.255  16.911  25.841  1.00  7.39           C  
+ANISOU  639  CB  ASN A 103      867    997    943     51    -94    -91       C  
+ATOM    640  CG  ASN A 103      30.425  17.127  26.789  1.00  8.32           C  
+ANISOU  640  CG  ASN A 103      992    978   1190    206   -106    -97       C  
+ATOM    641  OD1 ASN A 103      30.615  16.354  27.755  1.00  8.45           O  
+ANISOU  641  OD1 ASN A 103     1231    980    997    100   -118   -166       O  
+ATOM    642  ND2 ASN A 103      31.194  18.190  26.552  1.00  9.22           N  
+ANISOU  642  ND2 ASN A 103     1109    879   1512    -34   -334    -99       N  
+ATOM    643  N   ASP A 104      28.234  14.365  23.346  1.00  5.90           N  
+ANISOU  643  N   ASP A 104      664    733    843     46    -32     13       N  
+ATOM    644  CA  ASP A 104      27.206  14.109  22.326  1.00  5.76           C  
+ANISOU  644  CA  ASP A 104      689    776    720     80    -53     29       C  
+ATOM    645  C   ASP A 104      26.023  13.356  22.910  1.00  5.54           C  
+ANISOU  645  C   ASP A 104      696    723    684    -34    -83    -46       C  
+ATOM    646  O   ASP A 104      25.812  12.184  22.686  1.00  5.85           O  
+ANISOU  646  O   ASP A 104      702    664    854     35    -14    -28       O  
+ATOM    647  CB  ASP A 104      27.816  13.389  21.124  1.00  6.28           C  
+ANISOU  647  CB  ASP A 104      860    689    835    -93    -51     28       C  
+ATOM    648  CG  ASP A 104      26.914  13.348  19.911  1.00  5.64           C  
+ANISOU  648  CG  ASP A 104      660    677    803    -79      4     -6       C  
+ATOM    649  OD1 ASP A 104      25.910  14.096  19.881  1.00  6.01           O  
+ANISOU  649  OD1 ASP A 104      713    732    837    121     29     -9       O  
+ATOM    650  OD2 ASP A 104      27.243  12.571  18.982  1.00  6.08           O  
+ANISOU  650  OD2 ASP A 104      769    755    785    121   -100    -83       O  
+ATOM    651  N   ILE A 105      25.220  14.109  23.635  1.00  5.64           N  
+ANISOU  651  N   ILE A 105      750    636    757     -9    -37    -12       N  
+ATOM    652  CA  ILE A 105      24.063  13.579  24.332  1.00  6.36           C  
+ANISOU  652  CA  ILE A 105      834    844    737    -28    -40    -46       C  
+ATOM    653  C   ILE A 105      22.972  14.629  24.365  1.00  5.52           C  
+ANISOU  653  C   ILE A 105      731    657    708    -29    -15    -73       C  
+ATOM    654  O   ILE A 105      23.249  15.815  24.472  1.00  6.38           O  
+ANISOU  654  O   ILE A 105      792    740    892     12     -9    -63       O  
+ATOM    655  CB  ILE A 105      24.457  13.072  25.750  1.00  6.34           C  
+ANISOU  655  CB  ILE A 105      937    740    732     -9     84    -83       C  
+ATOM    656  CG1 ILE A 105      23.258  12.366  26.409  1.00  7.12           C  
+ANISOU  656  CG1 ILE A 105     1156    880    668     27     28    -59       C  
+ATOM    657  CG2 ILE A 105      25.038  14.188  26.659  1.00  7.36           C  
+ANISOU  657  CG2 ILE A 105     1142    852    800    -66      8    -83       C  
+ATOM    658  CD1 ILE A 105      23.661  11.638  27.714  1.00  8.58           C  
+ANISOU  658  CD1 ILE A 105     1280   1169    809    -45      2    157       C  
+ATOM    659  N   MET A 106      21.738  14.173  24.217  1.00  5.90           N  
+ANISOU  659  N   MET A 106      742    618    881    -10    -30    -75       N  
+ATOM    660  CA  MET A 106      20.558  15.013  24.218  1.00  6.44           C  
+ANISOU  660  CA  MET A 106      814    803    827     60     82    -66       C  
+ATOM    661  C   MET A 106      19.442  14.287  24.945  1.00  6.40           C  
+ANISOU  661  C   MET A 106      838    747    844     -2      7    -37       C  
+ATOM    662  O   MET A 106      19.305  13.062  24.820  1.00  6.54           O  
+ANISOU  662  O   MET A 106      861    801    823    100     67    -17       O  
+ATOM    663  CB  MET A 106      20.160  15.320  22.772  1.00  6.60           C  
+ANISOU  663  CB  MET A 106      765    787    955     65    101    -31       C  
+ATOM    664  CG  MET A 106      18.856  16.014  22.574  1.00  7.65           C  
+ANISOU  664  CG  MET A 106     1077    979    849    156    132     87       C  
+ATOM    665  SD  MET A 106      18.528  16.509  20.866  1.00  8.25           S  
+ANISOU  665  SD  MET A 106     1266    965    903    110   -103     58       S  
+ATOM    666  CE  MET A 106      18.303  14.939  20.054  1.00  7.70           C  
+ANISOU  666  CE  MET A 106     1001    960    964    192    -97   -127       C  
+ATOM    667  N   LEU A 107      18.614  15.051  25.662  1.00  6.62           N  
+ANISOU  667  N   LEU A 107      757    890    868     20     30    -49       N  
+ATOM    668  CA  LEU A 107      17.425  14.525  26.302  1.00  6.98           C  
+ANISOU  668  CA  LEU A 107      888    809    954    -35     45    -82       C  
+ATOM    669  C   LEU A 107      16.214  15.098  25.614  1.00  6.71           C  
+ANISOU  669  C   LEU A 107      789    815    943    -19     67    -24       C  
+ATOM    670  O   LEU A 107      16.126  16.301  25.386  1.00  8.02           O  
+ANISOU  670  O   LEU A 107      909    909   1229      1     20    -62       O  
+ATOM    671  CB  LEU A 107      17.418  14.868  27.776  1.00  7.51           C  
+ANISOU  671  CB  LEU A 107      968    896    986     24    -75   -175       C  
+ATOM    672  CG  LEU A 107      18.243  13.932  28.641  1.00  8.48           C  
+ANISOU  672  CG  LEU A 107     1318    991    911    128   -112   -243       C  
+ATOM    673  CD1 LEU A 107      18.528  14.526  30.029  1.00 10.56           C  
+ANISOU  673  CD1 LEU A 107     1705   1300   1007    112    -53    -74       C  
+ATOM    674  CD2 LEU A 107      17.534  12.588  28.860  1.00 11.55           C  
+ANISOU  674  CD2 LEU A 107     1937   1179   1272    -28      9    -15       C  
+ATOM    675  N   ILE A 108      15.286  14.215  25.263  1.00  6.83           N  
+ANISOU  675  N   ILE A 108      822    747   1023    -19    124    -49       N  
+ATOM    676  CA  ILE A 108      14.000  14.593  24.667  1.00  6.99           C  
+ANISOU  676  CA  ILE A 108      917    818    918    -52     82     43       C  
+ATOM    677  C   ILE A 108      12.886  14.276  25.641  1.00  7.78           C  
+ANISOU  677  C   ILE A 108      901    968   1084     11     33     47       C  
+ATOM    678  O   ILE A 108      12.791  13.168  26.140  1.00  7.70           O  
+ANISOU  678  O   ILE A 108      955    908   1063    101    130     33       O  
+ATOM    679  CB  ILE A 108      13.779  13.824  23.364  1.00  7.39           C  
+ANISOU  679  CB  ILE A 108      810    965   1033    -42     53     -5       C  
+ATOM    680  CG1 ILE A 108      14.694  14.339  22.257  1.00  9.36           C  
+ANISOU  680  CG1 ILE A 108     1170   1330   1055   -161     31   -112       C  
+ATOM    681  CG2 ILE A 108      12.302  13.913  22.925  1.00 10.34           C  
+ANISOU  681  CG2 ILE A 108      980   1671   1275    172    -55    -60       C  
+ATOM    682  CD1 ILE A 108      14.807  13.379  21.079  1.00 11.25           C  
+ANISOU  682  CD1 ILE A 108     1639   1488   1146   -302    162   -369       C  
+ATOM    683  N   LYS A 109      12.085  15.286  25.962  1.00  8.11           N  
+ANISOU  683  N   LYS A 109      985    992   1105     19    215     20       N  
+ATOM    684  CA  LYS A 109      10.896  15.084  26.783  1.00  8.47           C  
+ANISOU  684  CA  LYS A 109      988    996   1232    -55    180    110       C  
+ATOM    685  C   LYS A 109       9.728  14.833  25.851  1.00  8.34           C  
+ANISOU  685  C   LYS A 109      960   1045   1161    106    173    106       C  
+ATOM    686  O   LYS A 109       9.543  15.510  24.849  1.00  9.11           O  
+ANISOU  686  O   LYS A 109      979   1248   1233    225    128     52       O  
+ATOM    687  CB  LYS A 109      10.614  16.320  27.639  1.00  8.83           C  
+ANISOU  687  CB  LYS A 109     1059   1081   1213    -26    188    106       C  
+ATOM    688  CG  LYS A 109       9.580  16.066  28.737  1.00  9.96           C  
+ANISOU  688  CG  LYS A 109     1159   1299   1327   -134    238     55       C  
+ATOM    689  CD  LYS A 109       9.356  17.268  29.625  1.00 10.58           C  
+ANISOU  689  CD  LYS A 109     1251   1535   1234     -9    217    -21       C  
+ATOM    690  CE  LYS A 109       8.549  16.962  30.862  1.00 14.24           C  
+ANISOU  690  CE  LYS A 109     1809   2088   1513      9    338    -20       C  
+ATOM    691  NZ  LYS A 109       8.279  18.217  31.649  1.00 15.36           N  
+ANISOU  691  NZ  LYS A 109     2052   2120   1663    279    384   -158       N  
+ATOM    692  N   LEU A 110       8.928  13.862  26.238  1.00  9.25           N  
+ANISOU  692  N   LEU A 110      960   1135   1420     16    118    -10       N  
+ATOM    693  CA  LEU A 110       7.709  13.522  25.511  1.00  9.70           C  
+ANISOU  693  CA  LEU A 110     1070   1158   1455     63    134    -16       C  
+ATOM    694  C   LEU A 110       6.555  14.414  25.948  1.00  9.73           C  
+ANISOU  694  C   LEU A 110     1129   1226   1342    130    131    -61       C  
+ATOM    695  O   LEU A 110       6.365  14.707  27.131  1.00 10.93           O  
+ANISOU  695  O   LEU A 110     1370   1318   1463    282     80   -197       O  
+ATOM    696  CB  LEU A 110       7.356  12.067  25.777  1.00  9.54           C  
+ANISOU  696  CB  LEU A 110      883   1226   1515     38    213    -69       C  
+ATOM    697  CG  LEU A 110       8.442  11.048  25.389  1.00 10.01           C  
+ANISOU  697  CG  LEU A 110     1004   1159   1638     27    280    -42       C  
+ATOM    698  CD1 LEU A 110       7.992   9.625  25.673  1.00 12.66           C  
+ANISOU  698  CD1 LEU A 110     1554   1099   2156    110    403     16       C  
+ATOM    699  CD2 LEU A 110       8.873  11.191  23.946  1.00 12.66           C  
+ANISOU  699  CD2 LEU A 110     1453   1647   1710    -16    211   -203       C  
+ATOM    700  N   LYS A 111       5.770  14.848  24.977  1.00  9.44           N  
+ANISOU  700  N   LYS A 111     1113   1114   1357     92    129    -87       N  
+ATOM    701  CA  LYS A 111       4.635  15.740  25.261  1.00 10.49           C  
+ANISOU  701  CA  LYS A 111     1191   1224   1569    121    166    -34       C  
+ATOM    702  C   LYS A 111       3.605  15.098  26.174  1.00 11.86           C  
+ANISOU  702  C   LYS A 111     1412   1468   1624    177    270     44       C  
+ATOM    703  O   LYS A 111       2.977  15.760  26.998  1.00 13.43           O  
+ANISOU  703  O   LYS A 111     1613   1659   1829    380    502    -43       O  
+ATOM    704  CB  LYS A 111       3.977  16.154  23.948  1.00 10.57           C  
+ANISOU  704  CB  LYS A 111     1206   1278   1531     65    150    -39       C  
+ATOM    705  CG  LYS A 111       2.809  17.111  24.142  1.00 13.83           C  
+ANISOU  705  CG  LYS A 111     1564   1800   1888    227    206     -7       C  
+ATOM    706  CD  LYS A 111       2.252  17.536  22.816  1.00 17.15           C  
+ANISOU  706  CD  LYS A 111     2185   2051   2281    329     12    145       C  
+ATOM    707  CE  LYS A 111       1.117  18.558  22.909  1.00 21.39           C  
+ANISOU  707  CE  LYS A 111     2523   2718   2883    300    -16    122       C  
+ATOM    708  NZ  LYS A 111       0.522  18.661  21.545  1.00 24.30           N  
+ANISOU  708  NZ  LYS A 111     2984   3057   3191    272   -206    104       N  
+ATOM    709  N   SER A 112       3.394  13.811  25.980  1.00 11.80           N  
+ANISOU  709  N   SER A 112     1163   1478   1841     53    367    123       N  
+ATOM    710  CA  SER A 112       2.590  12.988  26.885  1.00 13.15           C  
+ANISOU  710  CA  SER A 112     1421   1590   1984      3    327    253       C  
+ATOM    711  C   SER A 112       3.393  11.759  27.227  1.00 12.04           C  
+ANISOU  711  C   SER A 112     1235   1446   1891     85    335    193       C  
+ATOM    712  O   SER A 112       4.280  11.362  26.469  1.00 12.23           O  
+ANISOU  712  O   SER A 112     1126   1681   1837    129    401    120       O  
+ATOM    713  CB  SER A 112       1.263  12.604  26.221  1.00 13.52           C  
+ANISOU  713  CB  SER A 112     1309   1598   2228    -69    343    349       C  
+ATOM    714  OG  SER A 112       1.430  11.968  24.978  1.00 16.88           O  
+ANISOU  714  OG  SER A 112     1621   2249   2544   -288    -50    399       O  
+ATOM    715  N   ALA A 113       3.100  11.149  28.360  1.00 12.87           N  
+ANISOU  715  N   ALA A 113     1373   1606   1911    156    356    161       N  
+ATOM    716  CA  ALA A 113       3.856   9.978  28.802  1.00 12.42           C  
+ANISOU  716  CA  ALA A 113     1296   1648   1774     80    240    216       C  
+ATOM    717  C   ALA A 113       3.606   8.797  27.906  1.00 12.75           C  
+ANISOU  717  C   ALA A 113     1273   1734   1836   -113    184    211       C  
+ATOM    718  O   ALA A 113       2.461   8.529  27.483  1.00 14.01           O  
+ANISOU  718  O   ALA A 113     1177   1958   2186   -246     61    377       O  
+ATOM    719  CB  ALA A 113       3.526   9.638  30.243  1.00 14.43           C  
+ANISOU  719  CB  ALA A 113     1794   1696   1993     63    244    295       C  
+ATOM    720  N   ALA A 114       4.667   8.045  27.633  1.00 11.13           N  
+ANISOU  720  N   ALA A 114     1187   1474   1565    -89    227    174       N  
+ATOM    721  CA  ALA A 114       4.515   6.742  27.007  1.00 12.04           C  
+ANISOU  721  CA  ALA A 114     1417   1603   1553   -191    267     79       C  
+ATOM    722  C   ALA A 114       3.738   5.829  27.939  1.00 12.36           C  
+ANISOU  722  C   ALA A 114     1529   1649   1518   -192    123    122       C  
+ATOM    723  O   ALA A 114       3.838   5.964  29.175  1.00 12.75           O  
+ANISOU  723  O   ALA A 114     1519   1749   1576   -210    166    109       O  
+ATOM    724  CB  ALA A 114       5.847   6.142  26.731  1.00 12.90           C  
+ANISOU  724  CB  ALA A 114     1617   1610   1672    -52    432     49       C  
+ATOM    725  N   SER A 115       2.987   4.909  27.343  1.00 11.93           N  
+ANISOU  725  N   SER A 115     1361   1613   1557   -274    142    187       N  
+ATOM    726  CA  SER A 115       2.308   3.873  28.105  1.00 12.74           C  
+ANISOU  726  CA  SER A 115     1458   1734   1649   -261     83    221       C  
+ATOM    727  C   SER A 115       3.222   2.660  28.105  1.00 12.22           C  
+ANISOU  727  C   SER A 115     1334   1722   1584   -285    150    191       C  
+ATOM    728  O   SER A 115       3.408   1.998  27.101  1.00 13.31           O  
+ANISOU  728  O   SER A 115     1766   1653   1637   -153    -49    246       O  
+ATOM    729  CB  SER A 115       0.981   3.515  27.469  1.00 13.69           C  
+ANISOU  729  CB  SER A 115     1514   1857   1829   -242     71    278       C  
+ATOM    730  OG  SER A 115       0.365   2.505  28.240  1.00 17.37           O  
+ANISOU  730  OG  SER A 115     1837   2283   2480   -531     54    354       O  
+ATOM    731  N   LEU A 116       3.852   2.397  29.235  1.00 11.83           N  
+ANISOU  731  N   LEU A 116     1362   1736   1398   -203    195    241       N  
+ATOM    732  CA  LEU A 116       4.875   1.360  29.300  1.00 12.05           C  
+ANISOU  732  CA  LEU A 116     1403   1726   1447   -182    127    223       C  
+ATOM    733  C   LEU A 116       4.192   0.019  29.359  1.00 12.48           C  
+ANISOU  733  C   LEU A 116     1400   1777   1565   -230    211    234       C  
+ATOM    734  O   LEU A 116       3.193  -0.195  30.076  1.00 13.56           O  
+ANISOU  734  O   LEU A 116     1373   2040   1738   -246    464    286       O  
+ATOM    735  CB  LEU A 116       5.810   1.572  30.488  1.00 12.58           C  
+ANISOU  735  CB  LEU A 116     1498   1825   1456   -158    140    203       C  
+ATOM    736  CG  LEU A 116       6.536   2.915  30.495  1.00 12.56           C  
+ANISOU  736  CG  LEU A 116     1586   1686   1498   -151    113    325       C  
+ATOM    737  CD1 LEU A 116       7.502   2.993  31.697  1.00 14.94           C  
+ANISOU  737  CD1 LEU A 116     2040   1846   1791   -215   -249    -47       C  
+ATOM    738  CD2 LEU A 116       7.290   3.214  29.200  1.00 13.86           C  
+ANISOU  738  CD2 LEU A 116     1582   2046   1637   -239    381    354       C  
+ATOM    739  N   ASN A 117       4.722  -0.903  28.576  1.00 12.11           N  
+ANISOU  739  N   ASN A 117     1404   1652   1543   -222    198    192       N  
+ATOM    740  CA  ASN A 117       4.181  -2.237  28.463  1.00 12.45           C  
+ANISOU  740  CA  ASN A 117     1399   1646   1684   -150     97    241       C  
+ATOM    741  C   ASN A 117       5.318  -3.154  28.031  1.00 13.20           C  
+ANISOU  741  C   ASN A 117     1467   1772   1775   -140     71    197       C  
+ATOM    742  O   ASN A 117       6.471  -2.725  28.056  1.00 13.99           O  
+ANISOU  742  O   ASN A 117     1490   1819   2004   -271     38    146       O  
+ATOM    743  CB  ASN A 117       2.976  -2.247  27.508  1.00 12.16           C  
+ANISOU  743  CB  ASN A 117     1316   1710   1593   -231     75    283       C  
+ATOM    744  CG  ASN A 117       3.315  -1.749  26.111  1.00 12.71           C  
+ANISOU  744  CG  ASN A 117     1528   1694   1606    -80     83    329       C  
+ATOM    745  OD1 ASN A 117       4.331  -2.125  25.564  1.00 13.17           O  
+ANISOU  745  OD1 ASN A 117     1345   2043   1616   -101    267    412       O  
+ATOM    746  ND2 ASN A 117       2.421  -0.982  25.510  1.00 12.90           N  
+ANISOU  746  ND2 ASN A 117     1252   1822   1826   -111     69    463       N  
+ATOM    747  N   SER A 118       5.042  -4.373  27.592  1.00 14.76           N  
+ANISOU  747  N   SER A 118     1687   1849   2072    -99     92    206       N  
+ATOM    748  CA  SER A 118       6.140  -5.279  27.293  1.00 15.48           C  
+ANISOU  748  CA  SER A 118     1855   1872   2152    -39    103    174       C  
+ATOM    749  C   SER A 118       6.912  -4.865  26.046  1.00 15.07           C  
+ANISOU  749  C   SER A 118     1753   1918   2054    -42    111    153       C  
+ATOM    750  O   SER A 118       8.071  -5.264  25.877  1.00 16.13           O  
+ANISOU  750  O   SER A 118     1755   2071   2302     87    140    172       O  
+ATOM    751  CB  SER A 118       5.655  -6.719  27.140  1.00 16.78           C  
+ANISOU  751  CB  SER A 118     2117   1999   2258    -86    117    180       C  
+ATOM    752  OG  SER A 118       4.734  -6.810  26.079  1.00 17.97           O  
+ANISOU  752  OG  SER A 118     2537   1781   2510   -163     40    149       O  
+ATOM    753  N   ARG A 119       6.262  -4.100  25.173  1.00 13.47           N  
+ANISOU  753  N   ARG A 119     1511   1752   1855   -157    158    191       N  
+ATOM    754  CA  ARG A 119       6.856  -3.683  23.905  1.00 13.27           C  
+ANISOU  754  CA  ARG A 119     1486   1842   1710    -22    104     80       C  
+ATOM    755  C   ARG A 119       7.439  -2.278  23.929  1.00 11.84           C  
+ANISOU  755  C   ARG A 119     1258   1778   1460      0    153    144       C  
+ATOM    756  O   ARG A 119       8.138  -1.904  22.985  1.00 12.80           O  
+ANISOU  756  O   ARG A 119     1223   2218   1420    -93    176    203       O  
+ATOM    757  CB  ARG A 119       5.792  -3.787  22.802  1.00 14.06           C  
+ANISOU  757  CB  ARG A 119     1594   1946   1801    -78     35     22       C  
+ATOM    758  CG  ARG A 119       5.470  -5.239  22.480  1.00 18.43           C  
+ANISOU  758  CG  ARG A 119     2295   2348   2357   -148    103    -81       C  
+ATOM    759  CD  ARG A 119       4.005  -5.553  22.399  1.00 27.08           C  
+ANISOU  759  CD  ARG A 119     3131   3511   3646    -29    -53      2       C  
+ATOM    760  NE  ARG A 119       3.755  -6.654  21.457  1.00 29.61           N  
+ANISOU  760  NE  ARG A 119     3726   3811   3713    -37    -15   -181       N  
+ATOM    761  CZ  ARG A 119       2.888  -7.648  21.648  1.00 32.80           C  
+ANISOU  761  CZ  ARG A 119     4140   4138   4185    -57     62    -90       C  
+ATOM    762  NH1 ARG A 119       2.159  -7.738  22.762  1.00 35.32           N  
+ANISOU  762  NH1 ARG A 119     4553   4557   4308    -38     97     39       N  
+ATOM    763  NH2 ARG A 119       2.753  -8.578  20.708  1.00 32.77           N  
+ANISOU  763  NH2 ARG A 119     4112   4175   4163   -135    -44    -69       N  
+ATOM    764  N   VAL A 120       7.103  -1.505  24.956  1.00 11.31           N  
+ANISOU  764  N   VAL A 120     1257   1811   1228    -39    135    213       N  
+ATOM    765  CA  VAL A 120       7.573  -0.144  25.133  1.00 10.61           C  
+ANISOU  765  CA  VAL A 120     1149   1644   1236    -54    161    211       C  
+ATOM    766  C   VAL A 120       8.019  -0.052  26.587  1.00 10.65           C  
+ANISOU  766  C   VAL A 120     1111   1715   1220    -81    184    246       C  
+ATOM    767  O   VAL A 120       7.190  -0.004  27.507  1.00 11.46           O  
+ANISOU  767  O   VAL A 120     1018   2023   1312    -42    227    390       O  
+ATOM    768  CB  VAL A 120       6.481   0.874  24.793  1.00 10.50           C  
+ANISOU  768  CB  VAL A 120     1133   1597   1259   -155    186    301       C  
+ATOM    769  CG1 VAL A 120       6.951   2.269  25.111  1.00 12.01           C  
+ANISOU  769  CG1 VAL A 120     1415   1582   1564   -135    -30    188       C  
+ATOM    770  CG2 VAL A 120       6.034   0.718  23.338  1.00 11.68           C  
+ANISOU  770  CG2 VAL A 120     1435   1643   1359   -171    105     73       C  
+ATOM    771  N   ALA A 121       9.329  -0.096  26.800  1.00  9.63           N  
+ANISOU  771  N   ALA A 121      999   1563   1095    -15    172    342       N  
+ATOM    772  CA  ALA A 121       9.892  -0.223  28.122  1.00  9.54           C  
+ANISOU  772  CA  ALA A 121     1078   1430   1116    -21    186    223       C  
+ATOM    773  C   ALA A 121      11.142   0.577  28.232  1.00  8.91           C  
+ANISOU  773  C   ALA A 121      970   1291   1123    -20    140    150       C  
+ATOM    774  O   ALA A 121      11.856   0.748  27.254  1.00  9.52           O  
+ANISOU  774  O   ALA A 121     1157   1389   1071   -104    256    236       O  
+ATOM    775  CB  ALA A 121      10.175  -1.706  28.427  1.00 10.87           C  
+ANISOU  775  CB  ALA A 121     1252   1449   1427     21    157    232       C  
+ATOM    776  N   SER A 122      11.419   1.073  29.424  1.00  8.69           N  
+ANISOU  776  N   SER A 122     1040   1238   1023   -107    200    258       N  
+ATOM    777  C   SER A 122      13.843   0.937  29.779  1.00  8.87           C  
+ANISOU  777  C   SER A 122     1071   1173   1123    -68     54    284       C  
+ATOM    778  O   SER A 122      13.730  -0.252  30.129  1.00  9.62           O  
+ANISOU  778  O   SER A 122     1042   1261   1352   -105    163    362       O  
+ATOM    779  CA ASER A 122      12.622   1.845  29.619  0.50  8.75           C  
+ANISOU  779  CA ASER A 122      988   1222   1113    -52    128    216       C  
+ATOM    780  CB ASER A 122      12.457   2.789  30.809  0.50  8.85           C  
+ANISOU  780  CB ASER A 122     1085   1158   1116    -10     81    175       C  
+ATOM    781  OG ASER A 122      12.040   2.080  31.963  0.50  7.59           O  
+ANISOU  781  OG ASER A 122     1011   1018    852   -112    177    251       O  
+ATOM    782  CA BSER A 122      12.623   1.838  29.696  0.50  9.72           C  
+ANISOU  782  CA BSER A 122     1102   1316   1273    -48    103    198       C  
+ATOM    783  CB BSER A 122      12.477   2.578  31.027  0.50 10.51           C  
+ANISOU  783  CB BSER A 122     1291   1313   1389    -36     46    136       C  
+ATOM    784  OG BSER A 122      11.355   3.420  31.029  0.50 14.12           O  
+ANISOU  784  OG BSER A 122     1676   1735   1953    -10    -69     50       O  
+ATOM    785  N   ILE A 123      14.997   1.509  29.530  1.00  8.15           N  
+ANISOU  785  N   ILE A 123      888   1214    993    -13     72    256       N  
+ATOM    786  CA  ILE A 123      16.271   0.857  29.799  1.00  8.12           C  
+ANISOU  786  CA  ILE A 123      927   1098   1058     53     87    199       C  
+ATOM    787  C   ILE A 123      16.942   1.553  30.978  1.00  8.32           C  
+ANISOU  787  C   ILE A 123     1022   1225    914     88    117    195       C  
+ATOM    788  O   ILE A 123      16.958   2.780  31.057  1.00  8.86           O  
+ANISOU  788  O   ILE A 123     1284   1212    867    116     22    212       O  
+ATOM    789  CB  ILE A 123      17.192   0.852  28.530  1.00  6.84           C  
+ANISOU  789  CB  ILE A 123      861   1069    669     37     35     41       C  
+ATOM    790  CG1 ILE A 123      18.503   0.127  28.797  1.00  8.89           C  
+ANISOU  790  CG1 ILE A 123      925   1305   1147    141    -76     89       C  
+ATOM    791  CG2 ILE A 123      17.494   2.258  28.030  1.00  8.38           C  
+ANISOU  791  CG2 ILE A 123     1040   1145    997    -42     62    300       C  
+ATOM    792  CD1 ILE A 123      18.351  -1.344  28.965  1.00 11.56           C  
+ANISOU  792  CD1 ILE A 123     1477   1431   1484    107     28    139       C  
+ATOM    793  N   SER A 124      17.501   0.756  31.886  1.00  8.88           N  
+ANISOU  793  N   SER A 124     1112   1313    948    153    119    176       N  
+ATOM    794  C   SER A 124      19.418   2.062  32.695  1.00  9.62           C  
+ANISOU  794  C   SER A 124     1309   1470    873    111    -73    183       C  
+ATOM    795  O   SER A 124      20.193   1.677  31.798  1.00  9.37           O  
+ANISOU  795  O   SER A 124     1167   1473    921     51     34    179       O  
+ATOM    796  CA ASER A 124      18.174   1.285  33.057  0.50  9.66           C  
+ANISOU  796  CA ASER A 124     1269   1426    976     97     -5    204       C  
+ATOM    797  CB ASER A 124      18.597   0.135  33.970  0.50  9.70           C  
+ANISOU  797  CB ASER A 124     1305   1380   1000    142    -78    195       C  
+ATOM    798  OG ASER A 124      17.465  -0.578  34.421  0.50 10.42           O  
+ANISOU  798  OG ASER A 124     1368   1685    905     14    -86    580       O  
+ATOM    799  CA BSER A 124      18.187   1.256  33.061  0.50 10.30           C  
+ANISOU  799  CA BSER A 124     1352   1495   1064     88      5    141       C  
+ATOM    800  CB BSER A 124      18.637   0.059  33.904  0.50 10.58           C  
+ANISOU  800  CB BSER A 124     1417   1480   1122    140    -40    139       C  
+ATOM    801  OG BSER A 124      19.285   0.468  35.093  0.50 14.74           O  
+ANISOU  801  OG BSER A 124     2011   2090   1498     -7    -28    -63       O  
+ATOM    802  N   LEU A 125      19.622   3.146  33.404  1.00 10.49           N  
+ANISOU  802  N   LEU A 125     1427   1573    985     19    -37    128       N  
+ATOM    803  CA  LEU A 125      20.869   3.870  33.318  1.00 11.24           C  
+ANISOU  803  CA  LEU A 125     1595   1616   1059    -42   -134    173       C  
+ATOM    804  C   LEU A 125      21.948   3.119  34.077  1.00 11.51           C  
+ANISOU  804  C   LEU A 125     1679   1708    985    -23    -86    229       C  
+ATOM    805  O   LEU A 125      21.659   2.378  35.026  1.00 12.71           O  
+ANISOU  805  O   LEU A 125     1741   1939   1149    -91   -110    418       O  
+ATOM    806  CB  LEU A 125      20.695   5.258  33.915  1.00 12.86           C  
+ANISOU  806  CB  LEU A 125     1771   1708   1406     -7   -212    125       C  
+ATOM    807  CG  LEU A 125      19.867   6.189  33.028  1.00 15.52           C  
+ANISOU  807  CG  LEU A 125     1963   1951   1982     46   -234    196       C  
+ATOM    808  CD1 LEU A 125      19.752   7.503  33.738  1.00 19.30           C  
+ANISOU  808  CD1 LEU A 125     2535   2198   2599    111   -253     82       C  
+ATOM    809  CD2 LEU A 125      20.489   6.362  31.623  1.00 16.78           C  
+ANISOU  809  CD2 LEU A 125     2290   2177   1907    -14   -408    201       C  
+ATOM    810  N   PRO A 126      23.200   3.336  33.708  1.00 11.31           N  
+ANISOU  810  N   PRO A 126     1621   1628   1045     65   -129    210       N  
+ATOM    811  CA  PRO A 126      24.279   2.714  34.447  1.00 12.85           C  
+ANISOU  811  CA  PRO A 126     1734   1897   1250     17    -81    189       C  
+ATOM    812  C   PRO A 126      24.504   3.381  35.800  1.00 13.00           C  
+ANISOU  812  C   PRO A 126     1780   1961   1196     52    -55    128       C  
+ATOM    813  O   PRO A 126      24.176   4.539  35.970  1.00 14.90           O  
+ANISOU  813  O   PRO A 126     2102   2295   1264   -139    -90     18       O  
+ATOM    814  CB  PRO A 126      25.479   2.946  33.554  1.00 13.25           C  
+ANISOU  814  CB  PRO A 126     1672   1982   1377    115    -58    219       C  
+ATOM    815  CG  PRO A 126      25.137   4.150  32.755  1.00 14.51           C  
+ANISOU  815  CG  PRO A 126     1942   1982   1587    -62    -73    231       C  
+ATOM    816  CD  PRO A 126      23.693   4.196  32.623  1.00 11.57           C  
+ANISOU  816  CD  PRO A 126     1735   1609   1052      1   -115    262       C  
+ATOM    817  N   THR A 127      25.005   2.607  36.737  1.00 15.00           N  
+ANISOU  817  N   THR A 127     1943   2316   1437     21    -96    115       N  
+ATOM    818  C   THR A 127      27.023   3.204  38.009  1.00 14.89           C  
+ANISOU  818  C   THR A 127     1898   2203   1557     12   -129     44       C  
+ATOM    819  O   THR A 127      27.605   3.896  38.831  1.00 17.42           O  
+ANISOU  819  O   THR A 127     2173   2673   1773     25   -191    -83       O  
+ATOM    820  CA ATHR A 127      25.505   3.050  38.050  0.50 16.01           C  
+ANISOU  820  CA ATHR A 127     2045   2402   1634     17   -112     52       C  
+ATOM    821  CB ATHR A 127      25.228   1.989  39.166  0.50 16.82           C  
+ANISOU  821  CB ATHR A 127     2161   2385   1845    -22    -62     77       C  
+ATOM    822  OG1ATHR A 127      23.950   1.364  38.973  0.50 19.24           O  
+ANISOU  822  OG1ATHR A 127     2422   2769   2117    -87    -82     42       O  
+ATOM    823  CG2ATHR A 127      25.311   2.633  40.559  0.50 18.69           C  
+ANISOU  823  CG2ATHR A 127     2466   2545   2089      7    -82     17       C  
+ATOM    824  CA BTHR A 127      25.502   3.238  37.971  0.50 14.39           C  
+ANISOU  824  CA BTHR A 127     1869   2188   1409     38    -96     78       C  
+ATOM    825  CB BTHR A 127      24.892   2.633  39.250  0.50 13.80           C  
+ANISOU  825  CB BTHR A 127     1830   2071   1343     31    -49     99       C  
+ATOM    826  OG1BTHR A 127      25.163   1.225  39.274  0.50 12.82           O  
+ANISOU  826  OG1BTHR A 127     1734   1914   1222     59   -167    540       O  
+ATOM    827  CG2BTHR A 127      23.402   2.867  39.295  0.50 13.17           C  
+ANISOU  827  CG2BTHR A 127     1837   1916   1250     37      0    -91       C  
+ATOM    828  N   SER A 128      27.651   2.447  37.101  1.00 14.10           N  
+ANISOU  828  N   SER A 128     1790   2153   1413     25   -205    128       N  
+ATOM    829  C   SER A 128      29.355   2.240  35.391  1.00 13.27           C  
+ANISOU  829  C   SER A 128     1705   1992   1341     80   -219    227       C  
+ATOM    830  O   SER A 128      28.498   1.711  34.681  1.00 14.28           O  
+ANISOU  830  O   SER A 128     1720   2413   1290      0   -204    225       O  
+ATOM    831  CA ASER A 128      29.081   2.524  36.861  0.50 12.87           C  
+ANISOU  831  CA ASER A 128     1723   1852   1314     41   -215    119       C  
+ATOM    832  CB ASER A 128      29.830   1.520  37.735  0.50 12.55           C  
+ANISOU  832  CB ASER A 128     1764   1718   1286     44   -260    111       C  
+ATOM    833  OG ASER A 128      29.584   0.186  37.300  0.50 10.87           O  
+ANISOU  833  OG ASER A 128     1949   1241    939     77   -248     80       O  
+ATOM    834  CA BSER A 128      29.093   2.493  36.872  0.50 13.85           C  
+ANISOU  834  CA BSER A 128     1784   2031   1446     34   -193    122       C  
+ATOM    835  CB BSER A 128      29.839   1.434  37.692  0.50 14.20           C  
+ANISOU  835  CB BSER A 128     1859   2010   1523     43   -227    141       C  
+ATOM    836  OG BSER A 128      29.781   1.659  39.090  0.50 16.61           O  
+ANISOU  836  OG BSER A 128     2190   2341   1778     15   -166     85       O  
+ATOM    837  N   CYS A 129      30.551   2.582  34.941  1.00 13.06           N  
+ANISOU  837  N   CYS A 129     1692   2047   1222     88   -306    298       N  
+ATOM    838  CA  CYS A 129      30.956   2.394  33.568  1.00 13.26           C  
+ANISOU  838  CA  CYS A 129     1619   2093   1323    166   -209    284       C  
+ATOM    839  C   CYS A 129      31.225   0.932  33.291  1.00 13.14           C  
+ANISOU  839  C   CYS A 129     1619   2010   1362    265   -174    344       C  
+ATOM    840  O   CYS A 129      31.548   0.169  34.218  1.00 15.03           O  
+ANISOU  840  O   CYS A 129     2046   2090   1573    384   -275    535       O  
+ATOM    841  CB  CYS A 129      32.171   3.253  33.288  1.00 12.86           C  
+ANISOU  841  CB  CYS A 129     1551   2269   1066     68   -267    364       C  
+ATOM    842  SG  CYS A 129      31.939   4.983  33.574  1.00 14.40           S  
+ANISOU  842  SG  CYS A 129     1587   2733   1150    108   -421    268       S  
+ATOM    843  N   ALA A 130      31.125   0.529  32.033  1.00 14.43           N  
+ANISOU  843  N   ALA A 130     1716   2112   1653    366   -117    282       N  
+ATOM    844  CA  ALA A 130      31.406  -0.833  31.600  1.00 14.48           C  
+ANISOU  844  CA  ALA A 130     1727   2085   1687    251    -67    253       C  
+ATOM    845  C   ALA A 130      32.889  -0.979  31.244  1.00 15.71           C  
+ANISOU  845  C   ALA A 130     1821   2181   1966    258   -101    267       C  
+ATOM    846  O   ALA A 130      33.576  -0.012  30.925  1.00 17.79           O  
+ANISOU  846  O   ALA A 130     1868   2496   2395    349    -24    289       O  
+ATOM    847  CB  ALA A 130      30.547  -1.214  30.398  1.00 15.48           C  
+ANISOU  847  CB  ALA A 130     1802   2087   1993    266    -65    168       C  
+ATOM    848  N   SER A 131      33.365  -2.215  31.280  1.00 15.62           N  
+ANISOU  848  N   SER A 131     1846   2243   1844    313    -30    229       N  
+ATOM    849  CA  SER A 131      34.779  -2.476  31.051  1.00 14.92           C  
+ANISOU  849  CA  SER A 131     1765   2174   1728    369    -71    190       C  
+ATOM    850  C   SER A 131      35.023  -2.988  29.637  1.00 13.21           C  
+ANISOU  850  C   SER A 131     1599   1867   1552    329    -72    212       C  
+ATOM    851  O   SER A 131      34.149  -3.591  28.992  1.00 13.54           O  
+ANISOU  851  O   SER A 131     1418   2250   1474    472    -59    349       O  
+ATOM    852  CB  SER A 131      35.328  -3.473  32.071  1.00 15.42           C  
+ANISOU  852  CB  SER A 131     1824   2223   1809    437    -68    217       C  
+ATOM    853  OG  SER A 131      34.711  -4.717  31.880  1.00 17.39           O  
+ANISOU  853  OG  SER A 131     2119   2465   2022    343     32    427       O  
+ATOM    854  N   ALA A 132      36.258  -2.819  29.213  1.00 12.51           N  
+ANISOU  854  N   ALA A 132     1575   1718   1459    338    -99    256       N  
+ATOM    855  CA  ALA A 132      36.711  -3.364  27.955  1.00 11.20           C  
+ANISOU  855  CA  ALA A 132     1390   1595   1270    255    -98    337       C  
+ATOM    856  C   ALA A 132      36.418  -4.855  27.879  1.00 10.81           C  
+ANISOU  856  C   ALA A 132     1258   1452   1396    306   -108    412       C  
+ATOM    857  O   ALA A 132      36.591  -5.604  28.858  1.00 11.73           O  
+ANISOU  857  O   ALA A 132     1403   1588   1462    232   -250    596       O  
+ATOM    858  CB  ALA A 132      38.192  -3.110  27.765  1.00 13.18           C  
+ANISOU  858  CB  ALA A 132     1577   1754   1676     64    -33    216       C  
+ATOM    859  N   GLY A 133      35.973  -5.293  26.720  1.00 10.76           N  
+ANISOU  859  N   GLY A 133     1228   1356   1502    326   -212    252       N  
+ATOM    860  CA  GLY A 133      35.709  -6.692  26.438  1.00 12.51           C  
+ANISOU  860  CA  GLY A 133     1511   1441   1801    237   -319    261       C  
+ATOM    861  C   GLY A 133      34.267  -7.102  26.645  1.00 12.84           C  
+ANISOU  861  C   GLY A 133     1493   1420   1962     27   -480    256       C  
+ATOM    862  O   GLY A 133      33.863  -8.196  26.220  1.00 16.41           O  
+ANISOU  862  O   GLY A 133     1864   1565   2803    135   -611    289       O  
+ATOM    863  N   THR A 134      33.474  -6.250  27.282  1.00 13.19           N  
+ANISOU  863  N   THR A 134     1400   1727   1881   -103   -350    547       N  
+ATOM    864  CA  THR A 134      32.050  -6.532  27.515  1.00 14.23           C  
+ANISOU  864  CA  THR A 134     1487   1869   2051    -78   -337    549       C  
+ATOM    865  C   THR A 134      31.332  -6.566  26.127  1.00 13.77           C  
+ANISOU  865  C   THR A 134     1513   1674   2045   -125   -312    513       C  
+ATOM    866  O   THR A 134      31.493  -5.616  25.367  1.00 12.32           O  
+ANISOU  866  O   THR A 134     1448   1359   1873    -95   -175    593       O  
+ATOM    867  CB  THR A 134      31.437  -5.447  28.457  1.00 14.95           C  
+ANISOU  867  CB  THR A 134     1589   2224   1864    -56   -469    524       C  
+ATOM    868  OG1 THR A 134      32.193  -5.284  29.691  1.00 19.48           O  
+ANISOU  868  OG1 THR A 134     2057   3154   2191    -14   -287    373       O  
+ATOM    869  CG2 THR A 134      29.997  -5.804  28.738  1.00 17.08           C  
+ANISOU  869  CG2 THR A 134     1671   2506   2311     46   -194    709       C  
+ATOM    870  N   GLN A 135      30.608  -7.646  25.754  1.00 14.87           N  
+ANISOU  870  N   GLN A 135     1752   1678   2220   -104   -397    571       N  
+ATOM    871  CA  GLN A 135      29.792  -7.677  24.501  1.00 14.71           C  
+ANISOU  871  CA  GLN A 135     1653   1764   2170    -44   -254    421       C  
+ATOM    872  C   GLN A 135      28.459  -6.996  24.784  1.00 13.87           C  
+ANISOU  872  C   GLN A 135     1421   1839   2008    -49   -183    497       C  
+ATOM    873  O   GLN A 135      27.746  -7.415  25.661  1.00 17.09           O  
+ANISOU  873  O   GLN A 135     1680   2560   2254    175    -71    755       O  
+ATOM    874  CB  GLN A 135      29.576  -9.151  23.968  1.00 15.25           C  
+ANISOU  874  CB  GLN A 135     1820   1697   2274    -40   -276    430       C  
+ATOM    875  CG  GLN A 135      28.875  -9.273  22.559  1.00 15.97           C  
+ANISOU  875  CG  GLN A 135     1991   1732   2342    -81   -268    387       C  
+ATOM    876  CD  GLN A 135      28.738 -10.721  22.014  1.00 16.41           C  
+ANISOU  876  CD  GLN A 135     1984   2039   2209     48   -255    224       C  
+ATOM    877  OE1 GLN A 135      29.348 -11.113  21.006  1.00 21.12           O  
+ANISOU  877  OE1 GLN A 135     2298   2594   3133    118      2    -99       O  
+ATOM    878  NE2 GLN A 135      27.876 -11.474  22.630  1.00 16.36           N  
+ANISOU  878  NE2 GLN A 135     2251   2040   1925    104   -293    304       N  
+ATOM    879  N   CYS A 136      28.119  -5.986  23.991  1.00 10.06           N  
+ANISOU  879  N   CYS A 136     1158   1280   1382    -53   -130    465       N  
+ATOM    880  CA  CYS A 136      26.928  -5.142  24.095  1.00  9.32           C  
+ANISOU  880  CA  CYS A 136      897   1523   1119     -3    -43    214       C  
+ATOM    881  C   CYS A 136      26.053  -5.378  22.863  1.00  7.97           C  
+ANISOU  881  C   CYS A 136      980    964   1082     -9     -7    200       C  
+ATOM    882  O   CYS A 136      26.510  -5.913  21.865  1.00  8.83           O  
+ANISOU  882  O   CYS A 136      900   1054   1398    116   -146      2       O  
+ATOM    883  CB  CYS A 136      27.355  -3.685  24.144  1.00  8.94           C  
+ANISOU  883  CB  CYS A 136      779   1717    899     11   -169     83       C  
+ATOM    884  SG  CYS A 136      28.500  -3.362  25.524  1.00 14.29           S  
+ANISOU  884  SG  CYS A 136     1039   3148   1240    388   -214   -563       S  
+ATOM    885  N   LEU A 137      24.824  -4.890  22.935  1.00  6.95           N  
+ANISOU  885  N   LEU A 137      816    871    953      8     17    267       N  
+ATOM    886  CA  LEU A 137      23.869  -4.969  21.835  1.00  7.10           C  
+ANISOU  886  CA  LEU A 137      845    854    995    -46    -58    222       C  
+ATOM    887  C   LEU A 137      23.626  -3.550  21.339  1.00  6.20           C  
+ANISOU  887  C   LEU A 137      773    755    825      4    -53    219       C  
+ATOM    888  O   LEU A 137      23.191  -2.688  22.096  1.00  6.57           O  
+ANISOU  888  O   LEU A 137      724    888    884     26    -38    279       O  
+ATOM    889  CB  LEU A 137      22.557  -5.587  22.301  1.00  7.26           C  
+ANISOU  889  CB  LEU A 137      934    769   1052    -64     45    362       C  
+ATOM    890  CG  LEU A 137      21.524  -5.830  21.202  1.00  8.04           C  
+ANISOU  890  CG  LEU A 137     1044   1039    970   -207    -33    327       C  
+ATOM    891  CD1 LEU A 137      21.984  -6.956  20.303  1.00  9.69           C  
+ANISOU  891  CD1 LEU A 137     1074   1429   1178   -182   -131    244       C  
+ATOM    892  CD2 LEU A 137      20.152  -6.157  21.773  1.00  9.82           C  
+ANISOU  892  CD2 LEU A 137     1000   1357   1373   -262     -8    340       C  
+ATOM    893  N   ILE A 138      23.881  -3.356  20.042  1.00  5.67           N  
+ANISOU  893  N   ILE A 138      685    619    849     63     14    157       N  
+ATOM    894  CA  ILE A 138      23.714  -2.086  19.361  1.00  5.95           C  
+ANISOU  894  CA  ILE A 138      789    647    822     35    -71    104       C  
+ATOM    895  C   ILE A 138      22.606  -2.285  18.338  1.00  5.96           C  
+ANISOU  895  C   ILE A 138      757    726    780     23    -75    159       C  
+ATOM    896  O   ILE A 138      22.579  -3.294  17.647  1.00  6.36           O  
+ANISOU  896  O   ILE A 138      778    649    988     96   -150     36       O  
+ATOM    897  CB  ILE A 138      25.042  -1.669  18.676  1.00  6.28           C  
+ANISOU  897  CB  ILE A 138      793    668    923     94     -8    130       C  
+ATOM    898  CG1 ILE A 138      26.203  -1.742  19.689  1.00  7.03           C  
+ANISOU  898  CG1 ILE A 138      711    884   1076      6    -30    252       C  
+ATOM    899  CG2 ILE A 138      24.892  -0.284  18.097  1.00  6.82           C  
+ANISOU  899  CG2 ILE A 138      893    689   1008    -86    -48    203       C  
+ATOM    900  CD1 ILE A 138      27.536  -1.312  19.127  1.00  8.29           C  
+ANISOU  900  CD1 ILE A 138      882    845   1424   -128     25    196       C  
+ATOM    901  N   SER A 139      21.701  -1.336  18.232  1.00  5.43           N  
+ANISOU  901  N   SER A 139      741    501    818     -2    -27     66       N  
+ATOM    902  CA  SER A 139      20.514  -1.507  17.399  1.00  5.53           C  
+ANISOU  902  CA  SER A 139      746    553    800    -18     40     36       C  
+ATOM    903  C   SER A 139      20.131  -0.241  16.693  1.00  4.82           C  
+ANISOU  903  C   SER A 139      638    394    797    -10     -9     89       C  
+ATOM    904  O   SER A 139      20.440   0.842  17.137  1.00  5.46           O  
+ANISOU  904  O   SER A 139      836    507    730     -9     51     76       O  
+ATOM    905  CB  SER A 139      19.374  -2.106  18.228  1.00  6.16           C  
+ANISOU  905  CB  SER A 139      800    611    928    -27    -16    206       C  
+ATOM    906  OG  SER A 139      19.126  -1.364  19.389  1.00  6.37           O  
+ANISOU  906  OG  SER A 139      897    810    713      4     30     99       O  
+ATOM    907  N   GLY A 140      19.436  -0.401  15.569  1.00  5.24           N  
+ANISOU  907  N   GLY A 140      660    463    865    -67      7     26       N  
+ATOM    908  CA  GLY A 140      18.907   0.738  14.856  1.00  5.14           C  
+ANISOU  908  CA  GLY A 140      628    498    827    -19     18     77       C  
+ATOM    909  C   GLY A 140      18.381   0.391  13.484  1.00  5.48           C  
+ANISOU  909  C   GLY A 140      661    605    814   -124     57     39       C  
+ATOM    910  O   GLY A 140      18.506  -0.734  12.973  1.00  6.00           O  
+ANISOU  910  O   GLY A 140      732    671    876    -56    -90    115       O  
+ATOM    911  N   TRP A 141      17.856   1.430  12.842  1.00  5.30           N  
+ANISOU  911  N   TRP A 141      694    448    870    -36    -74     59       N  
+ATOM    912  CA  TRP A 141      17.299   1.391  11.488  1.00  6.11           C  
+ANISOU  912  CA  TRP A 141      770    594    955     15    -41     50       C  
+ATOM    913  C   TRP A 141      18.218   2.085  10.483  1.00  6.08           C  
+ANISOU  913  C   TRP A 141      773    710    825     13    -34     58       C  
+ATOM    914  O   TRP A 141      17.785   2.484   9.411  1.00  6.54           O  
+ANISOU  914  O   TRP A 141      862    840    780     57   -114    164       O  
+ATOM    915  CB  TRP A 141      15.902   2.010  11.460  1.00  6.45           C  
+ANISOU  915  CB  TRP A 141      859    762    827     70   -127     58       C  
+ATOM    916  CG  TRP A 141      14.849   1.212  12.143  1.00  6.32           C  
+ANISOU  916  CG  TRP A 141      831    614    953    -32   -141     83       C  
+ATOM    917  CD1 TRP A 141      14.145   0.179  11.624  1.00  6.93           C  
+ANISOU  917  CD1 TRP A 141      847    793    991      4    -16     -3       C  
+ATOM    918  CD2 TRP A 141      14.345   1.441  13.464  1.00  6.01           C  
+ANISOU  918  CD2 TRP A 141      717    680    885    -39   -246    108       C  
+ATOM    919  NE1 TRP A 141      13.247  -0.264  12.547  1.00  6.69           N  
+ANISOU  919  NE1 TRP A 141      846    628   1065     22    -72     22       N  
+ATOM    920  CE2 TRP A 141      13.327   0.511  13.679  1.00  5.67           C  
+ANISOU  920  CE2 TRP A 141      671    664    816    155     12    107       C  
+ATOM    921  CE3 TRP A 141      14.660   2.345  14.477  1.00  6.37           C  
+ANISOU  921  CE3 TRP A 141      710    695   1014     66   -123     97       C  
+ATOM    922  CZ2 TRP A 141      12.615   0.450  14.877  1.00  6.67           C  
+ANISOU  922  CZ2 TRP A 141      572    738   1223    -31    -95     47       C  
+ATOM    923  CZ3 TRP A 141      13.940   2.304  15.649  1.00  6.87           C  
+ANISOU  923  CZ3 TRP A 141      723    909    979     95    -39     93       C  
+ATOM    924  CH2 TRP A 141      12.912   1.377  15.838  1.00  6.67           C  
+ANISOU  924  CH2 TRP A 141      845    746    940     72    -94     35       C  
+ATOM    925  N   GLY A 142      19.500   2.194  10.811  1.00  6.22           N  
+ANISOU  925  N   GLY A 142      849    776    738    -57    -60    135       N  
+ATOM    926  CA  GLY A 142      20.448   2.797   9.929  1.00  6.61           C  
+ANISOU  926  CA  GLY A 142      884    818    810    -96      4    128       C  
+ATOM    927  C   GLY A 142      20.856   1.929   8.769  1.00  6.38           C  
+ANISOU  927  C   GLY A 142      885    754    784    -38   -130    246       C  
+ATOM    928  O   GLY A 142      20.447   0.796   8.627  1.00  6.46           O  
+ANISOU  928  O   GLY A 142      982    722    751    -49   -120    102       O  
+ATOM    929  N   ASN A 143      21.717   2.493   7.949  1.00  6.86           N  
+ANISOU  929  N   ASN A 143     1045    771    789    -67     -9    125       N  
+ATOM    930  CA  ASN A 143      22.209   1.880   6.758  1.00  7.47           C  
+ANISOU  930  CA  ASN A 143     1113    924    801      9    -77     58       C  
+ATOM    931  C   ASN A 143      22.836   0.549   7.068  1.00  7.56           C  
+ANISOU  931  C   ASN A 143     1089   1006    777     64    -37     52       C  
+ATOM    932  O   ASN A 143      23.550   0.385   8.054  1.00  6.74           O  
+ANISOU  932  O   ASN A 143     1087    744    729     67     14     88       O  
+ATOM    933  CB  ASN A 143      23.241   2.839   6.141  1.00  7.91           C  
+ATOM    934  CG  ASN A 143      23.597   2.560   4.713  1.00 10.06           C  
+ANISOU  934  CG  ASN A 143     1599   1180   1041   -106    150    195       C  
+ATOM    935  OD1 ASN A 143      23.182   1.589   4.101  1.00 11.63           O  
+ANISOU  935  OD1 ASN A 143     2251   1412    754   -353    203     53       O  
+ATOM    936  ND2 ASN A 143      24.437   3.447   4.162  1.00 13.96           N  
+ANISOU  936  ND2 ASN A 143     2604   1378   1321   -220    487    190       N  
+ATOM    937  N   THR A 144      22.554  -0.415   6.209  1.00  7.89           N  
+ANISOU  937  N   THR A 144     1252    950    794    139    -55     56       N  
+ATOM    938  CA  THR A 144      23.095  -1.760   6.319  1.00  8.11           C  
+ANISOU  938  CA  THR A 144     1313    968    798     99     28     70       C  
+ATOM    939  C   THR A 144      24.258  -2.006   5.356  1.00  8.80           C  
+ANISOU  939  C   THR A 144     1391    974    976     63     81    -48       C  
+ATOM    940  O   THR A 144      24.823  -3.084   5.329  1.00  9.48           O  
+ANISOU  940  O   THR A 144     1472    974   1156    192    147     -4       O  
+ATOM    941  CB  THR A 144      22.024  -2.846   6.093  1.00  8.23           C  
+ANISOU  941  CB  THR A 144     1524    833    769     83    -54     88       C  
+ATOM    942  OG1 THR A 144      21.521  -2.766   4.764  1.00 10.53           O  
+ANISOU  942  OG1 THR A 144     1692   1364    941    -45   -179    -61       O  
+ATOM    943  CG2 THR A 144      20.876  -2.696   7.062  1.00  8.95           C  
+ANISOU  943  CG2 THR A 144     1166   1208   1025    -26    -68      9       C  
+ATOM    944  N   LYS A 145      24.598  -1.008   4.546  1.00  9.83           N  
+ANISOU  944  N   LYS A 145     1545   1040   1147      0    185    -48       N  
+ATOM    945  CA  LYS A 145      25.753  -1.078   3.657  1.00 12.75           C  
+ANISOU  945  CA  LYS A 145     1857   1566   1420     20    221     39       C  
+ATOM    946  C   LYS A 145      26.850  -0.089   4.064  1.00 14.02           C  
+ANISOU  946  C   LYS A 145     2068   1726   1531    -43    285     35       C  
+ATOM    947  O   LYS A 145      26.564   1.045   4.446  1.00 15.13           O  
+ANISOU  947  O   LYS A 145     2456   1707   1584   -175    438     16       O  
+ATOM    948  CB  LYS A 145      25.310  -0.821   2.202  1.00 12.65           C  
+ANISOU  948  CB  LYS A 145     1773   1663   1370     47    210    -27       C  
+ATOM    949  CG  LYS A 145      24.482  -1.923   1.596  1.00 15.05           C  
+ANISOU  949  CG  LYS A 145     2035   1958   1725    -12    123      9       C  
+ATOM    950  CD  LYS A 145      24.217  -1.671   0.108  1.00 17.02           C  
+ANISOU  950  CD  LYS A 145     2295   2286   1882     31    -14   -120       C  
+ATOM    951  CE  LYS A 145      23.380  -2.795  -0.494  1.00 20.19           C  
+ANISOU  951  CE  LYS A 145     2817   2763   2089    -49   -183    -55       C  
+ATOM    952  NZ  LYS A 145      22.935  -2.478  -1.903  1.00 24.01           N  
+ANISOU  952  NZ  LYS A 145     3286   3370   2465     32   -252     99       N  
+ATOM    953  N   SER A 146      28.098  -0.527   3.980  1.00 16.67           N  
+ANISOU  953  N   SER A 146     2278   2163   1893   -173    145    -47       N  
+ATOM    954  CA  SER A 146      29.272   0.320   4.266  1.00 19.64           C  
+ANISOU  954  CA  SER A 146     2561   2599   2302   -229    127     -5       C  
+ATOM    955  C   SER A 146      29.727   1.158   3.049  1.00 21.97           C  
+ANISOU  955  C   SER A 146     2838   2913   2594   -263    129    -10       C  
+ATOM    956  O   SER A 146      30.542   2.084   3.176  1.00 23.00           O  
+ANISOU  956  O   SER A 146     2931   3094   2714   -357    174   -105       O  
+ATOM    957  CB  SER A 146      30.410  -0.569   4.767  1.00 20.13           C  
+ANISOU  957  CB  SER A 146     2562   2716   2369   -263     62    -29       C  
+ATOM    958  OG  SER A 146      30.677  -1.624   3.860  1.00 23.20           O  
+ANISOU  958  OG  SER A 146     2920   3105   2789   -162   -109     42       O  
+ATOM    959  N   SER A 147      29.203   0.819   1.874  1.00 23.78           N  
+ANISOU  959  N   SER A 147     3107   3235   2694   -220    168     50       N  
+ATOM    960  CA  SER A 147      29.401   1.604   0.662  1.00 26.04           C  
+ANISOU  960  CA  SER A 147     3377   3446   3067    -99    144     42       C  
+ATOM    961  C   SER A 147      28.053   1.586  -0.025  1.00 25.91           C  
+ANISOU  961  C   SER A 147     3393   3463   2986    -99    119     49       C  
+ATOM    962  O   SER A 147      27.460   0.531  -0.222  1.00 28.43           O  
+ANISOU  962  O   SER A 147     3712   3779   3310   -110    172      6       O  
+ATOM    963  CB  SER A 147      30.485   0.992  -0.217  1.00 26.51           C  
+ANISOU  963  CB  SER A 147     3422   3490   3159    -84    126     17       C  
+ATOM    964  OG  SER A 147      31.674   0.799   0.529  1.00 29.98           O  
+ANISOU  964  OG  SER A 147     3758   4047   3583    -18    113     17       O  
+ATOM    965  N   GLY A 148      27.532   2.759  -0.344  1.00 26.01           N  
+ANISOU  965  N   GLY A 148     3294   3560   3027    -43    148      4       N  
+ATOM    966  CA  GLY A 148      26.186   2.843  -0.888  1.00 25.11           C  
+ANISOU  966  CA  GLY A 148     3187   3483   2869   -112    134     52       C  
+ATOM    967  C   GLY A 148      25.212   2.778   0.270  1.00 24.05           C  
+ANISOU  967  C   GLY A 148     3096   3398   2641   -114     78     96       C  
+ATOM    968  O   GLY A 148      25.612   2.901   1.433  1.00 23.33           O  
+ANISOU  968  O   GLY A 148     3096   3295   2473   -236    152    143       O  
+ATOM    969  N   THR A 149      23.934   2.630  -0.053  1.00 22.13           N  
+ANISOU  969  N   THR A 149     2877   3152   2377   -125    120    155       N  
+ATOM    970  CA  THR A 149      22.888   2.788   0.956  1.00 21.82           C  
+ANISOU  970  CA  THR A 149     2834   3097   2357    -58     76    128       C  
+ATOM    971  C   THR A 149      21.786   1.740   0.801  1.00 19.64           C  
+ANISOU  971  C   THR A 149     2635   2861   1965    -35      4     93       C  
+ATOM    972  O   THR A 149      21.325   1.424  -0.292  1.00 20.74           O  
+ANISOU  972  O   THR A 149     2883   3168   1829    -47    -96    229       O  
+ATOM    973  CB  THR A 149      22.282   4.236   0.998  1.00 22.95           C  
+ANISOU  973  CB  THR A 149     2932   3247   2541     -6     33    119       C  
+ATOM    974  OG1 THR A 149      21.636   4.549  -0.244  1.00 26.89           O  
+ANISOU  974  OG1 THR A 149     3538   3896   2781     71   -128    123       O  
+ATOM    975  CG2 THR A 149      23.354   5.301   1.275  1.00 24.73           C  
+ANISOU  975  CG2 THR A 149     3102   3329   2965     31     71     48       C  
+ATOM    976  N   SER A 150      21.405   1.162   1.926  1.00 15.38           N  
+ANISOU  976  N   SER A 150     2122   2348   1374    -46      4    128       N  
+ATOM    977  CA  SER A 150      20.276   0.242   2.035  1.00 14.32           C  
+ANISOU  977  CA  SER A 150     1921   2158   1359    -30   -117     32       C  
+ATOM    978  C   SER A 150      19.704   0.412   3.434  1.00 12.05           C  
+ANISOU  978  C   SER A 150     1645   1819   1113    -66   -149    182       C  
+ATOM    979  O   SER A 150      20.334   0.078   4.431  1.00 12.99           O  
+ANISOU  979  O   SER A 150     1724   2282    927    109   -201    240       O  
+ATOM    980  CB  SER A 150      20.740  -1.174   1.822  1.00 14.61           C  
+ANISOU  980  CB  SER A 150     1976   2203   1369    -73    -59    -38       C  
+ATOM    981  OG  SER A 150      19.668  -2.080   1.938  1.00 17.66           O  
+ANISOU  981  OG  SER A 150     2614   2285   1809   -336   -150   -149       O  
+ATOM    982  N   TYR A 151      18.525   1.000   3.522  1.00 10.86           N  
+ANISOU  982  N   TYR A 151     1493   1702    930   -124   -139    241       N  
+ATOM    983  CA  TYR A 151      17.892   1.278   4.805  1.00 11.40           C  
+ANISOU  983  CA  TYR A 151     1483   1670   1175   -132   -147    160       C  
+ATOM    984  C   TYR A 151      16.838   0.221   5.052  1.00 11.22           C  
+ANISOU  984  C   TYR A 151     1398   1592   1270   -189   -252    101       C  
+ATOM    985  O   TYR A 151      15.971   0.011   4.215  1.00 12.70           O  
+ANISOU  985  O   TYR A 151     1539   1849   1435   -397   -418     63       O  
+ATOM    986  CB  TYR A 151      17.337   2.706   4.815  1.00 12.70           C  
+ANISOU  986  CB  TYR A 151     1699   1675   1451    -10    -54     82       C  
+ATOM    987  CG  TYR A 151      18.494   3.690   4.914  1.00 13.34           C  
+ANISOU  987  CG  TYR A 151     1872   1539   1655   -124     46    106       C  
+ATOM    988  CD1 TYR A 151      19.038   4.007   6.157  1.00 13.94           C  
+ANISOU  988  CD1 TYR A 151     1732   1484   2078   -247   -207    215       C  
+ATOM    989  CD2 TYR A 151      19.090   4.267   3.798  1.00 16.83           C  
+ANISOU  989  CD2 TYR A 151     2463   2018   1911   -167     66    -32       C  
+ATOM    990  CE1 TYR A 151      20.098   4.880   6.310  1.00 15.89           C  
+ANISOU  990  CE1 TYR A 151     1853   1840   2343    -69   -220    253       C  
+ATOM    991  CE2 TYR A 151      20.188   5.151   3.954  1.00 16.27           C  
+ANISOU  991  CE2 TYR A 151     2359   1869   1955   -218    238     66       C  
+ATOM    992  CZ  TYR A 151      20.687   5.423   5.228  1.00 15.72           C  
+ANISOU  992  CZ  TYR A 151     2082   1725   2165   -157     52     70       C  
+ATOM    993  OH  TYR A 151      21.761   6.280   5.448  1.00 16.71           O  
+ANISOU  993  OH  TYR A 151     1959   1712   2679    -71     -7     26       O  
+ATOM    994  N   PRO A 152      16.886  -0.447   6.200  1.00  9.75           N  
+ANISOU  994  N   PRO A 152     1131   1482   1090   -224   -243     -7       N  
+ATOM    995  CA  PRO A 152      15.987  -1.534   6.491  1.00  9.71           C  
+ANISOU  995  CA  PRO A 152     1232   1311   1147   -110   -188    -18       C  
+ATOM    996  C   PRO A 152      14.600  -1.083   6.927  1.00  9.84           C  
+ANISOU  996  C   PRO A 152     1238   1393   1105   -125   -207    114       C  
+ATOM    997  O   PRO A 152      14.413  -0.012   7.471  1.00 11.89           O  
+ANISOU  997  O   PRO A 152     1250   1413   1852   -126   -172    108       O  
+ATOM    998  CB  PRO A 152      16.700  -2.240   7.653  1.00  9.89           C  
+ANISOU  998  CB  PRO A 152     1196   1302   1259   -125   -106     41       C  
+ATOM    999  CG  PRO A 152      17.322  -1.116   8.377  1.00  9.07           C  
+ANISOU  999  CG  PRO A 152     1073   1205   1168   -135   -191     24       C  
+ATOM   1000  CD  PRO A 152      17.847  -0.210   7.296  1.00  9.37           C  
+ANISOU 1000  CD  PRO A 152     1144   1268   1145   -137   -218    -68       C  
+ATOM   1001  N   ASP A 153      13.628  -1.949   6.721  1.00 10.59           N  
+ANISOU 1001  N   ASP A 153     1233   1503   1287   -190   -199    134       N  
+ATOM   1002  CA  ASP A 153      12.293  -1.745   7.297  1.00 11.04           C  
+ANISOU 1002  CA  ASP A 153     1250   1640   1302   -154   -118    145       C  
+ATOM   1003  C   ASP A 153      12.251  -2.089   8.796  1.00  9.66           C  
+ANISOU 1003  C   ASP A 153     1068   1391   1211   -171   -175    123       C  
+ATOM   1004  O   ASP A 153      11.668  -1.332   9.576  1.00 10.27           O  
+ANISOU 1004  O   ASP A 153     1153   1268   1480   -101   -167    181       O  
+ATOM   1005  CB  ASP A 153      11.239  -2.586   6.567  1.00 11.94           C  
+ANISOU 1005  CB  ASP A 153     1267   1901   1367   -199    -97    150       C  
+ATOM   1006  CG  ASP A 153      11.017  -2.149   5.128  1.00 15.27           C  
+ANISOU 1006  CG  ASP A 153     1855   2214   1730   -196   -143    190       C  
+ATOM   1007  OD1 ASP A 153      11.149  -0.955   4.818  1.00 16.80           O  
+ANISOU 1007  OD1 ASP A 153     2185   2551   1646    268   -177    335       O  
+ATOM   1008  OD2 ASP A 153      10.660  -3.029   4.336  1.00 22.39           O  
+ANISOU 1008  OD2 ASP A 153     3296   3014   2195    -98   -370    -32       O  
+ATOM   1009  N   VAL A 154      12.844  -3.235   9.179  1.00  9.82           N  
+ANISOU 1009  N   VAL A 154     1191   1316   1222    -63   -141    -87       N  
+ATOM   1010  CA  VAL A 154      12.772  -3.721  10.521  1.00  8.78           C  
+ANISOU 1010  CA  VAL A 154      961   1142   1231    -76   -146     -8       C  
+ATOM   1011  C   VAL A 154      14.038  -3.418  11.283  1.00  7.67           C  
+ANISOU 1011  C   VAL A 154      864    786   1263    -68   -118    -72       C  
+ATOM   1012  O   VAL A 154      15.092  -3.133  10.722  1.00  8.04           O  
+ANISOU 1012  O   VAL A 154      970   1111    971    -58   -188    107       O  
+ATOM   1013  CB  VAL A 154      12.415  -5.226  10.623  1.00  8.07           C  
+ANISOU 1013  CB  VAL A 154      950    934   1182   -114   -251   -107       C  
+ATOM   1014  CG1 VAL A 154      11.081  -5.527   9.921  1.00 10.51           C  
+ANISOU 1014  CG1 VAL A 154     1243   1268   1482   -120   -364    -93       C  
+ATOM   1015  CG2 VAL A 154      13.522  -6.130  10.110  1.00  9.56           C  
+ANISOU 1015  CG2 VAL A 154     1217    963   1450     25   -295    -55       C  
+ATOM   1016  N   LEU A 155      13.928  -3.509  12.595  1.00  7.16           N  
+ANISOU 1016  N   LEU A 155      707    871   1140    -24    -49     77       N  
+ATOM   1017  CA  LEU A 155      15.054  -3.146  13.445  1.00  7.04           C  
+ANISOU 1017  CA  LEU A 155      777    811   1087    -38    -73     94       C  
+ATOM   1018  C   LEU A 155      16.181  -4.152  13.351  1.00  6.01           C  
+ANISOU 1018  C   LEU A 155      742    730    812   -108    -21     79       C  
+ATOM   1019  O   LEU A 155      15.946  -5.365  13.449  1.00  6.86           O  
+ANISOU 1019  O   LEU A 155      706    696   1201   -184    -68    107       O  
+ATOM   1020  CB  LEU A 155      14.582  -3.011  14.899  1.00  6.90           C  
+ANISOU 1020  CB  LEU A 155      752    740   1127    -50      5     65       C  
+ATOM   1021  CG  LEU A 155      15.604  -2.493  15.909  1.00  6.87           C  
+ANISOU 1021  CG  LEU A 155      718    821   1069    -55     49     90       C  
+ATOM   1022  CD1 LEU A 155      15.977  -1.048  15.586  1.00  6.83           C  
+ANISOU 1022  CD1 LEU A 155      936    467   1190   -147    -62     70       C  
+ATOM   1023  CD2 LEU A 155      15.070  -2.668  17.353  1.00  7.87           C  
+ANISOU 1023  CD2 LEU A 155      993    936   1059   -120    151    218       C  
+ATOM   1024  N   LYS A 156      17.395  -3.654  13.188  1.00  5.44           N  
+ANISOU 1024  N   LYS A 156      787    377    900    -19      6    -43       N  
+ATOM   1025  CA  LYS A 156      18.579  -4.479  13.115  1.00  6.15           C  
+ANISOU 1025  CA  LYS A 156      804    586    946      9     42   -108       C  
+ATOM   1026  C   LYS A 156      19.426  -4.337  14.365  1.00  5.65           C  
+ANISOU 1026  C   LYS A 156      707    531    908     16    -56     35       C  
+ATOM   1027  O   LYS A 156      19.390  -3.338  15.079  1.00  5.79           O  
+ANISOU 1027  O   LYS A 156      774    588    838    -60    -36    166       O  
+ATOM   1028  CB  LYS A 156      19.403  -4.128  11.859  1.00  6.36           C  
+ANISOU 1028  CB  LYS A 156      780    609   1025     -1    -15     50       C  
+ATOM   1029  CG  LYS A 156      18.695  -4.371  10.527  1.00  7.62           C  
+ANISOU 1029  CG  LYS A 156     1000    841   1054   -146     10     67       C  
+ATOM   1030  CD  LYS A 156      18.440  -5.861  10.317  1.00  9.77           C  
+ANISOU 1030  CD  LYS A 156     1330   1179   1203   -301    -88     82       C  
+ATOM   1031  CE  LYS A 156      17.880  -6.212   8.965  1.00 10.24           C  
+ANISOU 1031  CE  LYS A 156     1557   1120   1212     -3   -100      7       C  
+ATOM   1032  NZ  LYS A 156      17.993  -7.701   8.792  1.00 10.95           N  
+ANISOU 1032  NZ  LYS A 156     1617    959   1583   -193     69    -90       N  
+ATOM   1033  N   CYS A 157      20.200  -5.387  14.609  1.00  6.43           N  
+ANISOU 1033  N   CYS A 157      687    734   1022    -26    -41     52       N  
+ATOM   1034  CA  CYS A 157      20.975  -5.579  15.802  1.00  6.53           C  
+ANISOU 1034  CA  CYS A 157      808    707    966     51    -27     59       C  
+ATOM   1035  C   CYS A 157      22.377  -6.057  15.487  1.00  6.92           C  
+ANISOU 1035  C   CYS A 157      769    705   1156    -44      8     67       C  
+ATOM   1036  O   CYS A 157      22.604  -6.737  14.508  1.00  6.40           O  
+ANISOU 1036  O   CYS A 157      688    680   1061    -58    -20     53       O  
+ATOM   1037  CB  CYS A 157      20.332  -6.671  16.688  1.00  7.83           C  
+ANISOU 1037  CB  CYS A 157      843   1011   1120    102    -19     93       C  
+ATOM   1038  SG  CYS A 157      19.042  -6.074  17.848  1.00  7.65           S  
+ANISOU 1038  SG  CYS A 157      922    922   1060     14     -7    203       S  
+ATOM   1039  N   LEU A 158      23.315  -5.725  16.371  1.00  6.43           N  
+ANISOU 1039  N   LEU A 158      687    704   1050     -9     40     90       N  
+ATOM   1040  CA  LEU A 158      24.692  -6.151  16.284  1.00  6.96           C  
+ANISOU 1040  CA  LEU A 158      881    683   1080    -18     12    129       C  
+ATOM   1041  C   LEU A 158      25.215  -6.399  17.688  1.00  6.02           C  
+ANISOU 1041  C   LEU A 158      677    652    957    -18    -71    136       C  
+ATOM   1042  O   LEU A 158      25.072  -5.551  18.563  1.00  6.89           O  
+ANISOU 1042  O   LEU A 158      905    739    974      0    -62    200       O  
+ATOM   1043  CB  LEU A 158      25.549  -5.063  15.630  1.00  7.04           C  
+ANISOU 1043  CB  LEU A 158      857    715   1102    -39    -26    192       C  
+ATOM   1044  CG  LEU A 158      27.029  -5.400  15.426  1.00  7.36           C  
+ANISOU 1044  CG  LEU A 158      928    877    992   -119     33    144       C  
+ATOM   1045  CD1 LEU A 158      27.252  -6.491  14.401  1.00 11.11           C  
+ANISOU 1045  CD1 LEU A 158     1409   1050   1759   -288    360   -212       C  
+ATOM   1046  CD2 LEU A 158      27.809  -4.107  15.070  1.00  8.38           C  
+ANISOU 1046  CD2 LEU A 158     1038    757   1388   -110    172     58       C  
+ATOM   1047  N   LYS A 159      25.858  -7.540  17.887  1.00  6.95           N  
+ANISOU 1047  N   LYS A 159      804    663   1171    -43    -76    148       N  
+ATOM   1048  CA  LYS A 159      26.598  -7.786  19.090  1.00  7.81           C  
+ANISOU 1048  CA  LYS A 159      957    835   1174     45    -53    153       C  
+ATOM   1049  C   LYS A 159      28.019  -7.319  18.877  1.00  6.94           C  
+ANISOU 1049  C   LYS A 159      855    604   1177    110    -18    209       C  
+ATOM   1050  O   LYS A 159      28.637  -7.667  17.868  1.00  8.33           O  
+ANISOU 1050  O   LYS A 159      907    981   1277    -17     77    116       O  
+ATOM   1051  CB  LYS A 159      26.565  -9.285  19.423  1.00  8.78           C  
+ANISOU 1051  CB  LYS A 159     1119    924   1293     55   -113    235       C  
+ATOM   1052  CG  LYS A 159      25.132  -9.769  19.745  1.00  9.87           C  
+ANISOU 1052  CG  LYS A 159     1280   1052   1417     -7    -42    170       C  
+ATOM   1053  CD  LYS A 159      25.079 -11.236  20.141  1.00 10.79           C  
+ANISOU 1053  CD  LYS A 159     1379   1239   1480      1    -98    144       C  
+ATOM   1054  CE  LYS A 159      23.649 -11.673  20.370  1.00 12.87           C  
+ANISOU 1054  CE  LYS A 159     1401   1553   1934   -238   -137    127       C  
+ATOM   1055  NZ  LYS A 159      23.528 -12.923  21.190  1.00 13.90           N  
+ANISOU 1055  NZ  LYS A 159     1876   1655   1749     36   -102    130       N  
+ATOM   1056  N   ALA A 160      28.535  -6.498  19.791  1.00  7.37           N  
+ANISOU 1056  N   ALA A 160      804    779   1216     32    -42    181       N  
+ATOM   1057  CA  ALA A 160      29.833  -5.874  19.594  1.00  8.06           C  
+ANISOU 1057  CA  ALA A 160      955    880   1226    -23   -102    297       C  
+ATOM   1058  C   ALA A 160      30.496  -5.669  20.949  1.00  7.98           C  
+ANISOU 1058  C   ALA A 160      948    781   1300   -109   -105    247       C  
+ATOM   1059  O   ALA A 160      29.856  -5.267  21.940  1.00  8.80           O  
+ANISOU 1059  O   ALA A 160     1079    935   1326    -51   -167    295       O  
+ATOM   1060  CB  ALA A 160      29.651  -4.505  18.921  1.00  8.87           C  
+ANISOU 1060  CB  ALA A 160     1151    900   1317   -117   -210    317       C  
+ATOM   1061  N   PRO A 161      31.808  -5.880  21.008  1.00  8.13           N  
+ANISOU 1061  N   PRO A 161     1032    729   1326    -22   -160    283       N  
+ATOM   1062  CA  PRO A 161      32.536  -5.641  22.251  1.00  7.88           C  
+ANISOU 1062  CA  PRO A 161     1045    629   1321     62   -148    190       C  
+ATOM   1063  C   PRO A 161      33.025  -4.219  22.436  1.00  8.44           C  
+ANISOU 1063  C   PRO A 161     1002    820   1383    -39   -219    154       C  
+ATOM   1064  O   PRO A 161      33.398  -3.550  21.462  1.00  8.82           O  
+ANISOU 1064  O   PRO A 161     1155    785   1408    -35   -316    265       O  
+ATOM   1065  CB  PRO A 161      33.730  -6.602  22.142  1.00  8.56           C  
+ANISOU 1065  CB  PRO A 161     1204    639   1406    130   -230    227       C  
+ATOM   1066  CG  PRO A 161      34.056  -6.554  20.669  1.00  8.95           C  
+ANISOU 1066  CG  PRO A 161     1197    756   1445     84   -142    245       C  
+ATOM   1067  CD  PRO A 161      32.661  -6.483  19.987  1.00  7.89           C  
+ANISOU 1067  CD  PRO A 161      998    703   1296   -138   -212    197       C  
+ATOM   1068  N   ILE A 162      33.067  -3.807  23.690  1.00  8.44           N  
+ANISOU 1068  N   ILE A 162     1051    874   1280    -70   -233    336       N  
+ATOM   1069  CA  ILE A 162      33.734  -2.569  24.064  1.00  8.46           C  
+ANISOU 1069  CA  ILE A 162     1012    971   1231     21   -208    245       C  
+ATOM   1070  C   ILE A 162      35.238  -2.736  23.918  1.00  7.89           C  
+ANISOU 1070  C   ILE A 162      987    953   1056     84   -161    207       C  
+ATOM   1071  O   ILE A 162      35.808  -3.722  24.397  1.00  8.55           O  
+ANISOU 1071  O   ILE A 162     1021    970   1256     74    -58    409       O  
+ATOM   1072  CB  ILE A 162      33.406  -2.184  25.512  1.00  9.03           C  
+ANISOU 1072  CB  ILE A 162     1059   1141   1229     -2   -178    209       C  
+ATOM   1073  CG1 ILE A 162      31.901  -1.954  25.667  1.00 11.12           C  
+ANISOU 1073  CG1 ILE A 162     1238   1481   1504     58   -116     24       C  
+ATOM   1074  CG2 ILE A 162      34.199  -0.935  25.933  1.00 10.06           C  
+ANISOU 1074  CG2 ILE A 162     1073   1366   1381     96   -132     70       C  
+ATOM   1075  CD1 ILE A 162      31.495  -1.428  27.068  1.00 13.21           C  
+ANISOU 1075  CD1 ILE A 162     1782   1838   1396     90     46    207       C  
+ATOM   1076  N   LEU A 163      35.883  -1.801  23.213  1.00  7.41           N  
+ANISOU 1076  N   LEU A 163      915    874   1026    170    -98    275       N  
+ATOM   1077  CA  LEU A 163      37.304  -1.852  23.035  1.00  7.75           C  
+ANISOU 1077  CA  LEU A 163     1076    797   1070     49    -33    242       C  
+ATOM   1078  C   LEU A 163      38.001  -1.037  24.092  1.00  7.45           C  
+ANISOU 1078  C   LEU A 163      922    817   1091     45    -80    302       C  
+ATOM   1079  O   LEU A 163      37.420  -0.135  24.687  1.00  8.53           O  
+ANISOU 1079  O   LEU A 163     1050   1142   1046     27   -102    133       O  
+ATOM   1080  CB  LEU A 163      37.671  -1.341  21.636  1.00  8.02           C  
+ANISOU 1080  CB  LEU A 163     1019    781   1243    199    -17    253       C  
+ATOM   1081  CG  LEU A 163      36.954  -2.054  20.481  1.00  9.66           C  
+ANISOU 1081  CG  LEU A 163     1492   1100   1077    292      8    223       C  
+ATOM   1082  CD1 LEU A 163      37.445  -1.513  19.139  1.00 13.60           C  
+ANISOU 1082  CD1 LEU A 163     2246   1583   1338    298    -74    313       C  
+ATOM   1083  CD2 LEU A 163      37.156  -3.529  20.505  1.00 12.88           C  
+ANISOU 1083  CD2 LEU A 163     1760   1479   1654     36   -251     54       C  
+ATOM   1084  N   SER A 164      39.273  -1.342  24.328  1.00  8.59           N  
+ANISOU 1084  N   SER A 164     1090    982   1193     53   -104    139       N  
+ATOM   1085  CA  SER A 164      40.054  -0.577  25.276  1.00  9.58           C  
+ANISOU 1085  CA  SER A 164     1181   1165   1293     53   -187    186       C  
+ATOM   1086  C   SER A 164      40.233   0.857  24.834  1.00  9.43           C  
+ANISOU 1086  C   SER A 164     1064   1184   1334     25   -186     45       C  
+ATOM   1087  O   SER A 164      40.219   1.146  23.632  1.00  8.53           O  
+ANISOU 1087  O   SER A 164      905    881   1456    -47   -235    141       O  
+ATOM   1088  CB  SER A 164      41.415  -1.205  25.474  1.00 10.82           C  
+ANISOU 1088  CB  SER A 164     1329   1293   1489     85   -256    124       C  
+ATOM   1089  OG  SER A 164      42.187  -1.048  24.308  1.00 10.93           O  
+ANISOU 1089  OG  SER A 164     1156   1210   1786    158   -231    305       O  
+ATOM   1090  N   ASP A 165      40.404   1.742  25.799  1.00  9.65           N  
+ANISOU 1090  N   ASP A 165     1210   1136   1319     40   -202    158       N  
+ATOM   1091  CA  ASP A 165      40.649   3.147  25.493  1.00  9.92           C  
+ANISOU 1091  CA  ASP A 165     1233   1188   1348    -24   -189     90       C  
+ATOM   1092  C   ASP A 165      41.898   3.285  24.612  1.00  9.95           C  
+ANISOU 1092  C   ASP A 165     1192   1172   1414     31   -191    102       C  
+ATOM   1093  O   ASP A 165      41.922   4.087  23.694  1.00  9.47           O  
+ANISOU 1093  O   ASP A 165     1072   1198   1328    -96   -143      5       O  
+ATOM   1094  CB  ASP A 165      40.764   3.966  26.780  1.00 10.79           C  
+ANISOU 1094  CB  ASP A 165     1251   1376   1471    -99   -204     33       C  
+ATOM   1095  CG  ASP A 165      40.881   5.446  26.512  1.00 12.42           C  
+ANISOU 1095  CG  ASP A 165     1319   1441   1955   -144   -141     14       C  
+ATOM   1096  OD1 ASP A 165      39.956   6.034  25.914  1.00 12.16           O  
+ANISOU 1096  OD1 ASP A 165     1423   1381   1815    -75   -101    -49       O  
+ATOM   1097  OD2 ASP A 165      41.894   6.051  26.929  1.00 15.31           O  
+ANISOU 1097  OD2 ASP A 165     1853   1697   2265   -319   -480     74       O  
+ATOM   1098  N   SER A 166      42.939   2.493  24.886  1.00 10.18           N  
+ANISOU 1098  N   SER A 166     1120   1275   1472     15   -219    141       N  
+ATOM   1099  CA  SER A 166      44.174   2.630  24.111  1.00 11.64           C  
+ANISOU 1099  CA  SER A 166     1278   1451   1693     68   -194    176       C  
+ATOM   1100  C   SER A 166      43.935   2.177  22.678  1.00 10.39           C  
+ANISOU 1100  C   SER A 166      975   1355   1616     73   -217    141       C  
+ATOM   1101  O   SER A 166      44.398   2.809  21.764  1.00 10.29           O  
+ANISOU 1101  O   SER A 166      862   1319   1726     44   -218    187       O  
+ATOM   1102  CB  SER A 166      45.380   1.936  24.759  1.00 13.71           C  
+ANISOU 1102  CB  SER A 166     1544   1892   1773     30   -267    223       C  
+ATOM   1103  OG  SER A 166      45.231   0.559  24.754  1.00 17.05           O  
+ANISOU 1103  OG  SER A 166     1997   2322   2156     34   -354    142       O  
+ATOM   1104  N   SER A 167      43.164   1.116  22.452  1.00  9.64           N  
+ANISOU 1104  N   SER A 167      948   1258   1455     32   -103    153       N  
+ATOM   1105  C   SER A 167      41.976   1.775  20.397  1.00  8.86           C  
+ANISOU 1105  C   SER A 167      845   1147   1374     15   -111     27       C  
+ATOM   1106  O   SER A 167      42.177   2.058  19.213  1.00  9.09           O  
+ANISOU 1106  O   SER A 167      784   1304   1365    -85     63    -34       O  
+ATOM   1107  CA ASER A 167      42.814   0.686  21.108  0.50  9.41           C  
+ANISOU 1107  CA ASER A 167      968   1203   1403     23    -80    111       C  
+ATOM   1108  CB ASER A 167      42.081  -0.664  21.203  0.50 10.18           C  
+ANISOU 1108  CB ASER A 167     1203   1197   1466      3   -161    110       C  
+ATOM   1109  OG ASER A 167      41.725  -1.154  19.924  0.50 10.09           O  
+ANISOU 1109  OG ASER A 167     1378   1310   1145    -41     13    182       O  
+ATOM   1110  CA BSER A 167      42.824   0.717  21.088  0.50  9.89           C  
+ANISOU 1110  CA BSER A 167     1007   1241   1508     36    -89     89       C  
+ATOM   1111  CB BSER A 167      42.106  -0.624  21.083  0.50 11.06           C  
+ANISOU 1111  CB BSER A 167     1255   1294   1653     10   -143     58       C  
+ATOM   1112  OG BSER A 167      43.035  -1.639  21.287  0.50 13.36           O  
+ANISOU 1112  OG BSER A 167     1553   1451   2073     36    -85    -10       O  
+ATOM   1113  N   CYS A 168      41.066   2.383  21.128  1.00  8.49           N  
+ANISOU 1113  N   CYS A 168      731   1222   1270     99    -78    146       N  
+ATOM   1114  CA  CYS A 168      40.226   3.436  20.565  1.00  7.87           C  
+ANISOU 1114  CA  CYS A 168      718   1155   1116    -15   -142    129       C  
+ATOM   1115  C   CYS A 168      41.074   4.637  20.118  1.00  7.97           C  
+ANISOU 1115  C   CYS A 168      625   1170   1232     44    -63    115       C  
+ATOM   1116  O   CYS A 168      40.902   5.144  19.021  1.00  8.45           O  
+ANISOU 1116  O   CYS A 168      639   1361   1210     46     83    137       O  
+ATOM   1117  CB  CYS A 168      39.213   3.818  21.612  1.00  7.77           C  
+ANISOU 1117  CB  CYS A 168      704   1025   1222     28   -105    156       C  
+ATOM   1118  SG  CYS A 168      37.834   4.835  21.004  1.00  7.69           S  
+ANISOU 1118  SG  CYS A 168      788    957   1177    -38    -14     70       S  
+ATOM   1119  N   LYS A 169      42.022   5.035  20.946  1.00  8.93           N  
+ANISOU 1119  N   LYS A 169      752   1269   1370    -59   -103    144       N  
+ATOM   1120  CA  LYS A 169      42.919   6.127  20.613  1.00  9.63           C  
+ANISOU 1120  CA  LYS A 169      884   1279   1495   -118    -72     75       C  
+ATOM   1121  C   LYS A 169      43.950   5.777  19.556  1.00 10.03           C  
+ANISOU 1121  C   LYS A 169      882   1449   1479   -166    -76     52       C  
+ATOM   1122  O   LYS A 169      44.442   6.660  18.870  1.00 10.64           O  
+ANISOU 1122  O   LYS A 169     1129   1330   1582   -213     15    148       O  
+ATOM   1123  CB  LYS A 169      43.589   6.650  21.867  1.00  9.27           C  
+ANISOU 1123  CB  LYS A 169      939   1215   1365   -104   -108    108       C  
+ATOM   1124  CG  LYS A 169      42.606   7.359  22.774  1.00 10.66           C  
+ANISOU 1124  CG  LYS A 169     1111   1314   1625   -114    -29    -63       C  
+ATOM   1125  CD  LYS A 169      43.207   7.666  24.099  1.00 12.51           C  
+ANISOU 1125  CD  LYS A 169     1432   1496   1822    -99    -34    -53       C  
+ATOM   1126  CE  LYS A 169      42.292   8.534  24.892  1.00 14.61           C  
+ANISOU 1126  CE  LYS A 169     1653   1908   1987     25     17   -143       C  
+ATOM   1127  NZ  LYS A 169      42.692   8.601  26.297  1.00 16.09           N  
+ANISOU 1127  NZ  LYS A 169     1834   2139   2139   -174    -50    -73       N  
+ATOM   1128  N   SER A 170      44.258   4.509  19.405  1.00 10.42           N  
+ANISOU 1128  N   SER A 170      749   1536   1673   -161     55     84       N  
+ATOM   1129  C   SER A 170      44.388   4.236  16.974  1.00 10.91           C  
+ANISOU 1129  C   SER A 170     1005   1524   1616   -149     75     -4       C  
+ATOM   1130  O   SER A 170      44.976   4.694  15.981  1.00 12.02           O  
+ANISOU 1130  O   SER A 170      949   1866   1750    -75    205    -39       O  
+ATOM   1131  CA ASER A 170      45.103   4.056  18.304  0.50 10.27           C  
+ANISOU 1131  CA ASER A 170      909   1448   1545    -53     52      1       C  
+ATOM   1132  CB ASER A 170      45.480   2.596  18.489  0.50 10.12           C  
+ANISOU 1132  CB ASER A 170      803   1466   1574     19    -11     -3       C  
+ATOM   1133  OG ASER A 170      46.412   2.224  17.495  0.50 10.06           O  
+ANISOU 1133  OG ASER A 170      896   1397   1527    135     18   -147       O  
+ATOM   1134  CA BSER A 170      45.112   4.029  18.317  0.50 10.70           C  
+ANISOU 1134  CA BSER A 170      964   1488   1614    -59     52     35       C  
+ATOM   1135  CB BSER A 170      45.484   2.545  18.541  0.50 10.86           C  
+ANISOU 1135  CB BSER A 170      918   1517   1688     -1      0     29       C  
+ATOM   1136  OG BSER A 170      46.369   2.339  19.658  0.50 12.98           O  
+ANISOU 1136  OG BSER A 170     1223   1655   2051    162    -40    200       O  
+ATOM   1137  N   ALA A 171      43.089   3.940  16.962  1.00  8.95           N  
+ANISOU 1137  N   ALA A 171      812   1120   1467   -100    187    -21       N  
+ATOM   1138  CA  ALA A 171      42.274   4.096  15.767  1.00  9.12           C  
+ANISOU 1138  CA  ALA A 171      931   1226   1308   -128    165    -76       C  
+ATOM   1139  C   ALA A 171      42.025   5.561  15.448  1.00  8.85           C  
+ANISOU 1139  C   ALA A 171      703   1356   1301   -190     75     -5       C  
+ATOM   1140  O   ALA A 171      42.003   5.942  14.274  1.00  9.18           O  
+ANISOU 1140  O   ALA A 171     1042   1325   1121   -218     37     36       O  
+ATOM   1141  CB  ALA A 171      40.945   3.314  15.929  1.00  9.56           C  
+ANISOU 1141  CB  ALA A 171      956   1181   1495   -118     81    -51       C  
+ATOM   1142  N   TYR A 172      41.800   6.371  16.474  1.00  8.19           N  
+ANISOU 1142  N   TYR A 172      777   1187   1147   -158    103    -38       N  
+ATOM   1143  CA  TYR A 172      41.371   7.749  16.308  1.00  8.10           C  
+ANISOU 1143  CA  TYR A 172      772   1162   1143   -105     72     13       C  
+ATOM   1144  C   TYR A 172      42.233   8.697  17.144  1.00  8.70           C  
+ANISOU 1144  C   TYR A 172      746   1263   1294   -217    120     11       C  
+ATOM   1145  O   TYR A 172      41.758   9.333  18.076  1.00  8.37           O  
+ANISOU 1145  O   TYR A 172      862   1148   1170   -243     -4   -132       O  
+ATOM   1146  CB  TYR A 172      39.904   7.861  16.715  1.00  7.97           C  
+ANISOU 1146  CB  TYR A 172      777    980   1268    -85     41     -3       C  
+ATOM   1147  CG  TYR A 172      38.932   7.091  15.852  1.00  7.06           C  
+ANISOU 1147  CG  TYR A 172      673    862   1145   -126    155    -23       C  
+ATOM   1148  CD1 TYR A 172      38.587   7.534  14.618  1.00  7.68           C  
+ANISOU 1148  CD1 TYR A 172      808    846   1263     -7    112    -56       C  
+ATOM   1149  CD2 TYR A 172      38.319   5.958  16.325  1.00  7.19           C  
+ANISOU 1149  CD2 TYR A 172      733   1000    998    107     73     61       C  
+ATOM   1150  CE1 TYR A 172      37.650   6.876  13.862  1.00  7.24           C  
+ANISOU 1150  CE1 TYR A 172      826    652   1273    -25    -27    226       C  
+ATOM   1151  CE2 TYR A 172      37.389   5.301  15.568  1.00  7.07           C  
+ANISOU 1151  CE2 TYR A 172      671    843   1169   -124     39    -54       C  
+ATOM   1152  CZ  TYR A 172      37.056   5.754  14.327  1.00  6.90           C  
+ANISOU 1152  CZ  TYR A 172      886    628   1108     -2     68     26       C  
+ATOM   1153  OH  TYR A 172      36.100   5.104  13.562  1.00  6.44           O  
+ANISOU 1153  OH  TYR A 172      800    669    977    -32      9     -1       O  
+ATOM   1154  N   PRO A 173      43.540   8.765  16.871  1.00  9.38           N  
+ANISOU 1154  N   PRO A 173      789   1401   1373   -141     73   -112       N  
+ATOM   1155  CA  PRO A 173      44.405   9.597  17.699  1.00  9.71           C  
+ANISOU 1155  CA  PRO A 173      783   1399   1506   -173     33    -79       C  
+ATOM   1156  C   PRO A 173      43.988  11.057  17.658  1.00 10.33           C  
+ANISOU 1156  C   PRO A 173      750   1586   1589   -154     42    -59       C  
+ATOM   1157  O   PRO A 173      43.645  11.598  16.605  1.00 10.36           O  
+ANISOU 1157  O   PRO A 173      825   1374   1736   -279    287     63       O  
+ATOM   1158  CB  PRO A 173      45.797   9.345  17.108  1.00  9.99           C  
+ANISOU 1158  CB  PRO A 173      816   1544   1436    -35     54     -2       C  
+ATOM   1159  CG  PRO A 173      45.552   8.880  15.722  1.00 10.58           C  
+ANISOU 1159  CG  PRO A 173      906   1499   1613   -291    217    -99       C  
+ATOM   1160  CD  PRO A 173      44.266   8.115  15.768  1.00  9.48           C  
+ANISOU 1160  CD  PRO A 173      878   1370   1353   -179     80   -170       C  
+ATOM   1161  N   GLY A 174      43.977  11.662  18.843  1.00 11.00           N  
+ANISOU 1161  N   GLY A 174      910   1575   1695   -154    -39   -137       N  
+ATOM   1162  CA  GLY A 174      43.625  13.064  18.965  1.00 10.72           C  
+ANISOU 1162  CA  GLY A 174     1030   1327   1717   -201     -9   -164       C  
+ATOM   1163  C   GLY A 174      42.136  13.352  18.938  1.00 11.19           C  
+ANISOU 1163  C   GLY A 174     1129   1275   1845    -14     25   -121       C  
+ATOM   1164  O   GLY A 174      41.752  14.511  19.016  1.00 13.36           O  
+ANISOU 1164  O   GLY A 174     1218   1355   2502   -132     53   -340       O  
+ATOM   1165  N   GLN A 175      41.284  12.317  18.862  1.00  9.44           N  
+ANISOU 1165  N   GLN A 175      895   1161   1528    -56    166    -51       N  
+ATOM   1166  CA  GLN A 175      39.844  12.497  18.632  1.00  8.97           C  
+ANISOU 1166  CA  GLN A 175      923   1179   1305     15     84     45       C  
+ATOM   1167  C   GLN A 175      38.954  11.911  19.701  1.00  8.84           C  
+ANISOU 1167  C   GLN A 175      873   1146   1337     33     90      8       C  
+ATOM   1168  O   GLN A 175      37.746  12.115  19.658  1.00  9.49           O  
+ANISOU 1168  O   GLN A 175      839   1438   1327     30    100    150       O  
+ATOM   1169  CB  GLN A 175      39.462  11.892  17.298  1.00  9.55           C  
+ANISOU 1169  CB  GLN A 175      882   1249   1496    106     87     41       C  
+ATOM   1170  CG  GLN A 175      40.256  12.494  16.160  1.00 10.71           C  
+ANISOU 1170  CG  GLN A 175     1104   1626   1337    -39    -31     81       C  
+ATOM   1171  CD  GLN A 175      40.279  11.578  14.976  1.00 14.19           C  
+ANISOU 1171  CD  GLN A 175     1597   1592   2202    -22    214    -61       C  
+ATOM   1172  OE1 GLN A 175      39.264  11.356  14.322  1.00 15.22           O  
+ANISOU 1172  OE1 GLN A 175     1957   1992   1832    -19    253    207       O  
+ATOM   1173  NE2 GLN A 175      41.458  10.989  14.704  1.00 16.11           N  
+ANISOU 1173  NE2 GLN A 175     1715   1995   2409     46    377    107       N  
+ATOM   1174  N   ILE A 176      39.530  11.171  20.648  1.00  7.81           N  
+ANISOU 1174  N   ILE A 176      673    967   1327    -52    -35    -46       N  
+ATOM   1175  CA  ILE A 176      38.753  10.437  21.642  1.00  8.13           C  
+ANISOU 1175  CA  ILE A 176      685   1132   1271     74    -58   -108       C  
+ATOM   1176  C   ILE A 176      38.874  11.162  22.968  1.00  8.95           C  
+ANISOU 1176  C   ILE A 176      807   1297   1293      2    -79   -167       C  
+ATOM   1177  O   ILE A 176      39.982  11.293  23.508  1.00 10.59           O  
+ANISOU 1177  O   ILE A 176      781   1649   1591     47   -153   -320       O  
+ATOM   1178  CB  ILE A 176      39.221   8.977  21.782  1.00  7.74           C  
+ANISOU 1178  CB  ILE A 176      664   1104   1173    131     26    -37       C  
+ATOM   1179  CG1 ILE A 176      39.164   8.230  20.436  1.00  7.48           C  
+ANISOU 1179  CG1 ILE A 176      735   1092   1015    -49     84   -135       C  
+ATOM   1180  CG2 ILE A 176      38.434   8.257  22.874  1.00  9.15           C  
+ANISOU 1180  CG2 ILE A 176      894   1326   1254     60    -15     84       C  
+ATOM   1181  CD1 ILE A 176      37.762   8.230  19.796  1.00  8.76           C  
+ANISOU 1181  CD1 ILE A 176      901   1238   1187    -16   -144    -65       C  
+ATOM   1182  N   THR A 177      37.748  11.662  23.465  1.00  8.34           N  
+ANISOU 1182  N   THR A 177      781   1100   1288     -7   -186   -202       N  
+ATOM   1183  CA  THR A 177      37.727  12.288  24.767  1.00  8.62           C  
+ANISOU 1183  CA  THR A 177      892   1102   1280     45   -179   -250       C  
+ATOM   1184  C   THR A 177      37.360  11.268  25.820  1.00  9.05           C  
+ANISOU 1184  C   THR A 177      930   1281   1226    129   -168   -289       C  
+ATOM   1185  O   THR A 177      36.963  10.133  25.533  1.00  8.06           O  
+ANISOU 1185  O   THR A 177      988    972   1103    207   -151   -151       O  
+ATOM   1186  CB  THR A 177      36.740  13.459  24.806  1.00  9.58           C  
+ANISOU 1186  CB  THR A 177     1061   1050   1527     41   -182   -279       C  
+ATOM   1187  OG1 THR A 177      35.414  12.905  24.784  1.00  9.34           O  
+ANISOU 1187  OG1 THR A 177      787   1206   1553      9   -143   -347       O  
+ATOM   1188  CG2 THR A 177      36.986  14.420  23.630  1.00 10.80           C  
+ANISOU 1188  CG2 THR A 177     1216   1096   1789     76    -21   -188       C  
+ATOM   1189  N   SER A 178      37.384  11.718  27.056  1.00  9.45           N  
+ANISOU 1189  N   SER A 178      970   1317   1302     69   -152   -393       N  
+ATOM   1190  C   SER A 178      35.499  10.480  28.103  1.00  9.12           C  
+ANISOU 1190  C   SER A 178     1012   1288   1163    161   -125   -271       C  
+ATOM   1191  O   SER A 178      35.067   9.570  28.817  1.00  9.93           O  
+ANISOU 1191  O   SER A 178     1146   1500   1126    232   -125   -142       O  
+ATOM   1192  CA ASER A 178      36.979  10.847  28.153  0.50  9.73           C  
+ANISOU 1192  CA ASER A 178     1101   1364   1231     55   -167   -303       C  
+ATOM   1193  CB ASER A 178      37.233  11.506  29.515  0.50 10.92           C  
+ANISOU 1193  CB ASER A 178     1206   1619   1321    -24   -220   -315       C  
+ATOM   1194  OG ASER A 178      36.411  12.639  29.650  0.50 14.04           O  
+ANISOU 1194  OG ASER A 178     1780   1847   1707    -76   -321   -501       O  
+ATOM   1195  CA BSER A 178      36.970  10.923  28.188  0.50  9.90           C  
+ANISOU 1195  CA BSER A 178     1096   1406   1256     75   -152   -262       C  
+ATOM   1196  CB BSER A 178      37.170  11.761  29.477  0.50 10.51           C  
+ANISOU 1196  CB BSER A 178     1137   1529   1327    108   -194   -309       C  
+ATOM   1197  OG BSER A 178      38.531  12.178  29.610  0.50 14.85           O  
+ANISOU 1197  OG BSER A 178     1648   2190   1802   -146   -244   -212       O  
+ATOM   1198  N   ASN A 179      34.722  11.171  27.274  1.00  8.47           N  
+ANISOU 1198  N   ASN A 179      911   1306    998    151    -75   -202       N  
+ATOM   1199  CA  ASN A 179      33.281  10.922  27.121  1.00  7.95           C  
+ANISOU 1199  CA  ASN A 179      836   1222    960      0    -87    -74       C  
+ATOM   1200  C   ASN A 179      32.931  10.060  25.939  1.00  7.26           C  
+ANISOU 1200  C   ASN A 179      801   1150    807    112    -51    -20       C  
+ATOM   1201  O   ASN A 179      31.775  10.062  25.514  1.00  7.23           O  
+ANISOU 1201  O   ASN A 179      721   1131    893    112   -157    -83       O  
+ATOM   1202  CB  ASN A 179      32.553  12.259  27.059  1.00  7.91           C  
+ANISOU 1202  CB  ASN A 179      921   1169    916    -24    -50   -151       C  
+ATOM   1203  CG  ASN A 179      32.827  13.088  28.285  1.00  9.06           C  
+ANISOU 1203  CG  ASN A 179      988   1239   1215    205   -199    -95       C  
+ATOM   1204  OD1 ASN A 179      32.630  12.600  29.395  1.00  9.84           O  
+ANISOU 1204  OD1 ASN A 179     1238   1369   1132    203   -227   -154       O  
+ATOM   1205  ND2 ASN A 179      33.312  14.293  28.106  1.00  9.28           N  
+ANISOU 1205  ND2 ASN A 179      960   1173   1393     93   -187   -262       N  
+ATOM   1206  N   MET A 180      33.907   9.320  25.435  1.00  7.16           N  
+ANISOU 1206  N   MET A 180      783   1052    883     41   -186    -54       N  
+ATOM   1207  CA  MET A 180      33.724   8.465  24.262  1.00  6.64           C  
+ANISOU 1207  CA  MET A 180      737    893    890     84   -105    -57       C  
+ATOM   1208  C   MET A 180      34.354   7.126  24.511  1.00  7.03           C  
+ANISOU 1208  C   MET A 180      785    969    917    109   -170     84       C  
+ATOM   1209  O   MET A 180      35.360   7.009  25.201  1.00  8.03           O  
+ANISOU 1209  O   MET A 180      931   1036   1081     94   -335     58       O  
+ATOM   1210  CB  MET A 180      34.403   9.076  23.043  1.00  6.47           C  
+ANISOU 1210  CB  MET A 180      704    923    829     32   -106   -124       C  
+ATOM   1211  CG  MET A 180      33.838  10.418  22.661  1.00  6.13           C  
+ANISOU 1211  CG  MET A 180      618    792    919    140    -13    -52       C  
+ATOM   1212  SD  MET A 180      34.904  11.126  21.351  1.00  6.90           S  
+ANISOU 1212  SD  MET A 180      797    776   1047     64    -36    -27       S  
+ATOM   1213  CE  MET A 180      34.265  12.831  21.316  1.00  8.65           C  
+ANISOU 1213  CE  MET A 180     1109    668   1508    219     -9    103       C  
+ATOM   1214  N   PHE A 181      33.757   6.081  23.934  1.00  6.75           N  
+ANISOU 1214  N   PHE A 181      719    879    964     63    -96     59       N  
+ATOM   1215  CA  PHE A 181      34.403   4.771  23.826  1.00  6.28           C  
+ANISOU 1215  CA  PHE A 181      735    873    776    111    -47     91       C  
+ATOM   1216  C   PHE A 181      34.148   4.177  22.469  1.00  5.80           C  
+ANISOU 1216  C   PHE A 181      684    713    806     29   -101    205       C  
+ATOM   1217  O   PHE A 181      33.191   4.495  21.775  1.00  6.24           O  
+ANISOU 1217  O   PHE A 181      721    847    800    137    -94     88       O  
+ATOM   1218  CB  PHE A 181      33.949   3.808  24.950  1.00  7.36           C  
+ANISOU 1218  CB  PHE A 181      846   1066    881    143     -3     60       C  
+ATOM   1219  CG  PHE A 181      32.501   3.360  24.852  1.00  7.22           C  
+ANISOU 1219  CG  PHE A 181      906    943    891    105     86    249       C  
+ATOM   1220  CD1 PHE A 181      32.151   2.195  24.224  1.00  7.65           C  
+ANISOU 1220  CD1 PHE A 181      851    913   1140    165     64    250       C  
+ATOM   1221  CD2 PHE A 181      31.484   4.118  25.419  1.00  8.29           C  
+ANISOU 1221  CD2 PHE A 181      945   1077   1128     55     19     41       C  
+ATOM   1222  CE1 PHE A 181      30.835   1.780  24.179  1.00  8.00           C  
+ANISOU 1222  CE1 PHE A 181     1025    829   1185    119    -51     26       C  
+ATOM   1223  CE2 PHE A 181      30.164   3.684  25.359  1.00  8.37           C  
+ANISOU 1223  CE2 PHE A 181      982   1245    952     64     71    100       C  
+ATOM   1224  CZ  PHE A 181      29.852   2.502  24.774  1.00  7.44           C  
+ANISOU 1224  CZ  PHE A 181      895    928   1003    141     99    191       C  
+ATOM   1225  N   CYS A 182      35.049   3.278  22.104  1.00  5.39           N  
+ANISOU 1225  N   CYS A 182      582    674    789     87   -167    134       N  
+ATOM   1226  CA  CYS A 182      34.917   2.522  20.880  1.00  6.04           C  
+ANISOU 1226  CA  CYS A 182      684    739    870    104    -87     97       C  
+ATOM   1227  C   CYS A 182      34.309   1.163  21.164  1.00  6.04           C  
+ANISOU 1227  C   CYS A 182      720    687    887     67     49    253       C  
+ATOM   1228  O   CYS A 182      34.577   0.562  22.193  1.00  6.45           O  
+ANISOU 1228  O   CYS A 182      780    819    850     24    -93    136       O  
+ATOM   1229  CB  CYS A 182      36.263   2.292  20.194  1.00  6.47           C  
+ANISOU 1229  CB  CYS A 182      761    722    974    -68     14    208       C  
+ATOM   1230  SG  CYS A 182      37.043   3.754  19.453  1.00  7.02           S  
+ANISOU 1230  SG  CYS A 182      777    910    980    -78    -62    237       S  
+ATOM   1231  N   ALA A 183      33.479   0.695  20.250  1.00  6.04           N  
+ANISOU 1231  N   ALA A 183      722    551   1021    126    -59    270       N  
+ATOM   1232  CA  ALA A 183      32.958  -0.671  20.344  1.00  6.48           C  
+ANISOU 1232  CA  ALA A 183      827    632   1001     66    -16    210       C  
+ATOM   1233  C   ALA A 183      32.837  -1.188  18.932  1.00  6.72           C  
+ANISOU 1233  C   ALA A 183      894    624   1035     35    -60    162       C  
+ATOM   1234  O   ALA A 183      32.581  -0.434  17.982  1.00  6.62           O  
+ANISOU 1234  O   ALA A 183      996    664    854     25    -67    175       O  
+ATOM   1235  CB  ALA A 183      31.610  -0.712  21.061  1.00  7.53           C  
+ANISOU 1235  CB  ALA A 183      801    861   1197    -63    -74    211       C  
+ATOM   1236  N   GLY A 184      33.015  -2.493  18.764  1.00  7.26           N  
+ANISOU 1236  N   GLY A 184     1128    584   1044     72   -158    124       N  
+ATOM   1237  CA  GLY A 184      32.951  -3.092  17.465  1.00  7.71           C  
+ANISOU 1237  CA  GLY A 184     1047    768   1111      2   -144     89       C  
+ATOM   1238  C   GLY A 184      34.187  -3.864  17.131  1.00  7.78           C  
+ANISOU 1238  C   GLY A 184      936    692   1328   -150   -252     95       C  
+ATOM   1239  O   GLY A 184      34.673  -4.641  17.959  1.00  8.30           O  
+ANISOU 1239  O   GLY A 184     1084    684   1385     66   -231    204       O  
+ATOM   1240  N   TYR A 185      34.644  -3.687  15.898  1.00  8.53           N  
+ANISOU 1240  N   TYR A 185      955    899   1384    -65   -176    141       N  
+ATOM   1241  CA  TYR A 185      35.572  -4.607  15.262  1.00  9.04           C  
+ANISOU 1241  CA  TYR A 185      907   1003   1521   -115    -43    183       C  
+ATOM   1242  C   TYR A 185      36.595  -3.789  14.523  1.00 10.73           C  
+ANISOU 1242  C   TYR A 185     1027   1060   1989    -50     63    256       C  
+ATOM   1243  O   TYR A 185      36.300  -2.668  14.074  1.00 13.73           O  
+ANISOU 1243  O   TYR A 185     1290   1638   2287   -114     58    651       O  
+ATOM   1244  CB  TYR A 185      34.774  -5.543  14.330  1.00  9.28           C  
+ANISOU 1244  CB  TYR A 185      988    983   1555     15      7     43       C  
+ATOM   1245  CG  TYR A 185      33.759  -6.342  15.085  1.00  7.92           C  
+ANISOU 1245  CG  TYR A 185     1015    714   1279    -16    -36    -32       C  
+ATOM   1246  CD1 TYR A 185      34.091  -7.554  15.664  1.00  8.67           C  
+ANISOU 1246  CD1 TYR A 185      879    853   1561    -32    -94     43       C  
+ATOM   1247  CD2 TYR A 185      32.491  -5.856  15.286  1.00  8.34           C  
+ANISOU 1247  CD2 TYR A 185      928    792   1448    -55   -152     77       C  
+ATOM   1248  CE1 TYR A 185      33.177  -8.264  16.396  1.00  8.11           C  
+ANISOU 1248  CE1 TYR A 185      927    636   1518    -31    -59    197       C  
+ATOM   1249  CE2 TYR A 185      31.544  -6.572  16.016  1.00  8.15           C  
+ANISOU 1249  CE2 TYR A 185      792    906   1398     28   -126    -30       C  
+ATOM   1250  CZ  TYR A 185      31.898  -7.758  16.581  1.00  8.12           C  
+ANISOU 1250  CZ  TYR A 185      968    729   1386     29   -122     12       C  
+ATOM   1251  OH  TYR A 185      30.994  -8.533  17.296  1.00  9.15           O  
+ANISOU 1251  OH  TYR A 185     1191    703   1582   -172     76    178       O  
+ATOM   1252  N   LEU A 186      37.810  -4.287  14.513  1.00  9.72           N  
+ANISOU 1252  N   LEU A 186     1001    833   1858      3    189    282       N  
+ATOM   1253  CA  LEU A 186      38.917  -3.644  13.827  1.00  9.89           C  
+ANISOU 1253  CA  LEU A 186     1030    874   1852     39    280    215       C  
+ATOM   1254  C   LEU A 186      39.147  -4.194  12.437  1.00 10.43           C  
+ANISOU 1254  C   LEU A 186     1078    992   1894    117    229    232       C  
+ATOM   1255  O   LEU A 186      39.833  -3.570  11.657  1.00 11.09           O  
+ANISOU 1255  O   LEU A 186     1179   1101   1931    140    242    376       O  
+ATOM   1256  CB  LEU A 186      40.185  -3.758  14.661  1.00  9.92           C  
+ANISOU 1256  CB  LEU A 186     1003    876   1889     12    255    238       C  
+ATOM   1257  CG  LEU A 186      40.149  -3.088  16.032  1.00 12.45           C  
+ANISOU 1257  CG  LEU A 186     1370   1378   1982    -10     57     10       C  
+ATOM   1258  CD1 LEU A 186      41.465  -3.348  16.736  1.00 14.52           C  
+ANISOU 1258  CD1 LEU A 186     1493   1791   2231   -159   -134    200       C  
+ATOM   1259  CD2 LEU A 186      39.882  -1.579  15.914  1.00 14.06           C  
+ANISOU 1259  CD2 LEU A 186     1554   1555   2233    202    180   -161       C  
+ATOM   1260  N   GLU A 187      38.602  -5.362  12.135  1.00 11.23           N  
+ANISOU 1260  N   GLU A 187     1184   1112   1969    122    350     75       N  
+ATOM   1261  CA  GLU A 187      38.847  -6.006  10.861  1.00 12.65           C  
+ANISOU 1261  CA  GLU A 187     1540   1300   1963    105    259    105       C  
+ATOM   1262  C   GLU A 187      37.762  -5.742   9.828  1.00 13.41           C  
+ANISOU 1262  C   GLU A 187     1591   1460   2041    137    265     33       C  
+ATOM   1263  O   GLU A 187      37.758  -6.355   8.751  1.00 15.80           O  
+ANISOU 1263  O   GLU A 187     1837   2089   2078    386    338    162       O  
+ATOM   1264  CB  GLU A 187      38.982  -7.517  11.078  1.00 13.58           C  
+ANISOU 1264  CB  GLU A 187     1746   1331   2079    111    142    -17       C  
+ATOM   1265  CG  GLU A 187      37.664  -8.191  11.403  1.00 16.15           C  
+ANISOU 1265  CG  GLU A 187     2041   1694   2399    -73     60    -65       C  
+ATOM   1266  CD  GLU A 187      37.258  -8.285  12.882  1.00 17.63           C  
+ANISOU 1266  CD  GLU A 187     2224   1934   2541    -31     77     61       C  
+ATOM   1267  OE1 GLU A 187      37.673  -7.501  13.754  1.00 17.07           O  
+ANISOU 1267  OE1 GLU A 187     2177   1605   2702    -70    230    259       O  
+ATOM   1268  OE2 GLU A 187      36.460  -9.208  13.176  1.00 23.36           O  
+ANISOU 1268  OE2 GLU A 187     2959   2652   3265   -448    324     28       O  
+ATOM   1269  N   GLY A 188      36.822  -4.862  10.139  1.00 12.98           N  
+ANISOU 1269  N   GLY A 188     1508   1313   2109    159    298    263       N  
+ATOM   1270  CA  GLY A 188      35.835  -4.472   9.144  1.00 13.46           C  
+ANISOU 1270  CA  GLY A 188     1515   1542   2053     67    274    167       C  
+ATOM   1271  C   GLY A 188      34.585  -5.323   9.114  1.00 12.52           C  
+ANISOU 1271  C   GLY A 188     1535   1235   1986     30    248    248       C  
+ATOM   1272  O   GLY A 188      34.536  -6.477   9.587  1.00 13.66           O  
+ANISOU 1272  O   GLY A 188     1769   1312   2108    223    364    294       O  
+ATOM   1273  N   GLY A 189      33.548  -4.742   8.557  1.00 10.12           N  
+ANISOU 1273  N   GLY A 189     1226    964   1653    199    447    104       N  
+ATOM   1274  CA  GLY A 189      32.353  -5.466   8.245  1.00 10.19           C  
+ANISOU 1274  CA  GLY A 189     1306   1001   1564     87    267    -81       C  
+ATOM   1275  C   GLY A 189      31.177  -5.414   9.210  1.00  8.53           C  
+ANISOU 1275  C   GLY A 189     1086    800   1355     57    255    -43       C  
+ATOM   1276  O   GLY A 189      30.085  -5.817   8.830  1.00  9.46           O  
+ANISOU 1276  O   GLY A 189     1366    963   1264    -97     98    -87       O  
+ATOM   1277  N   LYS A 190      31.374  -4.885  10.415  1.00  7.26           N  
+ANISOU 1277  N   LYS A 190      904    606   1245     -1    154     31       N  
+ATOM   1278  C   LYS A 190      30.365  -3.603  12.216  1.00  6.70           C  
+ANISOU 1278  C   LYS A 190      790    586   1168    -67     21     70       C  
+ATOM   1279  O   LYS A 190      31.363  -3.268  12.859  1.00  7.22           O  
+ANISOU 1279  O   LYS A 190      736    638   1370     88    -32    -39       O  
+ATOM   1280  CA ALYS A 190      30.351  -4.914  11.463  0.50  6.96           C  
+ANISOU 1280  CA ALYS A 190      820    662   1160    -36     35     57       C  
+ATOM   1281  CB ALYS A 190      30.644  -6.036  12.454  0.50  7.30           C  
+ANISOU 1281  CB ALYS A 190      916    684   1172    -21    112     22       C  
+ATOM   1282  CG ALYS A 190      30.452  -7.427  11.886  0.50  7.74           C  
+ANISOU 1282  CG ALYS A 190      905    755   1280     39     25     -9       C  
+ATOM   1283  CD ALYS A 190      30.755  -8.483  12.939  0.50  8.93           C  
+ANISOU 1283  CD ALYS A 190     1174    841   1376     37     68    103       C  
+ATOM   1284  CE ALYS A 190      30.815  -9.876  12.342  0.50  9.35           C  
+ANISOU 1284  CE ALYS A 190     1277    974   1303     76    -47    -95       C  
+ATOM   1285  NZ ALYS A 190      31.918  -9.979  11.329  0.50  9.92           N  
+ANISOU 1285  NZ ALYS A 190     1225   1083   1459    169    120    -75       N  
+ATOM   1286  CA BLYS A 190      30.339  -4.905  11.442  0.50  6.58           C  
+ANISOU 1286  CA BLYS A 190      762    627   1109    -41     36     65       C  
+ATOM   1287  CB BLYS A 190      30.577  -6.068  12.394  0.50  7.17           C  
+ANISOU 1287  CB BLYS A 190      902    694   1125     -9    135     34       C  
+ATOM   1288  CG BLYS A 190      30.556  -7.437  11.718  0.50  7.36           C  
+ANISOU 1288  CG BLYS A 190      862    800   1131     22     71      0       C  
+ATOM   1289  CD BLYS A 190      31.128  -8.490  12.646  0.50  9.03           C  
+ANISOU 1289  CD BLYS A 190     1287    947   1196     59     50     75       C  
+ATOM   1290  CE BLYS A 190      31.189  -9.856  12.005  0.50  9.50           C  
+ANISOU 1290  CE BLYS A 190     1252    978   1378   -101     74     59       C  
+ATOM   1291  NZ BLYS A 190      31.969 -10.755  12.876  0.50 11.70           N  
+ANISOU 1291  NZ BLYS A 190     1587   1375   1482    115    -31    130       N  
+ATOM   1292  N   ASP A 191      29.274  -2.837  12.148  1.00  5.69           N  
+ANISOU 1292  N   ASP A 191      645    627    887    -34     32    129       N  
+ATOM   1293  CA  ASP A 191      29.279  -1.525  12.819  1.00  5.89           C  
+ANISOU 1293  CA  ASP A 191      795    640    803     22     80     35       C  
+ATOM   1294  C   ASP A 191      27.886  -0.949  12.822  1.00  4.99           C  
+ANISOU 1294  C   ASP A 191      755    547    593    -19    -18    224       C  
+ATOM   1295  O   ASP A 191      26.994  -1.410  12.120  1.00  6.61           O  
+ANISOU 1295  O   ASP A 191      946    552   1014     27      0    -49       O  
+ATOM   1296  CB  ASP A 191      30.213  -0.580  12.003  1.00  5.76           C  
+ANISOU 1296  CB  ASP A 191      748    706    731     61    161     69       C  
+ATOM   1297  CG  ASP A 191      30.824   0.577  12.769  1.00  6.56           C  
+ANISOU 1297  CG  ASP A 191      879    653    958     92    126    139       C  
+ATOM   1298  OD1 ASP A 191      30.456   0.868  13.918  1.00  6.06           O  
+ANISOU 1298  OD1 ASP A 191      747    651    902    123     47     71       O  
+ATOM   1299  OD2 ASP A 191      31.729   1.175  12.141  1.00  6.67           O  
+ANISOU 1299  OD2 ASP A 191      975    602    955   -121    172     66       O  
+ATOM   1300  N   SER A 192      27.722   0.136  13.574  1.00  5.16           N  
+ANISOU 1300  N   SER A 192      735    543    681     67    -93     93       N  
+ATOM   1301  CA  SER A 192      26.593   1.054  13.395  1.00  5.13           C  
+ANISOU 1301  CA  SER A 192      626    556    765     22     44    128       C  
+ATOM   1302  C   SER A 192      26.891   1.984  12.224  1.00  5.43           C  
+ANISOU 1302  C   SER A 192      795    555    713    -18     15     64       C  
+ATOM   1303  O   SER A 192      28.063   2.168  11.853  1.00  5.66           O  
+ANISOU 1303  O   SER A 192      681    664    804     29    -19     85       O  
+ATOM   1304  CB  SER A 192      26.360   1.821  14.688  1.00  5.32           C  
+ANISOU 1304  CB  SER A 192      831    685    506     50     23    224       C  
+ATOM   1305  OG  SER A 192      27.495   2.531  15.094  1.00  5.98           O  
+ANISOU 1305  OG  SER A 192      764    590    915    -54     36    133       O  
+ATOM   1306  N   CYS A 193      25.852   2.637  11.699  1.00  5.51           N  
+ANISOU 1306  N   CYS A 193      713    660    720     23    110    132       N  
+ATOM   1307  CA  CYS A 193      26.010   3.450  10.506  1.00  5.55           C  
+ANISOU 1307  CA  CYS A 193      725    735    649    -69     52    108       C  
+ATOM   1308  C   CYS A 193      24.984   4.548  10.475  1.00  5.44           C  
+ANISOU 1308  C   CYS A 193      712    815    540      0     -5     25       C  
+ATOM   1309  O   CYS A 193      24.219   4.695  11.407  1.00  5.53           O  
+ANISOU 1309  O   CYS A 193      835    693    572    129     34    186       O  
+ATOM   1310  CB  CYS A 193      25.972   2.515   9.292  1.00  6.43           C  
+ANISOU 1310  CB  CYS A 193      843    919    678     50     12    153       C  
+ATOM   1311  SG  CYS A 193      26.714   3.204   7.762  1.00  7.11           S  
+ANISOU 1311  SG  CYS A 193     1075    868    758     73    153     80       S  
+ATOM   1312  N   GLN A 194      25.003   5.372   9.433  1.00  5.92           N  
+ANISOU 1312  N   GLN A 194      773    788    688     99    143    102       N  
+ATOM   1313  CA  GLN A 194      24.094   6.493   9.337  1.00  5.68           C  
+ANISOU 1313  CA  GLN A 194      793    674    691     95     81     79       C  
+ATOM   1314  C   GLN A 194      22.646   6.048   9.500  1.00  5.87           C  
+ANISOU 1314  C   GLN A 194      807    650    772      1     -9    160       C  
+ATOM   1315  O   GLN A 194      22.189   5.129   8.847  1.00  6.13           O  
+ANISOU 1315  O   GLN A 194      862    652    813     28      9     85       O  
+ATOM   1316  CB  GLN A 194      24.278   7.230   8.002  1.00  6.29           C  
+ANISOU 1316  CB  GLN A 194      831    781    777    152     48    160       C  
+ATOM   1317  CG  GLN A 194      25.454   8.214   7.986  1.00  6.36           C  
+ANISOU 1317  CG  GLN A 194      750    873    793     27     46    303       C  
+ATOM   1318  CD  GLN A 194      26.805   7.561   8.149  1.00  6.68           C  
+ANISOU 1318  CD  GLN A 194      990    644    902   -138    145    345       C  
+ATOM   1319  OE1 GLN A 194      27.064   6.524   7.517  1.00  7.43           O  
+ANISOU 1319  OE1 GLN A 194     1031    698   1093     73    114    230       O  
+ATOM   1320  NE2 GLN A 194      27.652   8.106   9.006  1.00  7.67           N  
+ANISOU 1320  NE2 GLN A 194      903   1152    856    -31     66    335       N  
+ATOM   1321  N   GLY A 195      21.925   6.761  10.362  1.00  5.34           N  
+ANISOU 1321  N   GLY A 195      757    514    755     58      4     92       N  
+ATOM   1322  CA  GLY A 195      20.581   6.411  10.765  1.00  5.69           C  
+ANISOU 1322  CA  GLY A 195      738    711    712     19     35    165       C  
+ATOM   1323  C   GLY A 195      20.501   5.687  12.086  1.00  5.65           C  
+ANISOU 1323  C   GLY A 195      700    728    719    -49     70    206       C  
+ATOM   1324  O   GLY A 195      19.421   5.601  12.647  1.00  5.94           O  
+ANISOU 1324  O   GLY A 195      694    737    825     26     10    251       O  
+ATOM   1325  N   ASP A 196      21.642   5.214  12.591  1.00  5.36           N  
+ANISOU 1325  N   ASP A 196      616    631    787    -56     76    120       N  
+ATOM   1326  CA  ASP A 196      21.695   4.580  13.902  1.00  4.99           C  
+ANISOU 1326  CA  ASP A 196      610    685    600     33     49    103       C  
+ATOM   1327  C   ASP A 196      21.978   5.563  15.032  1.00  4.95           C  
+ANISOU 1327  C   ASP A 196      581    546    752     75    -66     57       C  
+ATOM   1328  O   ASP A 196      21.755   5.211  16.196  1.00  5.15           O  
+ANISOU 1328  O   ASP A 196      616    588    751     55    -37    191       O  
+ATOM   1329  CB  ASP A 196      22.746   3.458  13.900  1.00  5.12           C  
+ANISOU 1329  CB  ASP A 196      702    640    603    -58     94    119       C  
+ATOM   1330  CG  ASP A 196      22.372   2.279  13.041  1.00  5.26           C  
+ANISOU 1330  CG  ASP A 196      664    596    736     69     63    153       C  
+ATOM   1331  OD1 ASP A 196      21.177   1.936  12.988  1.00  5.18           O  
+ANISOU 1331  OD1 ASP A 196      738    560    668     12     19     33       O  
+ATOM   1332  OD2 ASP A 196      23.302   1.698  12.429  1.00  5.60           O  
+ANISOU 1332  OD2 ASP A 196      698    664    764     52     84     68       O  
+ATOM   1333  N   SER A 197      22.508   6.747  14.721  1.00  4.94           N  
+ANISOU 1333  N   SER A 197      722    531    623     99      1    161       N  
+ATOM   1334  CA  SER A 197      22.870   7.756  15.709  1.00  5.11           C  
+ANISOU 1334  CA  SER A 197      675    615    651     30    -50    101       C  
+ATOM   1335  C   SER A 197      21.796   7.963  16.713  1.00  5.02           C  
+ANISOU 1335  C   SER A 197      596    551    758    -30     31    159       C  
+ATOM   1336  O   SER A 197      20.600   8.028  16.401  1.00  5.43           O  
+ANISOU 1336  O   SER A 197      541    810    710     68    -57    177       O  
+ATOM   1337  CB  SER A 197      23.111   9.141  15.111  1.00  5.99           C  
+ANISOU 1337  CB  SER A 197      898    560    816     19    -35     95       C  
+ATOM   1338  OG  SER A 197      24.447   9.282  14.745  1.00  6.37           O  
+ANISOU 1338  OG  SER A 197      705    808    906     25     48    120       O  
+ATOM   1339  N   GLY A 198      22.228   8.124  17.961  1.00  5.18           N  
+ANISOU 1339  N   GLY A 198      543    694    730    121   -110      5       N  
+ATOM   1340  CA  GLY A 198      21.315   8.388  19.043  1.00  5.18           C  
+ANISOU 1340  CA  GLY A 198      594    688    685    107    -44     27       C  
+ATOM   1341  C   GLY A 198      20.793   7.151  19.723  1.00  5.60           C  
+ANISOU 1341  C   GLY A 198      648    859    619     58    -95     -5       C  
+ATOM   1342  O   GLY A 198      20.258   7.230  20.832  1.00  6.31           O  
+ANISOU 1342  O   GLY A 198      809    936    650     76    -19    -25       O  
+ATOM   1343  N   GLY A 199      20.892   6.003  19.044  1.00  5.62           N  
+ANISOU 1343  N   GLY A 199      735    857    541     32     71     28       N  
+ATOM   1344  CA  GLY A 199      20.394   4.771  19.548  1.00  5.43           C  
+ANISOU 1344  CA  GLY A 199      688    848    527     60    -27    -17       C  
+ATOM   1345  C   GLY A 199      21.293   4.110  20.562  1.00  5.73           C  
+ANISOU 1345  C   GLY A 199      681    907    586     -3      0     46       C  
+ATOM   1346  O   GLY A 199      22.391   4.601  20.898  1.00  6.00           O  
+ANISOU 1346  O   GLY A 199      740    829    709     36   -125    213       O  
+ATOM   1347  N   PRO A 200      20.829   2.999  21.085  1.00  6.11           N  
+ANISOU 1347  N   PRO A 200      793    840    686    -66   -119    142       N  
+ATOM   1348  CA  PRO A 200      21.434   2.365  22.255  1.00  5.84           C  
+ANISOU 1348  CA  PRO A 200      713    831    675     35   -134    125       C  
+ATOM   1349  C   PRO A 200      22.617   1.454  21.986  1.00  5.97           C  
+ANISOU 1349  C   PRO A 200      844    803    620      0     19    195       C  
+ATOM   1350  O   PRO A 200      22.668   0.719  21.005  1.00  6.82           O  
+ANISOU 1350  O   PRO A 200      897    946    747    136   -132    167       O  
+ATOM   1351  CB  PRO A 200      20.299   1.499  22.798  1.00  6.45           C  
+ANISOU 1351  CB  PRO A 200      787    925    739      5    -98    201       C  
+ATOM   1352  CG  PRO A 200      19.485   1.167  21.578  1.00  6.58           C  
+ANISOU 1352  CG  PRO A 200      883    707    909    -62    -39     85       C  
+ATOM   1353  CD  PRO A 200      19.526   2.406  20.746  1.00  6.44           C  
+ANISOU 1353  CD  PRO A 200      759    787    899    -55    -24    174       C  
+ATOM   1354  N   VAL A 201      23.532   1.471  22.957  1.00  6.05           N  
+ANISOU 1354  N   VAL A 201      796    882    621     -4    -29    127       N  
+ATOM   1355  CA  VAL A 201      24.494   0.428  23.181  1.00  6.57           C  
+ANISOU 1355  CA  VAL A 201      828   1078    589    -13    -33    251       C  
+ATOM   1356  C   VAL A 201      24.201  -0.055  24.606  1.00  7.01           C  
+ANISOU 1356  C   VAL A 201      780   1168    716    -22    -52    188       C  
+ATOM   1357  O   VAL A 201      24.393   0.649  25.592  1.00  7.04           O  
+ANISOU 1357  O   VAL A 201      815   1174    687    107    -43    283       O  
+ATOM   1358  CB  VAL A 201      25.934   0.921  23.131  1.00  7.00           C  
+ANISOU 1358  CB  VAL A 201      814   1089    756    -52    -64    106       C  
+ATOM   1359  CG1 VAL A 201      26.922  -0.221  23.368  1.00  8.58           C  
+ANISOU 1359  CG1 VAL A 201      883   1479    897      7     71    154       C  
+ATOM   1360  CG2 VAL A 201      26.211   1.681  21.798  1.00  8.98           C  
+ANISOU 1360  CG2 VAL A 201     1350   1295    767   -153     59     48       C  
+ATOM   1361  N   VAL A 202      23.674  -1.272  24.700  1.00  6.94           N  
+ANISOU 1361  N   VAL A 202      857   1093    685    -30    -34    195       N  
+ATOM   1362  CA  VAL A 202      23.211  -1.814  25.990  1.00  7.43           C  
+ANISOU 1362  CA  VAL A 202      874   1215    733     74     12    264       C  
+ATOM   1363  C   VAL A 202      24.111  -2.971  26.367  1.00  8.26           C  
+ANISOU 1363  C   VAL A 202     1019   1324    793    159    121    254       C  
+ATOM   1364  O   VAL A 202      24.371  -3.875  25.569  1.00  8.34           O  
+ANISOU 1364  O   VAL A 202     1084   1282    803    199    -21    257       O  
+ATOM   1365  CB  VAL A 202      21.746  -2.219  25.914  1.00  7.47           C  
+ANISOU 1365  CB  VAL A 202      885   1184    768    -92   -119    324       C  
+ATOM   1366  CG1 VAL A 202      21.349  -3.128  27.104  1.00 10.02           C  
+ANISOU 1366  CG1 VAL A 202     1364   1451    992    -84    160    483       C  
+ATOM   1367  CG2 VAL A 202      20.918  -0.965  25.930  1.00  9.34           C  
+ANISOU 1367  CG2 VAL A 202      821   1557   1168    130    -40    260       C  
+ATOM   1368  N   CYS A 203      24.625  -2.908  27.591  1.00  9.11           N  
+ANISOU 1368  N   CYS A 203     1294   1354    812    250    -46    185       N  
+ATOM   1369  CA  CYS A 203      25.634  -3.855  28.098  1.00 10.24           C  
+ANISOU 1369  CA  CYS A 203     1496   1432    963    195      7    147       C  
+ATOM   1370  C   CYS A 203      25.142  -4.248  29.467  1.00 11.73           C  
+ANISOU 1370  C   CYS A 203     1854   1509   1093    305    -68    164       C  
+ATOM   1371  O   CYS A 203      24.916  -3.419  30.328  1.00 11.59           O  
+ANISOU 1371  O   CYS A 203     1846   1668    887    531   -151    265       O  
+ATOM   1372  CB  CYS A 203      27.012  -3.206  28.206  1.00 11.54           C  
+ANISOU 1372  CB  CYS A 203     1281   1649   1453    286    -53     31       C  
+ATOM   1373  SG  CYS A 203      27.475  -2.163  26.836  1.00 12.15           S  
+ANISOU 1373  SG  CYS A 203     1309   2055   1249     99    -28   -374       S  
+ATOM   1374  N   SER A 204      24.919  -5.524  29.643  1.00 12.22           N  
+ANISOU 1374  N   SER A 204     2176   1512    953    315    -40    246       N  
+ATOM   1375  C   SER A 204      23.241  -5.318  31.461  1.00 13.20           C  
+ANISOU 1375  C   SER A 204     2262   1451   1302    262     51    242       C  
+ATOM   1376  O   SER A 204      23.162  -5.012  32.659  1.00 14.24           O  
+ANISOU 1376  O   SER A 204     2667   1563   1179    395    169    391       O  
+ATOM   1377  CA ASER A 204      24.545  -6.010  30.968  0.50 11.93           C  
+ANISOU 1377  CA ASER A 204     2070   1417   1045    219    -27    222       C  
+ATOM   1378  CB ASER A 204      25.717  -5.818  31.991  0.50 11.81           C  
+ANISOU 1378  CB ASER A 204     1929   1347   1209    204      8    178       C  
+ATOM   1379  OG ASER A 204      26.969  -6.292  31.477  0.50 10.14           O  
+ANISOU 1379  OG ASER A 204     1730   1237    883    294    -20    258       O  
+ATOM   1380  CA BSER A 204      24.375  -6.089  30.874  0.50 13.04           C  
+ANISOU 1380  CA BSER A 204     2256   1498   1198    268     14    223       C  
+ATOM   1381  CB BSER A 204      25.455  -6.403  31.866  0.50 13.77           C  
+ANISOU 1381  CB BSER A 204     2293   1543   1394    306     -6    200       C  
+ATOM   1382  OG BSER A 204      25.959  -7.631  31.425  0.50 13.34           O  
+ANISOU 1382  OG BSER A 204     2411   1356   1301    424     70     73       O  
+ATOM   1383  N   GLY A 205      22.250  -5.094  30.596  1.00 12.69           N  
+ANISOU 1383  N   GLY A 205     2228   1326   1265    186    129    323       N  
+ATOM   1384  CA  GLY A 205      20.998  -4.448  31.018  1.00 12.55           C  
+ANISOU 1384  CA  GLY A 205     1980   1416   1371     74    141    372       C  
+ATOM   1385  C   GLY A 205      21.045  -2.963  31.288  1.00 11.68           C  
+ANISOU 1385  C   GLY A 205     1698   1334   1404     92    101    305       C  
+ATOM   1386  O   GLY A 205      20.085  -2.397  31.810  1.00 13.10           O  
+ANISOU 1386  O   GLY A 205     1780   1629   1568      0    360    305       O  
+ATOM   1387  N   LYS A 206      22.149  -2.308  30.922  1.00  9.33           N  
+ANISOU 1387  N   LYS A 206     1350   1234    960    116    142    316       N  
+ATOM   1388  C   LYS A 206      22.674  -0.182  29.892  1.00  8.72           C  
+ANISOU 1388  C   LYS A 206     1146   1300    867    139     39    194       C  
+ATOM   1389  O   LYS A 206      23.382  -0.700  29.047  1.00  8.99           O  
+ANISOU 1389  O   LYS A 206     1244   1310    860    268    -27    321       O  
+ATOM   1390  CA ALYS A 206      22.337  -0.886  31.190  0.50  9.41           C  
+ANISOU 1390  CA ALYS A 206     1287   1282   1005    115      5    207       C  
+ATOM   1391  CB ALYS A 206      23.468  -0.608  32.203  0.50 10.34           C  
+ANISOU 1391  CB ALYS A 206     1416   1479   1034     84    -29    172       C  
+ATOM   1392  CG ALYS A 206      23.388  -1.305  33.577  0.50  9.87           C  
+ANISOU 1392  CG ALYS A 206     1327   1459    962     95    -52    245       C  
+ATOM   1393  CD ALYS A 206      22.145  -0.955  34.349  0.50 11.35           C  
+ANISOU 1393  CD ALYS A 206     1679   1553   1079    103     35    -14       C  
+ATOM   1394  CE ALYS A 206      22.169  -1.598  35.738  0.50 13.29           C  
+ANISOU 1394  CE ALYS A 206     1910   1840   1296     15     72     57       C  
+ATOM   1395  NZ ALYS A 206      22.241  -3.095  35.637  0.50 16.87           N  
+ANISOU 1395  NZ ALYS A 206     2358   1936   2114     76    128      4       N  
+ATOM   1396  CA BLYS A 206      22.383  -0.906  31.190  0.50  9.48           C  
+ANISOU 1396  CA BLYS A 206     1300   1284   1016    120     23    209       C  
+ATOM   1397  CB BLYS A 206      23.596  -0.764  32.112  0.50 10.13           C  
+ANISOU 1397  CB BLYS A 206     1378   1479    990    120     18    193       C  
+ATOM   1398  CG BLYS A 206      23.604  -1.711  33.302  0.50 10.76           C  
+ANISOU 1398  CG BLYS A 206     1494   1436   1158    152    -18    250       C  
+ATOM   1399  CD BLYS A 206      22.420  -1.466  34.198  0.50 11.45           C  
+ANISOU 1399  CD BLYS A 206     1596   1629   1123    246    -18    172       C  
+ATOM   1400  CE BLYS A 206      22.443  -2.407  35.366  0.50 12.59           C  
+ANISOU 1400  CE BLYS A 206     1750   1457   1575     99    170    214       C  
+ATOM   1401  NZ BLYS A 206      21.215  -2.200  36.165  0.50 13.90           N  
+ANISOU 1401  NZ BLYS A 206     1801   1818   1662     72    186    101       N  
+ATOM   1402  N   LEU A 207      22.143   1.023  29.756  1.00  7.93           N  
+ANISOU 1402  N   LEU A 207     1062   1168    781     82     41    206       N  
+ATOM   1403  CA  LEU A 207      22.456   1.889  28.625  1.00  7.23           C  
+ANISOU 1403  CA  LEU A 207      963   1099    684     60      2    138       C  
+ATOM   1404  C   LEU A 207      23.841   2.498  28.823  1.00  7.52           C  
+ANISOU 1404  C   LEU A 207     1050   1029    776     59      7    129       C  
+ATOM   1405  O   LEU A 207      23.992   3.471  29.553  1.00  9.17           O  
+ANISOU 1405  O   LEU A 207      982   1495   1008    152    -78    -24       O  
+ATOM   1406  CB  LEU A 207      21.407   2.980  28.503  1.00  7.33           C  
+ANISOU 1406  CB  LEU A 207      925   1083    776    108      9    162       C  
+ATOM   1407  CG  LEU A 207      21.605   3.905  27.278  1.00  7.28           C  
+ANISOU 1407  CG  LEU A 207      856   1060    850    -10     -9    107       C  
+ATOM   1408  CD1 LEU A 207      21.404   3.176  25.958  1.00  7.75           C  
+ANISOU 1408  CD1 LEU A 207     1056   1138    750    134    -75     33       C  
+ATOM   1409  CD2 LEU A 207      20.668   5.113  27.386  1.00  9.26           C  
+ANISOU 1409  CD2 LEU A 207     1099   1336   1082    136    -38    173       C  
+ATOM   1410  N   GLN A 208      24.850   1.925  28.184  1.00  7.41           N  
+ANISOU 1410  N   GLN A 208      913   1115    787    123     20    191       N  
+ATOM   1411  CA  GLN A 208      26.211   2.391  28.341  1.00  7.28           C  
+ANISOU 1411  CA  GLN A 208      915   1188    664     48    -33    172       C  
+ATOM   1412  C   GLN A 208      26.666   3.325  27.225  1.00  6.76           C  
+ANISOU 1412  C   GLN A 208      832   1069    668    119   -106    146       C  
+ATOM   1413  O   GLN A 208      27.585   4.127  27.413  1.00  6.99           O  
+ANISOU 1413  O   GLN A 208      743   1315    597     33    -28    171       O  
+ATOM   1414  CB  GLN A 208      27.194   1.219  28.489  1.00  8.03           C  
+ANISOU 1414  CB  GLN A 208      988   1196    867     12     -6    310       C  
+ATOM   1415  CG  GLN A 208      27.009   0.424  29.788  1.00  9.05           C  
+ANISOU 1415  CG  GLN A 208     1112   1322   1003     24     -4    277       C  
+ATOM   1416  CD  GLN A 208      27.518   1.113  31.060  1.00  9.89           C  
+ANISOU 1416  CD  GLN A 208     1331   1578    847     78    -71    362       C  
+ATOM   1417  OE1 GLN A 208      27.831   2.281  31.093  1.00 12.75           O  
+ANISOU 1417  OE1 GLN A 208     1809   2173    858   -173   -279    236       O  
+ATOM   1418  NE2 GLN A 208      27.513   0.357  32.163  1.00 12.34           N  
+ANISOU 1418  NE2 GLN A 208     1354   2282   1051    407     -1    662       N  
+ATOM   1419  N   GLY A 209      26.029   3.253  26.068  1.00  6.78           N  
+ANISOU 1419  N   GLY A 209      819   1124    632     68   -103    273       N  
+ATOM   1420  CA  GLY A 209      26.455   4.097  24.982  1.00  6.23           C  
+ANISOU 1420  CA  GLY A 209      792    979    593     65     14    139       C  
+ATOM   1421  C   GLY A 209      25.338   4.632  24.154  1.00  5.86           C  
+ANISOU 1421  C   GLY A 209      636    924    667     81     33     94       C  
+ATOM   1422  O   GLY A 209      24.229   4.106  24.140  1.00  6.84           O  
+ANISOU 1422  O   GLY A 209      769   1083    747    -22    -16    188       O  
+ATOM   1423  N   ILE A 210      25.688   5.662  23.415  1.00  5.54           N  
+ANISOU 1423  N   ILE A 210      644    871    588     53    -17    126       N  
+ATOM   1424  CA  ILE A 210      24.831   6.309  22.426  1.00  5.95           C  
+ANISOU 1424  CA  ILE A 210      690    903    665     10    -52    146       C  
+ATOM   1425  C   ILE A 210      25.606   6.261  21.101  1.00  5.62           C  
+ANISOU 1425  C   ILE A 210      744    726    663     55    -95    153       C  
+ATOM   1426  O   ILE A 210      26.750   6.704  21.042  1.00  5.29           O  
+ANISOU 1426  O   ILE A 210      607    674    729     33    -33     23       O  
+ATOM   1427  CB  ILE A 210      24.514   7.773  22.779  1.00  5.91           C  
+ANISOU 1427  CB  ILE A 210      692    967    586     76     -5    185       C  
+ATOM   1428  CG1 ILE A 210      23.886   7.868  24.168  1.00  7.43           C  
+ANISOU 1428  CG1 ILE A 210      894   1080    849     69     -6     67       C  
+ATOM   1429  CG2 ILE A 210      23.629   8.375  21.694  1.00  6.70           C  
+ANISOU 1429  CG2 ILE A 210      683    881    981     91    -73    177       C  
+ATOM   1430  CD1 ILE A 210      23.846   9.319  24.678  1.00  8.50           C  
+ANISOU 1430  CD1 ILE A 210     1063   1106   1059     -3   -112   -142       C  
+ATOM   1431  N   VAL A 211      24.993   5.753  20.044  1.00  4.84           N  
+ANISOU 1431  N   VAL A 211      568    672    597    -14     21     91       N  
+ATOM   1432  CA  VAL A 211      25.625   5.770  18.725  1.00  5.14           C  
+ANISOU 1432  CA  VAL A 211      535    694    721     90     18     93       C  
+ATOM   1433  C   VAL A 211      25.959   7.203  18.348  1.00  5.03           C  
+ANISOU 1433  C   VAL A 211      646    642    621    123    -44     94       C  
+ATOM   1434  O   VAL A 211      25.082   8.062  18.328  1.00  5.06           O  
+ANISOU 1434  O   VAL A 211      602    649    671    126    -79     19       O  
+ATOM   1435  CB  VAL A 211      24.689   5.172  17.650  1.00  4.78           C  
+ANISOU 1435  CB  VAL A 211      652    470    693     40    -65     18       C  
+ATOM   1436  CG1 VAL A 211      25.407   5.192  16.298  1.00  5.91           C  
+ANISOU 1436  CG1 VAL A 211      791    712    743    140     51     24       C  
+ATOM   1437  CG2 VAL A 211      24.239   3.734  18.003  1.00  6.70           C  
+ANISOU 1437  CG2 VAL A 211      736    946    864    140     42    177       C  
+ATOM   1438  N   SER A 212      27.235   7.453  18.057  1.00  4.94           N  
+ANISOU 1438  N   SER A 212      573    600    704    141      7    117       N  
+ATOM   1439  CA  SER A 212      27.717   8.830  17.848  1.00  4.95           C  
+ANISOU 1439  CA  SER A 212      643    640    596    132    -81     92       C  
+ATOM   1440  C   SER A 212      28.399   9.032  16.499  1.00  5.33           C  
+ANISOU 1440  C   SER A 212      704    629    689    100    -92     79       C  
+ATOM   1441  O   SER A 212      27.845   9.697  15.636  1.00  5.87           O  
+ANISOU 1441  O   SER A 212      697    807    726     52    -55    200       O  
+ATOM   1442  CB  SER A 212      28.573   9.268  19.042  1.00  5.36           C  
+ANISOU 1442  CB  SER A 212      641    614    780    137    -23     32       C  
+ATOM   1443  OG  SER A 212      29.036  10.609  18.924  1.00  5.64           O  
+ANISOU 1443  OG  SER A 212      624    685    832    -35     71    -10       O  
+ATOM   1444  N   TRP A 213      29.582   8.453  16.282  1.00  4.67           N  
+ANISOU 1444  N   TRP A 213      621    524    629     35     58    187       N  
+ATOM   1445  CA  TRP A 213      30.328   8.747  15.065  1.00  5.01           C  
+ANISOU 1445  CA  TRP A 213      646    639    619     45     10    131       C  
+ATOM   1446  C   TRP A 213      31.328   7.636  14.746  1.00  5.28           C  
+ANISOU 1446  C   TRP A 213      654    542    807     17    -47    181       C  
+ATOM   1447  O   TRP A 213      31.534   6.721  15.530  1.00  5.61           O  
+ANISOU 1447  O   TRP A 213      681    688    761     55    -11    177       O  
+ATOM   1448  CB  TRP A 213      31.033  10.100  15.197  1.00  5.36           C  
+ANISOU 1448  CB  TRP A 213      611    617    808    119     81    174       C  
+ATOM   1449  CG  TRP A 213      32.118  10.189  16.226  1.00  5.53           C  
+ANISOU 1449  CG  TRP A 213      562    645    895      3     -3    188       C  
+ATOM   1450  CD1 TRP A 213      31.979  10.484  17.548  1.00  5.92           C  
+ANISOU 1450  CD1 TRP A 213      602    681    966    -83     70     99       C  
+ATOM   1451  CD2 TRP A 213      33.529  10.069  15.997  1.00  5.80           C  
+ANISOU 1451  CD2 TRP A 213      769    529    903     65    -11     63       C  
+ATOM   1452  NE1 TRP A 213      33.203  10.544  18.165  1.00  6.36           N  
+ANISOU 1452  NE1 TRP A 213      813    646    957    -64    -42     88       N  
+ATOM   1453  CE2 TRP A 213      34.172  10.276  17.236  1.00  6.27           C  
+ANISOU 1453  CE2 TRP A 213      661    764    955      5     -4     87       C  
+ATOM   1454  CE3 TRP A 213      34.311   9.837  14.868  1.00  6.41           C  
+ANISOU 1454  CE3 TRP A 213      775    709    949     60    -16     15       C  
+ATOM   1455  CZ2 TRP A 213      35.537  10.248  17.367  1.00  6.96           C  
+ANISOU 1455  CZ2 TRP A 213      703    850   1089    -67   -118    150       C  
+ATOM   1456  CZ3 TRP A 213      35.701   9.806  15.019  1.00  6.91           C  
+ANISOU 1456  CZ3 TRP A 213      803    751   1068    -73    118     66       C  
+ATOM   1457  CH2 TRP A 213      36.272   9.984  16.268  1.00  7.17           C  
+ANISOU 1457  CH2 TRP A 213      667    819   1236      9    -13     65       C  
+ATOM   1458  N   GLY A 214      31.972   7.758  13.583  1.00  5.59           N  
+ANISOU 1458  N   GLY A 214      849    548    726     93     17    163       N  
+ATOM   1459  CA  GLY A 214      33.096   6.933  13.223  1.00  5.93           C  
+ANISOU 1459  CA  GLY A 214      863    567    821     52      2    165       C  
+ATOM   1460  C   GLY A 214      33.565   7.343  11.861  1.00  6.37           C  
+ANISOU 1460  C   GLY A 214      847    753    818     28     42    190       C  
+ATOM   1461  O   GLY A 214      32.928   8.126  11.186  1.00  7.35           O  
+ANISOU 1461  O   GLY A 214     1070    834    887    135    149    272       O  
+ATOM   1462  N   SER A 215      34.694   6.799  11.446  1.00  6.37           N  
+ANISOU 1462  N   SER A 215      809    854    757     91    116    181       N  
+ATOM   1463  C   SER A 215      34.462   6.144   9.118  1.00  6.99           C  
+ANISOU 1463  C   SER A 215      931    846    876     75    260    339       C  
+ATOM   1464  O   SER A 215      34.845   4.996   8.925  1.00  7.64           O  
+ANISOU 1464  O   SER A 215     1143    736   1024    190    251    227       O  
+ATOM   1465  CA ASER A 215      35.191   7.044  10.098  0.50  7.02           C  
+ANISOU 1465  CA ASER A 215      905    903    859    119    140    252       C  
+ATOM   1466  CB ASER A 215      36.692   6.834  10.036  0.50  7.24           C  
+ANISOU 1466  CB ASER A 215      856   1057    836     14    172    148       C  
+ATOM   1467  OG ASER A 215      37.216   7.359   8.836  0.50  6.97           O  
+ANISOU 1467  OG ASER A 215      691   1124    832      6    427    243       O  
+ATOM   1468  CA BSER A 215      35.178   7.063  10.091  0.50  7.93           C  
+ANISOU 1468  CA BSER A 215     1038   1002    971    101    103    227       C  
+ATOM   1469  CB BSER A 215      36.693   6.947   9.998  0.50  8.55           C  
+ANISOU 1469  CB BSER A 215     1043   1159   1045     46    109    131       C  
+ATOM   1470  OG BSER A 215      37.325   7.998  10.716  0.50 13.92           O  
+ANISOU 1470  OG BSER A 215     1702   1836   1749   -155     37     28       O  
+ATOM   1471  N   GLY A 216      33.392   6.649   8.512  1.00  7.07           N  
+ANISOU 1471  N   GLY A 216     1032    668    985    118     95    283       N  
+ATOM   1472  CA  GLY A 216      32.510   5.785   7.757  1.00  7.69           C  
+ANISOU 1472  CA  GLY A 216     1150    847    924     57     59    281       C  
+ATOM   1473  C   GLY A 216      31.870   4.748   8.653  1.00  6.82           C  
+ANISOU 1473  C   GLY A 216      879    860    852     51    157    243       C  
+ATOM   1474  O   GLY A 216      31.715   4.954   9.864  1.00  7.32           O  
+ANISOU 1474  O   GLY A 216      937    916    927    141    138    195       O  
+ATOM   1475  N   CYS A 217      31.573   3.613   8.058  1.00  6.85           N  
+ANISOU 1475  N   CYS A 217      841    906    854     64    229    246       N  
+ATOM   1476  CA  CYS A 217      30.962   2.493   8.762  1.00  7.26           C  
+ANISOU 1476  CA  CYS A 217      929    917    910     49    245    237       C  
+ATOM   1477  C   CYS A 217      31.630   1.220   8.400  1.00  7.32           C  
+ANISOU 1477  C   CYS A 217      892    893    993    -38    228    225       C  
+ATOM   1478  O   CYS A 217      31.828   0.932   7.232  1.00  8.54           O  
+ANISOU 1478  O   CYS A 217     1165   1017   1060     77    312    172       O  
+ATOM   1479  CB  CYS A 217      29.467   2.351   8.371  1.00  8.72           C  
+ANISOU 1479  CB  CYS A 217     1100    837   1375    164    429    202       C  
+ATOM   1480  SG  CYS A 217      28.567   3.855   8.375  1.00  8.32           S  
+ANISOU 1480  SG  CYS A 217     1088   1028   1042     74    190    180       S  
+ATOM   1481  N   ALA A 218      31.945   0.404   9.412  1.00  6.98           N  
+ANISOU 1481  N   ALA A 218      948    785    915     13    175    126       N  
+ATOM   1482  CA  ALA A 218      32.445  -0.952   9.201  1.00  7.14           C  
+ANISOU 1482  CA  ALA A 218      898    691   1124     39    230     82       C  
+ATOM   1483  C   ALA A 218      33.763  -0.981   8.443  1.00  7.37           C  
+ANISOU 1483  C   ALA A 218      975    687   1139     90    174     37       C  
+ATOM   1484  O   ALA A 218      34.106  -1.973   7.815  1.00  8.21           O  
+ANISOU 1484  O   ALA A 218     1102    746   1271     27    359     16       O  
+ATOM   1485  CB  ALA A 218      31.380  -1.823   8.507  1.00  8.21           C  
+ANISOU 1485  CB  ALA A 218     1005    842   1271     19    112     58       C  
+ATOM   1486  N   GLN A 219      34.559   0.076   8.568  1.00  6.99           N  
+ANISOU 1486  N   GLN A 219      863    745   1046     78    228     29       N  
+ATOM   1487  CA  GLN A 219      35.878   0.148   7.921  1.00  7.73           C  
+ANISOU 1487  CA  GLN A 219      981    856   1099     37    259     92       C  
+ATOM   1488  C   GLN A 219      36.939  -0.453   8.813  1.00  7.76           C  
+ANISOU 1488  C   GLN A 219      895    808   1245     72    286     60       C  
+ATOM   1489  O   GLN A 219      36.918  -0.314  10.029  1.00  8.22           O  
+ANISOU 1489  O   GLN A 219      953    892   1276    113    318    252       O  
+ATOM   1490  CB  GLN A 219      36.211   1.597   7.577  1.00  7.81           C  
+ANISOU 1490  CB  GLN A 219      872    912   1184     89    300    133       C  
+ATOM   1491  CG  GLN A 219      35.194   2.234   6.632  1.00  8.72           C  
+ANISOU 1491  CG  GLN A 219     1098   1072   1140      3    239     73       C  
+ATOM   1492  CD  GLN A 219      35.048   1.409   5.372  1.00 11.43           C  
+ANISOU 1492  CD  GLN A 219     1360   1620   1359    154    243    -64       C  
+ATOM   1493  OE1 GLN A 219      36.030   1.142   4.674  1.00 13.28           O  
+ANISOU 1493  OE1 GLN A 219     1649   2051   1346     69    434   -181       O  
+ATOM   1494  NE2 GLN A 219      33.856   0.920   5.115  1.00 13.77           N  
+ANISOU 1494  NE2 GLN A 219     1665   1937   1629     73    123   -128       N  
+ATOM   1495  N   LYS A 220      37.922  -1.082   8.186  1.00  9.60           N  
+ANISOU 1495  N   LYS A 220     1011   1188   1447    169    344    177       N  
+ATOM   1496  C   LYS A 220      39.768  -0.553   9.727  1.00  9.06           C  
+ANISOU 1496  C   LYS A 220      934   1102   1406    136    320    179       C  
+ATOM   1497  O   LYS A 220      39.961   0.582   9.254  1.00  9.86           O  
+ANISOU 1497  O   LYS A 220     1064   1025   1657    127    359    291       O  
+ATOM   1498  CA ALYS A 220      39.074  -1.636   8.897  0.50  9.99           C  
+ANISOU 1498  CA ALYS A 220     1070   1182   1541    130    256    118       C  
+ATOM   1499  CB ALYS A 220      40.056  -2.268   7.892  0.50 10.87           C  
+ANISOU 1499  CB ALYS A 220     1218   1298   1611    150    216     88       C  
+ATOM   1500  CG ALYS A 220      41.229  -3.017   8.524  0.50 12.03           C  
+ANISOU 1500  CG ALYS A 220     1347   1540   1683    122    118    -38       C  
+ATOM   1501  CD ALYS A 220      42.124  -3.624   7.464  0.50 12.88           C  
+ANISOU 1501  CD ALYS A 220     1478   1645   1769    148    239    -40       C  
+ATOM   1502  CE ALYS A 220      43.523  -3.845   7.999  0.50 16.30           C  
+ANISOU 1502  CE ALYS A 220     1930   2035   2227    211     38     39       C  
+ATOM   1503  NZ ALYS A 220      44.381  -4.447   6.948  0.50 19.52           N  
+ANISOU 1503  NZ ALYS A 220     2425   2639   2351    126    179    -23       N  
+ATOM   1504  CA BLYS A 220      39.059  -1.629   8.922  0.50  9.34           C  
+ANISOU 1504  CA BLYS A 220      965   1078   1503    149    286    138       C  
+ATOM   1505  CB BLYS A 220      40.044  -2.304   7.971  0.50 10.54           C  
+ANISOU 1505  CB BLYS A 220     1140   1259   1605    180    232    107       C  
+ATOM   1506  CG BLYS A 220      39.488  -3.542   7.328  0.50 11.42           C  
+ANISOU 1506  CG BLYS A 220     1295   1337   1704    131    245     79       C  
+ATOM   1507  CD BLYS A 220      40.578  -4.317   6.640  0.50 12.66           C  
+ANISOU 1507  CD BLYS A 220     1465   1602   1739     27    241    -23       C  
+ATOM   1508  CE BLYS A 220      40.027  -5.262   5.593  0.50 14.73           C  
+ANISOU 1508  CE BLYS A 220     1798   1909   1887     27    113   -116       C  
+ATOM   1509  NZ BLYS A 220      41.061  -6.272   5.209  0.50 17.53           N  
+ANISOU 1509  NZ BLYS A 220     2228   2153   2278     98    254   -109       N  
+ATOM   1510  N   ASN A 221      40.155  -0.893  10.953  1.00  9.45           N  
+ANISOU 1510  N   ASN A 221      963   1038   1589    196    163    226       N  
+ATOM   1511  CA  ASN A 221      40.888  -0.027  11.840  1.00 10.54           C  
+ANISOU 1511  CA  ASN A 221     1066   1303   1633     34     75    234       C  
+ATOM   1512  C   ASN A 221      40.084   1.160  12.339  1.00  9.09           C  
+ANISOU 1512  C   ASN A 221      998   1164   1291    -52    128    280       C  
+ATOM   1513  O   ASN A 221      40.643   2.016  12.993  1.00 10.52           O  
+ANISOU 1513  O   ASN A 221     1018   1694   1284     89    164    -34       O  
+ATOM   1514  CB  ASN A 221      42.204   0.551  11.195  1.00 11.51           C  
+ANISOU 1514  CB  ASN A 221     1007   1397   1967     65     43    129       C  
+ATOM   1515  CG  ASN A 221      43.108  -0.475  10.544  1.00 15.82           C  
+ANISOU 1515  CG  ASN A 221     1786   1977   2246    148     16    120       C  
+ATOM   1516  OD1 ASN A 221      43.318  -1.551  11.083  1.00 15.71           O  
+ANISOU 1516  OD1 ASN A 221     2076   1786   2104    592    -99    323       O  
+ATOM   1517  ND2 ASN A 221      43.720  -0.102   9.389  1.00 17.47           N  
+ANISOU 1517  ND2 ASN A 221     2016   2176   2444    290     39   -239       N  
+ATOM   1518  N   LYS A 222      38.764   1.181  12.092  1.00  8.26           N  
+ANISOU 1518  N   LYS A 222      848   1057   1233     11    208    263       N  
+ATOM   1519  C   LYS A 222      36.625   1.866  13.031  1.00  7.49           C  
+ANISOU 1519  C   LYS A 222      841    870   1132    -10    121     50       C  
+ATOM   1520  O   LYS A 222      35.588   1.853  12.381  1.00  8.52           O  
+ANISOU 1520  O   LYS A 222      945   1325    966    -37    119    256       O  
+ATOM   1521  CA ALYS A 222      37.935   2.333  12.416  0.50  7.67           C  
+ANISOU 1521  CA ALYS A 222      891    934   1089      1    127    101       C  
+ATOM   1522  CB ALYS A 222      37.684   3.149  11.162  0.50  7.31           C  
+ANISOU 1522  CB ALYS A 222      773    964   1040     78    146     92       C  
+ATOM   1523  CG ALYS A 222      38.926   3.794  10.575  0.50  7.28           C  
+ANISOU 1523  CG ALYS A 222      901    914    948     83    159    118       C  
+ATOM   1524  CD ALYS A 222      39.522   4.862  11.480  0.50  7.29           C  
+ANISOU 1524  CD ALYS A 222      747   1078    946   -117    204    210       C  
+ATOM   1525  CE ALYS A 222      40.769   5.446  10.877  0.50  7.27           C  
+ANISOU 1525  CE ALYS A 222      890   1135    735   -183    121    370       C  
+ATOM   1526  NZ ALYS A 222      41.391   6.433  11.757  0.50  9.77           N  
+ANISOU 1526  NZ ALYS A 222     1287   1493    931   -643     40    418       N  
+ATOM   1527  CA BLYS A 222      37.937   2.335  12.416  0.50  7.96           C  
+ANISOU 1527  CA BLYS A 222      926    964   1133      4    127    101       C  
+ATOM   1528  CB BLYS A 222      37.694   3.164  11.164  0.50  7.89           C  
+ANISOU 1528  CB BLYS A 222      866   1018   1113     82    129     89       C  
+ATOM   1529  CG BLYS A 222      38.956   3.717  10.506  0.50  9.03           C  
+ANISOU 1529  CG BLYS A 222     1104   1077   1248    101    158    130       C  
+ATOM   1530  CD BLYS A 222      39.724   4.690  11.403  0.50 10.96           C  
+ANISOU 1530  CD BLYS A 222     1295   1521   1346    -15    239     81       C  
+ATOM   1531  CE BLYS A 222      41.174   4.841  10.961  0.50 13.17           C  
+ANISOU 1531  CE BLYS A 222     1493   1918   1591    100    276     92       C  
+ATOM   1532  NZ BLYS A 222      41.304   5.597   9.695  0.50 18.70           N  
+ANISOU 1532  NZ BLYS A 222     2379   2554   2171     25    107    163       N  
+ATOM   1533  N   PRO A 223      36.676   1.463  14.293  1.00  6.76           N  
+ANISOU 1533  N   PRO A 223      753    820    992     22    142     36       N  
+ATOM   1534  CA  PRO A 223      35.471   0.999  14.950  1.00  6.71           C  
+ANISOU 1534  CA  PRO A 223      739    807   1002     -5    121     26       C  
+ATOM   1535  C   PRO A 223      34.505   2.152  15.239  1.00  6.01           C  
+ANISOU 1535  C   PRO A 223      750    672    860    -23     76     63       C  
+ATOM   1536  O   PRO A 223      34.877   3.324  15.182  1.00  6.74           O  
+ANISOU 1536  O   PRO A 223      734    782   1045     -8    196    124       O  
+ATOM   1537  CB  PRO A 223      36.026   0.406  16.249  1.00  7.63           C  
+ANISOU 1537  CB  PRO A 223      873    860   1164     98    141    119       C  
+ATOM   1538  CG  PRO A 223      37.233   1.239  16.545  1.00  8.29           C  
+ANISOU 1538  CG  PRO A 223      905   1041   1200     51    140    184       C  
+ATOM   1539  CD  PRO A 223      37.835   1.493  15.201  1.00  7.47           C  
+ANISOU 1539  CD  PRO A 223      867    834   1134     17    158    132       C  
+ATOM   1540  N   GLY A 224      33.274   1.844  15.561  1.00  5.66           N  
+ANISOU 1540  N   GLY A 224      691    603    855    -30     84    152       N  
+ATOM   1541  CA  GLY A 224      32.368   2.888  15.973  1.00  5.71           C  
+ANISOU 1541  CA  GLY A 224      633    725    812    -12     11    102       C  
+ATOM   1542  C   GLY A 224      32.747   3.533  17.275  1.00  5.46           C  
+ANISOU 1542  C   GLY A 224      677    691    704    -19     96    114       C  
+ATOM   1543  O   GLY A 224      33.305   2.885  18.169  1.00  5.52           O  
+ANISOU 1543  O   GLY A 224      611    612    873     25    -20    103       O  
+ATOM   1544  N   VAL A 225      32.407   4.824  17.386  1.00  5.04           N  
+ANISOU 1544  N   VAL A 225      622    645    646    100      0    127       N  
+ATOM   1545  CA  VAL A 225      32.608   5.637  18.589  1.00  5.22           C  
+ANISOU 1545  CA  VAL A 225      575    718    687     91    -66    125       C  
+ATOM   1546  C   VAL A 225      31.248   5.990  19.161  1.00  4.82           C  
+ANISOU 1546  C   VAL A 225      683    441    707     33    -37     92       C  
+ATOM   1547  O   VAL A 225      30.292   6.329  18.445  1.00  5.04           O  
+ANISOU 1547  O   VAL A 225      574    708    633     98     -5    130       O  
+ATOM   1548  CB  VAL A 225      33.483   6.870  18.311  1.00  5.71           C  
+ANISOU 1548  CB  VAL A 225      611    758    800    -33     78     77       C  
+ATOM   1549  CG1 VAL A 225      33.858   7.522  19.614  1.00  6.27           C  
+ANISOU 1549  CG1 VAL A 225      747    854    779    -22   -144     23       C  
+ATOM   1550  CG2 VAL A 225      34.733   6.476  17.508  1.00  6.38           C  
+ANISOU 1550  CG2 VAL A 225      611    863    948     14    121     71       C  
+ATOM   1551  N   TYR A 226      31.160   5.924  20.480  1.00  5.05           N  
+ANISOU 1551  N   TYR A 226      488    729    702     27    -56    106       N  
+ATOM   1552  CA  TYR A 226      29.923   6.001  21.235  1.00  5.28           C  
+ANISOU 1552  CA  TYR A 226      637    618    749     65    -55    148       C  
+ATOM   1553  C   TYR A 226      30.061   6.956  22.408  1.00  5.46           C  
+ANISOU 1553  C   TYR A 226      652    696    726     55    -23    226       C  
+ATOM   1554  O   TYR A 226      31.095   6.992  23.073  1.00  5.79           O  
+ANISOU 1554  O   TYR A 226      588    815    797     44    -86     50       O  
+ATOM   1555  CB  TYR A 226      29.563   4.588  21.735  1.00  5.26           C  
+ANISOU 1555  CB  TYR A 226      546    681    770    127    -29    193       C  
+ATOM   1556  CG  TYR A 226      29.347   3.634  20.587  1.00  5.14           C  
+ANISOU 1556  CG  TYR A 226      634    586    729     78     43    171       C  
+ATOM   1557  CD1 TYR A 226      28.124   3.566  19.972  1.00  5.64           C  
+ANISOU 1557  CD1 TYR A 226      809    662    671     42    -25    138       C  
+ATOM   1558  CD2 TYR A 226      30.388   2.865  20.069  1.00  5.08           C  
+ANISOU 1558  CD2 TYR A 226      682    568    676    -60    -58    189       C  
+ATOM   1559  CE1 TYR A 226      27.922   2.780  18.859  1.00  5.67           C  
+ANISOU 1559  CE1 TYR A 226      579    908    666    170     -6     46       C  
+ATOM   1560  CE2 TYR A 226      30.195   2.072  18.947  1.00  5.62           C  
+ANISOU 1560  CE2 TYR A 226      571    658    905     43     28    111       C  
+ATOM   1561  CZ  TYR A 226      28.941   2.020  18.350  1.00  5.25           C  
+ANISOU 1561  CZ  TYR A 226      673    602    717      3    -15     87       C  
+ATOM   1562  OH  TYR A 226      28.696   1.274  17.210  1.00  5.61           O  
+ANISOU 1562  OH  TYR A 226      810    648    672     51    -54     96       O  
+ATOM   1563  N   THR A 227      29.010   7.708  22.700  1.00  5.38           N  
+ANISOU 1563  N   THR A 227      619    801    625     38   -121     17       N  
+ATOM   1564  CA  THR A 227      29.007   8.561  23.882  1.00  5.68           C  
+ANISOU 1564  CA  THR A 227      686    820    651    -65   -135    -64       C  
+ATOM   1565  C   THR A 227      28.964   7.685  25.117  1.00  6.06           C  
+ANISOU 1565  C   THR A 227      590    960    750     66      1    -61       C  
+ATOM   1566  O   THR A 227      28.160   6.745  25.196  1.00  6.33           O  
+ANISOU 1566  O   THR A 227      811   1092    501     15    -12     79       O  
+ATOM   1567  CB  THR A 227      27.780   9.447  23.872  1.00  6.40           C  
+ANISOU 1567  CB  THR A 227      687    981    761     83    -82    -66       C  
+ATOM   1568  OG1 THR A 227      27.708  10.093  22.610  1.00  7.00           O  
+ANISOU 1568  OG1 THR A 227      940    910    809     96     39     13       O  
+ATOM   1569  CG2 THR A 227      27.845  10.497  24.974  1.00  6.98           C  
+ANISOU 1569  CG2 THR A 227      925    848    880    123   -132   -208       C  
+ATOM   1570  N   LYS A 228      29.797   8.017  26.104  1.00  6.72           N  
+ANISOU 1570  N   LYS A 228      791   1019    741     16    -50     67       N  
+ATOM   1571  CA  LYS A 228      29.960   7.193  27.305  1.00  7.73           C  
+ANISOU 1571  CA  LYS A 228      891   1149    895    118    -42     67       C  
+ATOM   1572  C   LYS A 228      28.954   7.653  28.380  1.00  7.63           C  
+ANISOU 1572  C   LYS A 228     1015   1160    723    135   -101     21       C  
+ATOM   1573  O   LYS A 228      29.187   8.586  29.175  1.00  7.67           O  
+ANISOU 1573  O   LYS A 228      983   1222    708      3    -41     -8       O  
+ATOM   1574  CB  LYS A 228      31.383   7.328  27.777  1.00  8.21           C  
+ANISOU 1574  CB  LYS A 228      944   1230    945    207    -78    111       C  
+ATOM   1575  CG  LYS A 228      31.776   6.315  28.814  1.00  9.40           C  
+ANISOU 1575  CG  LYS A 228     1139   1358   1074    135    -15    114       C  
+ATOM   1576  CD  LYS A 228      33.282   6.426  29.196  1.00 12.07           C  
+ANISOU 1576  CD  LYS A 228     1433   1633   1520    177   -321    195       C  
+ATOM   1577  CE  LYS A 228      33.735   5.321  30.092  1.00 15.97           C  
+ANISOU 1577  CE  LYS A 228     1717   2333   2018     -5   -265    308       C  
+ATOM   1578  NZ  LYS A 228      35.195   5.424  30.331  1.00 17.89           N  
+ANISOU 1578  NZ  LYS A 228     1586   2921   2288     36   -334    313       N  
+ATOM   1579  N   VAL A 229      27.789   6.999  28.373  1.00  7.73           N  
+ANISOU 1579  N   VAL A 229     1024   1218    695     92   -120    106       N  
+ATOM   1580  CA  VAL A 229      26.618   7.431  29.144  1.00  8.07           C  
+ANISOU 1580  CA  VAL A 229     1000   1407    658     60    -58     90       C  
+ATOM   1581  C   VAL A 229      26.921   7.463  30.655  1.00  8.49           C  
+ANISOU 1581  C   VAL A 229     1091   1397    739     95    -69     71       C  
+ATOM   1582  O   VAL A 229      26.390   8.323  31.375  1.00  9.65           O  
+ANISOU 1582  O   VAL A 229     1180   1684    801    110     16    -38       O  
+ATOM   1583  CB  VAL A 229      25.424   6.513  28.852  1.00  7.57           C  
+ANISOU 1583  CB  VAL A 229      981   1255    638    136     66    174       C  
+ATOM   1584  CG1 VAL A 229      24.220   6.821  29.760  1.00  7.96           C  
+ANISOU 1584  CG1 VAL A 229      975   1248    800    181    167     57       C  
+ATOM   1585  CG2 VAL A 229      25.000   6.642  27.382  1.00  8.48           C  
+ANISOU 1585  CG2 VAL A 229     1122   1286    814     47   -140    121       C  
+ATOM   1586  N   CYS A 230      27.782   6.572  31.136  1.00  8.58           N  
+ANISOU 1586  N   CYS A 230     1110   1488    661     92    -45     40       N  
+ATOM   1587  CA  CYS A 230      28.038   6.540  32.583  1.00  9.54           C  
+ANISOU 1587  CA  CYS A 230     1301   1614    710     34     -2     71       C  
+ATOM   1588  C   CYS A 230      28.609   7.846  33.145  1.00 10.34           C  
+ANISOU 1588  C   CYS A 230     1455   1703    771    -16    -86     72       C  
+ATOM   1589  O   CYS A 230      28.519   8.094  34.341  1.00 12.85           O  
+ANISOU 1589  O   CYS A 230     2112   2084    684   -153    -64    -69       O  
+ATOM   1590  CB  CYS A 230      28.947   5.366  32.921  1.00  9.99           C  
+ANISOU 1590  CB  CYS A 230     1236   1626    932     51    -88     85       C  
+ATOM   1591  SG  CYS A 230      30.606   5.470  32.130  1.00 11.24           S  
+ANISOU 1591  SG  CYS A 230     1287   2043    940    147   -168    228       S  
+ATOM   1592  N   ASN A 231      29.205   8.686  32.311  1.00  9.61           N  
+ANISOU 1592  N   ASN A 231     1247   1557    846     39    -27     85       N  
+ATOM   1593  CA  ASN A 231      29.717   9.972  32.744  1.00  9.97           C  
+ANISOU 1593  CA  ASN A 231     1278   1511    996     86   -114      7       C  
+ATOM   1594  C   ASN A 231      28.644  11.031  32.934  1.00 10.55           C  
+ANISOU 1594  C   ASN A 231     1311   1580   1117    139     64   -143       C  
+ATOM   1595  O   ASN A 231      28.941  12.114  33.452  1.00 12.33           O  
+ANISOU 1595  O   ASN A 231     1421   1821   1441    173   -107   -211       O  
+ATOM   1596  CB  ASN A 231      30.734  10.530  31.749  1.00 10.59           C  
+ANISOU 1596  CB  ASN A 231     1262   1637   1124     50   -101     17       C  
+ATOM   1597  CG  ASN A 231      32.012   9.736  31.690  1.00 11.29           C  
+ANISOU 1597  CG  ASN A 231     1322   1727   1239     53    -81     27       C  
+ATOM   1598  OD1 ASN A 231      32.211   8.807  32.474  1.00 13.37           O  
+ANISOU 1598  OD1 ASN A 231     1318   1932   1828    107   -222    276       O  
+ATOM   1599  ND2 ASN A 231      32.885  10.070  30.720  1.00 12.47           N  
+ANISOU 1599  ND2 ASN A 231     1344   1932   1462    -70     35   -130       N  
+ATOM   1600  N   TYR A 232      27.410  10.752  32.476  1.00 10.13           N  
+ANISOU 1600  N   TYR A 232     1387   1510    951    137    -17    -96       N  
+ATOM   1601  CA  TYR A 232      26.362  11.760  32.398  1.00 10.24           C  
+ANISOU 1601  CA  TYR A 232     1255   1558   1076    103    117    -41       C  
+ATOM   1602  C   TYR A 232      25.200  11.477  33.319  1.00 11.40           C  
+ANISOU 1602  C   TYR A 232     1436   1787   1107    110    172    -41       C  
+ATOM   1603  O   TYR A 232      24.170  12.128  33.220  1.00 11.81           O  
+ANISOU 1603  O   TYR A 232     1278   2072   1137    179    256    -32       O  
+ATOM   1604  CB  TYR A 232      25.832  11.865  30.968  1.00 10.05           C  
+ANISOU 1604  CB  TYR A 232     1288   1415   1112     93     49     -2       C  
+ATOM   1605  CG  TYR A 232      26.904  12.386  30.062  1.00  9.11           C  
+ANISOU 1605  CG  TYR A 232     1059   1414    986    205     87    103       C  
+ATOM   1606  CD1 TYR A 232      27.204  13.715  30.040  1.00 10.00           C  
+ANISOU 1606  CD1 TYR A 232     1247   1477   1076    263     62    -87       C  
+ATOM   1607  CD2 TYR A 232      27.670  11.522  29.274  1.00  8.98           C  
+ANISOU 1607  CD2 TYR A 232     1259   1232    919     83      6    -85       C  
+ATOM   1608  CE1 TYR A 232      28.212  14.208  29.262  1.00  9.23           C  
+ANISOU 1608  CE1 TYR A 232     1288   1098   1121    144      2   -145       C  
+ATOM   1609  CE2 TYR A 232      28.704  12.028  28.487  1.00  7.99           C  
+ANISOU 1609  CE2 TYR A 232     1062   1039    933    132     -8    -95       C  
+ATOM   1610  CZ  TYR A 232      28.971  13.362  28.491  1.00  7.38           C  
+ANISOU 1610  CZ  TYR A 232      987   1077    740    131    -87     29       C  
+ATOM   1611  OH  TYR A 232      29.984  13.820  27.716  1.00  8.12           O  
+ANISOU 1611  OH  TYR A 232     1014   1038   1030    224    -17     -1       O  
+ATOM   1612  N   VAL A 233      25.331  10.531  34.229  1.00 12.75           N  
+ANISOU 1612  N   VAL A 233     1519   1919   1405    131    316    103       N  
+ATOM   1613  C   VAL A 233      23.698  11.381  35.882  1.00 13.69           C  
+ANISOU 1613  C   VAL A 233     1715   2041   1445    122    167    112       C  
+ATOM   1614  O   VAL A 233      22.494  11.605  35.989  1.00 13.72           O  
+ANISOU 1614  O   VAL A 233     1603   2294   1314    239    306      4       O  
+ATOM   1615  CA AVAL A 233      24.221  10.176  35.136  0.50 13.72           C  
+ANISOU 1615  CA AVAL A 233     1653   2021   1537     73    223    104       C  
+ATOM   1616  CB AVAL A 233      24.680   9.175  36.200  0.50 14.18           C  
+ANISOU 1616  CB AVAL A 233     1635   2113   1640     77    131    149       C  
+ATOM   1617  CG1AVAL A 233      23.583   8.958  37.253  0.50 15.23           C  
+ANISOU 1617  CG1AVAL A 233     1895   2115   1774    -17     -8     54       C  
+ATOM   1618  CG2AVAL A 233      25.014   7.887  35.551  0.50 15.88           C  
+ANISOU 1618  CG2AVAL A 233     1892   2267   1873     23    246     76       C  
+ATOM   1619  CA BVAL A 233      24.144  10.182  34.999  0.50 13.46           C  
+ANISOU 1619  CA BVAL A 233     1647   1978   1487     78    203    107       C  
+ATOM   1620  CB BVAL A 233      24.311   8.823  35.737  0.50 13.65           C  
+ANISOU 1620  CB BVAL A 233     1714   1947   1522     64    207    114       C  
+ATOM   1621  CG1BVAL A 233      24.410   7.669  34.721  0.50 15.68           C  
+ANISOU 1621  CG1BVAL A 233     1944   2165   1846      2    115    173       C  
+ATOM   1622  CG2BVAL A 233      25.505   8.879  36.668  0.50 14.00           C  
+ANISOU 1622  CG2BVAL A 233     1745   2007   1568     72    180    189       C  
+ATOM   1623  N   SER A 234      24.619  12.174  36.450  1.00 13.82           N  
+ANISOU 1623  N   SER A 234     1664   2145   1438    143    162     26       N  
+ATOM   1624  C   SER A 234      23.517  14.398  36.333  1.00 13.40           C  
+ANISOU 1624  C   SER A 234     1671   2050   1367     60     69    -36       C  
+ATOM   1625  O   SER A 234      22.483  14.941  36.700  1.00 13.08           O  
+ANISOU 1625  O   SER A 234     1673   2239   1058    107     40   -123       O  
+ATOM   1626  CA ASER A 234      24.212  13.371  37.208  0.50 14.16           C  
+ANISOU 1626  CA ASER A 234     1806   2109   1464     98     72     11       C  
+ATOM   1627  CB ASER A 234      25.401  14.018  37.900  0.50 15.38           C  
+ANISOU 1627  CB ASER A 234     1944   2210   1689     92     27    -15       C  
+ATOM   1628  OG ASER A 234      25.819  13.221  38.978  0.50 17.92           O  
+ANISOU 1628  OG ASER A 234     2294   2548   1967    122    -58    185       O  
+ATOM   1629  CA BSER A 234      24.246  13.378  37.216  0.50 13.96           C  
+ANISOU 1629  CA BSER A 234     1771   2084   1449     88     83      8       C  
+ATOM   1630  CB BSER A 234      25.497  14.009  37.842  0.50 15.25           C  
+ANISOU 1630  CB BSER A 234     1925   2215   1653     74     20     -4       C  
+ATOM   1631  OG BSER A 234      25.178  15.098  38.695  0.50 16.83           O  
+ANISOU 1631  OG BSER A 234     2169   2427   1796     85    -93    -45       O  
+ATOM   1632  N   TRP A 235      24.055  14.634  35.137  1.00 12.29           N  
+ANISOU 1632  N   TRP A 235     1618   1914   1135     26    129    -31       N  
+ATOM   1633  CA  TRP A 235      23.457  15.581  34.206  1.00 11.67           C  
+ANISOU 1633  CA  TRP A 235     1513   1736   1183     24     91   -120       C  
+ATOM   1634  C   TRP A 235      22.072  15.120  33.803  1.00 10.07           C  
+ANISOU 1634  C   TRP A 235     1424   1478    923     78    116   -196       C  
+ATOM   1635  O   TRP A 235      21.139  15.897  33.694  1.00 10.29           O  
+ANISOU 1635  O   TRP A 235     1485   1393   1030     79    262   -258       O  
+ATOM   1636  CB  TRP A 235      24.355  15.764  32.975  1.00 11.19           C  
+ANISOU 1636  CB  TRP A 235     1472   1639   1140    -80     88   -157       C  
+ATOM   1637  CG  TRP A 235      23.749  16.701  31.959  1.00 11.36           C  
+ANISOU 1637  CG  TRP A 235     1542   1633   1140   -188     87     29       C  
+ATOM   1638  CD1 TRP A 235      23.689  18.041  32.041  1.00 12.10           C  
+ANISOU 1638  CD1 TRP A 235     1755   1613   1227   -174     50    -19       C  
+ATOM   1639  CD2 TRP A 235      23.021  16.340  30.799  1.00 10.19           C  
+ANISOU 1639  CD2 TRP A 235     1310   1525   1035    -45    247    -11       C  
+ATOM   1640  NE1 TRP A 235      23.006  18.565  30.974  1.00 12.05           N  
+ANISOU 1640  NE1 TRP A 235     1762   1558   1256    -84    174    -39       N  
+ATOM   1641  CE2 TRP A 235      22.565  17.521  30.204  1.00 10.78           C  
+ANISOU 1641  CE2 TRP A 235     1331   1537   1228      0    204   -191       C  
+ATOM   1642  CE3 TRP A 235      22.726  15.120  30.198  1.00 10.19           C  
+ANISOU 1642  CE3 TRP A 235     1418   1367   1084    174    216   -109       C  
+ATOM   1643  CZ2 TRP A 235      21.860  17.518  29.022  1.00 10.92           C  
+ANISOU 1643  CZ2 TRP A 235     1432   1564   1153     80    211    -62       C  
+ATOM   1644  CZ3 TRP A 235      21.995  15.125  29.026  1.00 10.82           C  
+ANISOU 1644  CZ3 TRP A 235     1440   1635   1033     51    154   -161       C  
+ATOM   1645  CH2 TRP A 235      21.579  16.308  28.456  1.00 10.00           C  
+ANISOU 1645  CH2 TRP A 235     1341   1543    915    -17    231   -101       C  
+ATOM   1646  N   ILE A 236      21.929  13.829  33.520  1.00  9.97           N  
+ANISOU 1646  N   ILE A 236     1414   1394    979     72    205   -198       N  
+ATOM   1647  CA  ILE A 236      20.627  13.309  33.108  1.00  9.69           C  
+ANISOU 1647  CA  ILE A 236     1400   1363    917    154    192   -136       C  
+ATOM   1648  C   ILE A 236      19.622  13.517  34.221  1.00  9.83           C  
+ANISOU 1648  C   ILE A 236     1395   1402    937    160    223    -13       C  
+ATOM   1649  O   ILE A 236      18.539  14.051  34.004  1.00 10.90           O  
+ANISOU 1649  O   ILE A 236     1336   1648   1158    231    327   -111       O  
+ATOM   1650  CB  ILE A 236      20.703  11.822  32.690  1.00  9.37           C  
+ANISOU 1650  CB  ILE A 236     1383   1275    901    183     76     12       C  
+ATOM   1651  CG1 ILE A 236      21.505  11.634  31.388  1.00  9.30           C  
+ANISOU 1651  CG1 ILE A 236     1378   1372    782    189     79    -53       C  
+ATOM   1652  CG2 ILE A 236      19.304  11.235  32.579  1.00 10.96           C  
+ANISOU 1652  CG2 ILE A 236     1595   1387   1182     35    120    -47       C  
+ATOM   1653  CD1 ILE A 236      21.936  10.189  31.109  1.00 10.82           C  
+ANISOU 1653  CD1 ILE A 236     1607   1299   1205    293    132    -58       C  
+ATOM   1654  N   LYS A 237      19.988  13.128  35.426  1.00 11.14           N  
+ANISOU 1654  N   LYS A 237     1520   1625   1087    190    224    -70       N  
+ATOM   1655  CA  LYS A 237      19.087  13.273  36.573  1.00 12.32           C  
+ANISOU 1655  CA  LYS A 237     1763   1785   1132    103    273      7       C  
+ATOM   1656  C   LYS A 237      18.697  14.711  36.823  1.00 11.86           C  
+ANISOU 1656  C   LYS A 237     1682   1750   1074    103    358   -119       C  
+ATOM   1657  O   LYS A 237      17.509  15.023  37.044  1.00 11.95           O  
+ANISOU 1657  O   LYS A 237     1612   1846   1083    263    410     13       O  
+ATOM   1658  CB  LYS A 237      19.749  12.684  37.804  1.00 13.28           C  
+ANISOU 1658  CB  LYS A 237     1954   1905   1183    118    393     85       C  
+ATOM   1659  CG  LYS A 237      19.544  11.203  37.839  1.00 17.92           C  
+ANISOU 1659  CG  LYS A 237     2277   2318   2214     40    263    103       C  
+ATOM   1660  CD  LYS A 237      20.318  10.586  38.967  1.00 21.89           C  
+ANISOU 1660  CD  LYS A 237     2858   2867   2592     46      0     51       C  
+ATOM   1661  CE  LYS A 237      20.101   9.096  39.066  1.00 24.07           C  
+ANISOU 1661  CE  LYS A 237     3216   2999   2930    -11     69    -42       C  
+ATOM   1662  NZ  LYS A 237      21.084   8.532  40.038  1.00 27.26           N  
+ANISOU 1662  NZ  LYS A 237     3696   3418   3240    154     32    106       N  
+ATOM   1663  N   GLN A 238      19.671  15.602  36.752  1.00 12.15           N  
+ANISOU 1663  N   GLN A 238     1719   1736   1160     66    310    -97       N  
+ATOM   1664  C   GLN A 238      18.541  17.640  35.938  1.00 12.82           C  
+ANISOU 1664  C   GLN A 238     1803   1703   1362     99    217   -179       C  
+ATOM   1665  O   GLN A 238      17.641  18.411  36.204  1.00 12.75           O  
+ANISOU 1665  O   GLN A 238     1934   1755   1153    238    260   -357       O  
+ATOM   1666  CA AGLN A 238      19.386  17.001  37.028  0.50 12.89           C  
+ANISOU 1666  CA AGLN A 238     1831   1727   1337     94    222   -175       C  
+ATOM   1667  CB AGLN A 238      20.662  17.808  37.253  0.50 14.13           C  
+ANISOU 1667  CB AGLN A 238     1899   1910   1560     33    160    -70       C  
+ATOM   1668  CG AGLN A 238      20.377  19.220  37.732  0.50 15.74           C  
+ANISOU 1668  CG AGLN A 238     2096   2078   1805     97     38   -102       C  
+ATOM   1669  CD AGLN A 238      19.452  19.233  38.941  0.50 18.89           C  
+ANISOU 1669  CD AGLN A 238     2487   2591   2098    131     24    -84       C  
+ATOM   1670  OE1AGLN A 238      19.738  18.605  39.954  0.50 21.27           O  
+ANISOU 1670  OE1AGLN A 238     2876   2831   2373    165   -182     61       O  
+ATOM   1671  NE2AGLN A 238      18.329  19.921  38.823  0.50 17.97           N  
+ANISOU 1671  NE2AGLN A 238     2385   2539   1901    207    -90   -345       N  
+ATOM   1672  CA BGLN A 238      19.446  17.032  36.999  0.50 13.57           C  
+ANISOU 1672  CA BGLN A 238     1895   1795   1466     87    218   -162       C  
+ATOM   1673  CB BGLN A 238      20.777  17.801  37.019  0.50 14.56           C  
+ANISOU 1673  CB BGLN A 238     1942   1903   1685     27    185   -107       C  
+ATOM   1674  CG BGLN A 238      21.680  17.493  38.216  0.50 16.25           C  
+ANISOU 1674  CG BGLN A 238     2064   2115   1994     15    125    -73       C  
+ATOM   1675  CD BGLN A 238      22.899  18.384  38.304  0.50 17.32           C  
+ANISOU 1675  CD BGLN A 238     2208   2249   2122     33     59    -73       C  
+ATOM   1676  OE1BGLN A 238      22.817  19.584  38.059  0.50 22.63           O  
+ANISOU 1676  OE1BGLN A 238     3172   2519   2906     16     93     28       O  
+ATOM   1677  NE2BGLN A 238      24.042  17.801  38.642  0.50 20.14           N  
+ANISOU 1677  NE2BGLN A 238     2523   2805   2321    211    -87    -82       N  
+ATOM   1678  N   THR A 239      18.835  17.337  34.699  1.00 13.09           N  
+ANISOU 1678  N   THR A 239     1853   1590   1529    161    281   -385       N  
+ATOM   1679  CA  THR A 239      18.026  17.773  33.554  1.00 11.36           C  
+ANISOU 1679  CA  THR A 239     1805   1421   1090    163    289   -346       C  
+ATOM   1680  C   THR A 239      16.576  17.322  33.624  1.00 11.31           C  
+ANISOU 1680  C   THR A 239     1885   1528    884    163    130   -297       C  
+ATOM   1681  O   THR A 239      15.663  18.119  33.451  1.00 13.10           O  
+ANISOU 1681  O   THR A 239     2007   1644   1326    227    200   -252       O  
+ATOM   1682  CB  THR A 239      18.696  17.380  32.225  1.00 12.01           C  
+ANISOU 1682  CB  THR A 239     1922   1650    990    203    372   -275       C  
+ATOM   1683  OG1 THR A 239      20.032  17.920  32.211  1.00 13.24           O  
+ANISOU 1683  OG1 THR A 239     2057   1769   1203    157    372   -169       O  
+ATOM   1684  CG2 THR A 239      17.905  17.962  31.059  1.00 12.52           C  
+ANISOU 1684  CG2 THR A 239     2109   1497   1150    345    318    -52       C  
+ATOM   1685  N   ILE A 240      16.349  16.049  33.929  1.00 11.29           N  
+ANISOU 1685  N   ILE A 240     1854   1367   1068    228    173   -303       N  
+ATOM   1686  CA  ILE A 240      15.005  15.540  34.105  1.00 12.82           C  
+ANISOU 1686  CA  ILE A 240     1713   1801   1354    259    168   -245       C  
+ATOM   1687  C   ILE A 240      14.308  16.229  35.275  1.00 12.48           C  
+ANISOU 1687  C   ILE A 240     1683   1831   1225    308    232   -216       C  
+ATOM   1688  O   ILE A 240      13.120  16.537  35.188  1.00 15.15           O  
+ANISOU 1688  O   ILE A 240     1980   2424   1352    495    243   -234       O  
+ATOM   1689  CB  ILE A 240      14.993  14.004  34.328  1.00 13.10           C  
+ANISOU 1689  CB  ILE A 240     1666   1791   1518    148    210   -230       C  
+ATOM   1690  CG1 ILE A 240      15.384  13.278  33.037  1.00 13.86           C  
+ANISOU 1690  CG1 ILE A 240     1608   1902   1754    176     14   -226       C  
+ATOM   1691  CG2 ILE A 240      13.629  13.513  34.840  1.00 15.90           C  
+ANISOU 1691  CG2 ILE A 240     1875   2329   1835     83    141   -120       C  
+ATOM   1692  CD1 ILE A 240      15.690  11.802  33.289  1.00 14.80           C  
+ANISOU 1692  CD1 ILE A 240     1750   1830   2043    207     40    -99       C  
+ATOM   1693  N   ALA A 241      15.026  16.441  36.373  1.00 13.02           N  
+ANISOU 1693  N   ALA A 241     1726   1983   1236    303    249   -213       N  
+ATOM   1694  CA  ALA A 241      14.424  17.076  37.559  1.00 13.89           C  
+ANISOU 1694  CA  ALA A 241     1894   2051   1333    262    372   -222       C  
+ATOM   1695  C   ALA A 241      14.022  18.521  37.266  1.00 14.86           C  
+ANISOU 1695  C   ALA A 241     2040   2098   1505    285    298   -252       C  
+ATOM   1696  O   ALA A 241      13.054  19.052  37.852  1.00 16.83           O  
+ANISOU 1696  O   ALA A 241     2274   2179   1940    427    614   -470       O  
+ATOM   1697  CB  ALA A 241      15.409  17.028  38.706  1.00 15.14           C  
+ANISOU 1697  CB  ALA A 241     2087   2231   1434    201    239   -218       C  
+ATOM   1698  N   SER A 242      14.736  19.190  36.377  1.00 14.57           N  
+ANISOU 1698  N   SER A 242     2129   1950   1454    266    244   -265       N  
+ATOM   1699  C   SER A 242      13.804  21.020  34.929  1.00 14.53           C  
+ANISOU 1699  C   SER A 242     2191   1807   1523    175    127   -208       C  
+ATOM   1700  O   SER A 242      13.685  22.193  34.645  1.00 15.61           O  
+ANISOU 1700  O   SER A 242     2578   1762   1590    235    -11   -110       O  
+ATOM   1701  CA ASER A 242      14.577  20.626  36.176  0.50 14.32           C  
+ANISOU 1701  CA ASER A 242     2093   1864   1481    171    173   -196       C  
+ATOM   1702  CB ASER A 242      15.943  21.320  36.197  0.50 14.71           C  
+ANISOU 1702  CB ASER A 242     2180   1845   1562    151    114   -201       C  
+ATOM   1703  OG ASER A 242      16.791  20.843  35.169  0.50 15.20           O  
+ANISOU 1703  OG ASER A 242     2040   1979   1756     23    122   -298       O  
+ATOM   1704  CA BSER A 242      14.570  20.621  36.177  0.50 14.60           C  
+ANISOU 1704  CA BSER A 242     2145   1893   1510    183    158   -185       C  
+ATOM   1705  CB BSER A 242      15.938  21.289  36.199  0.50 15.13           C  
+ANISOU 1705  CB BSER A 242     2241   1888   1620    158    109   -194       C  
+ATOM   1706  OG BSER A 242      16.638  20.889  37.364  0.50 17.23           O  
+ANISOU 1706  OG BSER A 242     2449   2192   1904    147    -28   -175       O  
+ATOM   1707  N   ASN A 243      13.245  20.054  34.199  1.00 13.88           N  
+ANISOU 1707  N   ASN A 243     2098   1734   1440    279    142   -289       N  
+ATOM   1708  CA  ASN A 243      12.552  20.340  32.965  1.00 13.60           C  
+ANISOU 1708  CA  ASN A 243     2110   1636   1420    262    158   -265       C  
+ATOM   1709  C   ASN A 243      11.319  19.499  32.823  1.00 14.79           C  
+ANISOU 1709  C   ASN A 243     2208   1754   1657    269    181   -174       C  
+ATOM   1710  O   ASN A 243      11.011  18.637  33.629  1.00 17.26           O  
+ANISOU 1710  O   ASN A 243     2508   2171   1877     87     97     37       O  
+ATOM   1711  CB  ASN A 243      13.468  20.099  31.758  1.00 12.60           C  
+ANISOU 1711  CB  ASN A 243     1956   1579   1251    305    164   -314       C  
+ATOM   1712  CG  ASN A 243      14.657  21.053  31.689  1.00 13.48           C  
+ANISOU 1712  CG  ASN A 243     2336   1495   1289    243    195   -123       C  
+ATOM   1713  OD1 ASN A 243      14.537  22.185  31.192  1.00 19.45           O  
+ANISOU 1713  OD1 ASN A 243     3342   1735   2311    225    227     64       O  
+ATOM   1714  ND2 ASN A 243      15.795  20.627  32.198  1.00 15.45           N  
+ANISOU 1714  ND2 ASN A 243     2368   1795   1704    315    296   -334       N  
+ATOM   1715  OXT ASN A 243      10.572  19.638  31.844  1.00 16.48           O  
+ANISOU 1715  OXT ASN A 243     2389   2058   1813    329     74   -253       O  
+TER    1716      ASN A 243                                                      
+ATOM   1717  N   CYS B  24      18.343  13.841 -11.143  1.00 26.78           N  
+ANISOU 1717  N   CYS B  24     3072   3588   3512   -175    152   -252       N  
+ATOM   1718  CA  CYS B  24      19.655  14.557 -11.192  1.00 26.29           C  
+ANISOU 1718  CA  CYS B  24     3045   3512   3430   -121     81   -203       C  
+ATOM   1719  C   CYS B  24      20.806  13.555 -11.246  1.00 26.73           C  
+ANISOU 1719  C   CYS B  24     3172   3450   3533   -115     48   -127       C  
+ATOM   1720  O   CYS B  24      21.033  12.829 -10.276  1.00 28.20           O  
+ANISOU 1720  O   CYS B  24     3417   3650   3648   -118     57    -82       O  
+ATOM   1721  CB  CYS B  24      19.804  15.459  -9.958  1.00 25.80           C  
+ANISOU 1721  CB  CYS B  24     2929   3439   3434   -159     81   -216       C  
+ATOM   1722  SG  CYS B  24      21.312  16.450  -9.911  1.00 25.04           S  
+ANISOU 1722  SG  CYS B  24     2621   3644   3246   -257    381   -528       S  
+ATOM   1723  N   THR B  25      21.544  13.522 -12.362  1.00 26.14           N  
+ANISOU 1723  N   THR B  25     3096   3336   3498    -46     50   -130       N  
+ATOM   1724  CA  THR B  25      22.714  12.624 -12.466  1.00 25.42           C  
+ANISOU 1724  CA  THR B  25     2911   3287   3457    -59      9   -112       C  
+ATOM   1725  C   THR B  25      24.022  13.410 -12.250  1.00 22.87           C  
+ANISOU 1725  C   THR B  25     2575   2926   3187    -22     13   -101       C  
+ATOM   1726  O   THR B  25      24.268  14.436 -12.860  1.00 23.41           O  
+ANISOU 1726  O   THR B  25     2388   3157   3348    -50    -52    -66       O  
+ATOM   1727  CB  THR B  25      22.763  11.742 -13.772  1.00 26.41           C  
+ANISOU 1727  CB  THR B  25     3092   3412   3530    -16      3   -115       C  
+ATOM   1728  OG1 THR B  25      23.945  12.012 -14.548  1.00 29.23           O  
+ANISOU 1728  OG1 THR B  25     3563   3708   3833   -152    101    -41       O  
+ATOM   1729  CG2 THR B  25      21.510  11.900 -14.645  1.00 27.41           C  
+ANISOU 1729  CG2 THR B  25     3194   3599   3618    -30    -76    -80       C  
+ATOM   1730  N   VAL B  26      24.804  12.925 -11.304  1.00 19.54           N  
+ANISOU 1730  N   VAL B  26     2086   2426   2912    -32    110   -179       N  
+ATOM   1731  CA  VAL B  26      26.097  13.501 -10.990  1.00 16.96           C  
+ANISOU 1731  CA  VAL B  26     1747   2118   2577     15    137   -192       C  
+ATOM   1732  C   VAL B  26      27.179  12.705 -11.745  1.00 15.54           C  
+ANISOU 1732  C   VAL B  26     1608   1867   2428    126    149    -74       C  
+ATOM   1733  O   VAL B  26      27.248  11.485 -11.600  1.00 15.05           O  
+ANISOU 1733  O   VAL B  26     1456   1705   2556     10    202   -164       O  
+ATOM   1734  CB  VAL B  26      26.331  13.431  -9.482  1.00 17.48           C  
+ANISOU 1734  CB  VAL B  26     1807   2215   2620     43    243    -87       C  
+ATOM   1735  CG1 VAL B  26      27.616  14.093  -9.131  1.00 17.27           C  
+ANISOU 1735  CG1 VAL B  26     1889   2244   2428   -157    176    -88       C  
+ATOM   1736  CG2 VAL B  26      25.166  14.123  -8.728  1.00 19.25           C  
+ANISOU 1736  CG2 VAL B  26     2006   2495   2813    152    369   -225       C  
+ATOM   1737  N   PRO B  27      28.040  13.376 -12.537  1.00 13.77           N  
+ANISOU 1737  N   PRO B  27     1522   1529   2179     88     69      5       N  
+ATOM   1738  CA  PRO B  27      29.017  12.552 -13.294  1.00 14.13           C  
+ANISOU 1738  CA  PRO B  27     1590   1733   2043     56     77      6       C  
+ATOM   1739  C   PRO B  27      30.089  11.952 -12.391  1.00 12.06           C  
+ANISOU 1739  C   PRO B  27     1266   1479   1835     45    138     -2       C  
+ATOM   1740  O   PRO B  27      30.405  12.474 -11.340  1.00 11.00           O  
+ANISOU 1740  O   PRO B  27     1144   1192   1844    -13    219    -35       O  
+ATOM   1741  CB  PRO B  27      29.621  13.517 -14.306  1.00 15.02           C  
+ANISOU 1741  CB  PRO B  27     1706   1805   2194    174     12     75       C  
+ATOM   1742  CG  PRO B  27      29.463  14.793 -13.681  1.00 15.70           C  
+ANISOU 1742  CG  PRO B  27     2144   1735   2085   -179     87      1       C  
+ATOM   1743  CD  PRO B  27      28.188  14.795 -12.865  1.00 15.01           C  
+ANISOU 1743  CD  PRO B  27     1736   1706   2258    164     26     90       C  
+ATOM   1744  N   ILE B  28      30.643  10.834 -12.822  1.00 11.03           N  
+ANISOU 1744  N   ILE B  28     1208   1307   1676    -49    150    -53       N  
+ATOM   1745  CA  ILE B  28      31.740  10.219 -12.146  1.00 10.96           C  
+ANISOU 1745  CA  ILE B  28     1209   1274   1679    -58    150    -61       C  
+ATOM   1746  C   ILE B  28      32.852  11.269 -12.065  1.00  9.55           C  
+ANISOU 1746  C   ILE B  28     1002   1155   1471    -32    204     27       C  
+ATOM   1747  O   ILE B  28      33.168  11.947 -13.046  1.00 10.07           O  
+ANISOU 1747  O   ILE B  28     1215   1216   1393    111    180    -12       O  
+ATOM   1748  CB  ILE B  28      32.200   8.946 -12.904  1.00 10.88           C  
+ANISOU 1748  CB  ILE B  28     1240   1270   1621    -98    173    -91       C  
+ATOM   1749  CG1 ILE B  28      31.110   7.890 -12.828  1.00 12.11           C  
+ANISOU 1749  CG1 ILE B  28     1493   1321   1786   -128    190    -53       C  
+ATOM   1750  CG2 ILE B  28      33.480   8.420 -12.329  1.00 13.22           C  
+ANISOU 1750  CG2 ILE B  28     1491   1499   2032    136    244   -157       C  
+ATOM   1751  CD1 ILE B  28      31.365   6.722 -13.763  1.00 15.00           C  
+ANISOU 1751  CD1 ILE B  28     2097   1639   1962   -305    101   -136       C  
+ATOM   1752  N   GLY B  29      33.459  11.355 -10.895  1.00  9.76           N  
+ANISOU 1752  N   GLY B  29     1157   1096   1452    -58    234    111       N  
+ATOM   1753  CA  GLY B  29      34.546  12.275 -10.656  1.00  9.05           C  
+ANISOU 1753  CA  GLY B  29     1048    981   1410     -1    217     16       C  
+ATOM   1754  C   GLY B  29      34.138  13.583 -10.036  1.00  8.85           C  
+ANISOU 1754  C   GLY B  29     1052    988   1320     16    241     65       C  
+ATOM   1755  O   GLY B  29      35.009  14.287  -9.554  1.00  8.56           O  
+ANISOU 1755  O   GLY B  29     1045    900   1304     12    230    -19       O  
+ATOM   1756  N   TRP B  30      32.856  13.909 -10.051  1.00  9.05           N  
+ANISOU 1756  N   TRP B  30     1023   1061   1353    -72    274     46       N  
+ATOM   1757  CA  TRP B  30      32.374  15.158  -9.462  1.00  9.69           C  
+ANISOU 1757  CA  TRP B  30     1215   1104   1362     21    297     95       C  
+ATOM   1758  C   TRP B  30      32.593  15.172  -7.974  1.00  9.54           C  
+ANISOU 1758  C   TRP B  30     1302   1078   1243     45    316    162       C  
+ATOM   1759  O   TRP B  30      32.466  14.118  -7.332  1.00 11.90           O  
+ANISOU 1759  O   TRP B  30     2030   1044   1446     53    520    323       O  
+ATOM   1760  CB  TRP B  30      30.887  15.312  -9.759  1.00  9.95           C  
+ANISOU 1760  CB  TRP B  30     1238   1065   1476    -47    195      6       C  
+ATOM   1761  CG  TRP B  30      30.349  16.710  -9.597  1.00  9.26           C  
+ANISOU 1761  CG  TRP B  30     1180    960   1377     77    265     54       C  
+ATOM   1762  CD1 TRP B  30      29.708  17.251  -8.508  1.00  9.74           C  
+ANISOU 1762  CD1 TRP B  30     1135   1111   1452    -24    192     85       C  
+ATOM   1763  CD2 TRP B  30      30.365  17.736 -10.598  1.00  8.58           C  
+ANISOU 1763  CD2 TRP B  30     1026    976   1255     -1    281     91       C  
+ATOM   1764  NE1 TRP B  30      29.344  18.538  -8.790  1.00  9.48           N  
+ANISOU 1764  NE1 TRP B  30      995   1181   1423    234    234     21       N  
+ATOM   1765  CE2 TRP B  30      29.732  18.850 -10.064  1.00  7.57           C  
+ANISOU 1765  CE2 TRP B  30      839    895   1140    -15    140     58       C  
+ATOM   1766  CE3 TRP B  30      30.885  17.811 -11.901  1.00  8.89           C  
+ANISOU 1766  CE3 TRP B  30      951   1159   1265   -133     63    -23       C  
+ATOM   1767  CZ2 TRP B  30      29.610  20.037 -10.765  1.00  8.95           C  
+ANISOU 1767  CZ2 TRP B  30      896   1089   1414     38     65    -71       C  
+ATOM   1768  CZ3 TRP B  30      30.729  18.982 -12.604  1.00  9.98           C  
+ANISOU 1768  CZ3 TRP B  30     1083   1337   1370   -131    108     58       C  
+ATOM   1769  CH2 TRP B  30      30.110  20.085 -12.032  1.00  9.20           C  
+ANISOU 1769  CH2 TRP B  30      996   1094   1404    -87     81    183       C  
+ATOM   1770  N   SER B  31      32.883  16.326  -7.408  1.00  8.89           N  
+ANISOU 1770  N   SER B  31     1123   1114   1141     30    274    170       N  
+ATOM   1771  C   SER B  31      31.705  16.585  -5.318  1.00 11.70           C  
+ANISOU 1771  C   SER B  31     1579   1515   1349    168    190     84       C  
+ATOM   1772  O   SER B  31      30.984  17.544  -5.534  1.00 14.24           O  
+ANISOU 1772  O   SER B  31     1662   2004   1745    356    178    144       O  
+ATOM   1773  CA ASER B  31      33.065  16.503  -5.977  0.50 10.13           C  
+ANISOU 1773  CA ASER B  31     1326   1338   1184    131    159    117       C  
+ATOM   1774  CB ASER B  31      33.804  17.808  -5.693  0.50 10.36           C  
+ANISOU 1774  CB ASER B  31     1396   1421   1118    110     96     97       C  
+ATOM   1775  OG ASER B  31      34.032  17.953  -4.303  0.50 10.92           O  
+ANISOU 1775  OG ASER B  31     1572   1507   1070    148    206     36       O  
+ATOM   1776  CA BSER B  31      33.064  16.416  -5.985  0.50 10.76           C  
+ANISOU 1776  CA BSER B  31     1395   1390   1300    122    163    103       C  
+ATOM   1777  CB BSER B  31      34.047  17.516  -5.633  0.50 11.66           C  
+ANISOU 1777  CB BSER B  31     1562   1535   1331     78    117     81       C  
+ATOM   1778  OG BSER B  31      35.365  17.031  -5.860  0.50 13.97           O  
+ANISOU 1778  OG BSER B  31     1910   1609   1788     72    202      7       O  
+ATOM   1779  N   GLU B  32      31.368  15.587  -4.545  1.00 12.18           N  
+ANISOU 1779  N   GLU B  32     1580   1536   1511     58    280     67       N  
+ATOM   1780  CA  GLU B  32      30.098  15.543  -3.825  1.00 12.24           C  
+ANISOU 1780  CA  GLU B  32     1529   1639   1479    100    277    171       C  
+ATOM   1781  C   GLU B  32      30.314  16.023  -2.399  1.00 11.96           C  
+ANISOU 1781  C   GLU B  32     1500   1526   1515     66    224    243       C  
+ATOM   1782  O   GLU B  32      31.436  16.237  -1.953  1.00 11.05           O  
+ANISOU 1782  O   GLU B  32     1472   1557   1167    186    230    419       O  
+ATOM   1783  CB  GLU B  32      29.536  14.134  -3.887  1.00 13.09           C  
+ANISOU 1783  CB  GLU B  32     1695   1730   1549    150    236     81       C  
+ATOM   1784  CG  GLU B  32      29.189  13.781  -5.307  1.00 14.92           C  
+ANISOU 1784  CG  GLU B  32     2102   1830   1735     42    254     47       C  
+ATOM   1785  CD  GLU B  32      28.580  12.407  -5.418  1.00 18.12           C  
+ANISOU 1785  CD  GLU B  32     2229   1979   2674   -110    233   -166       C  
+ATOM   1786  OE1 GLU B  32      29.296  11.474  -5.835  1.00 22.61           O  
+ANISOU 1786  OE1 GLU B  32     2665   2412   3514     87    392   -297       O  
+ATOM   1787  OE2 GLU B  32      27.405  12.237  -5.079  1.00 20.41           O  
+ANISOU 1787  OE2 GLU B  32     2469   2337   2948   -133    272   -292       O  
+ATOM   1788  N   PRO B  33      29.230  16.211  -1.653  1.00 11.47           N  
+ANISOU 1788  N   PRO B  33     1383   1648   1327    129    193    273       N  
+ATOM   1789  CA  PRO B  33      29.407  16.710  -0.346  1.00 13.29           C  
+ANISOU 1789  CA  PRO B  33     1467   1956   1625    171    207     68       C  
+ATOM   1790  C   PRO B  33      30.254  15.807   0.554  1.00 11.14           C  
+ANISOU 1790  C   PRO B  33     1326   1521   1385    112    197    140       C  
+ATOM   1791  O   PRO B  33      30.211  14.588   0.426  1.00 10.53           O  
+ANISOU 1791  O   PRO B  33     1414   1365   1222     93     84    201       O  
+ATOM   1792  CB  PRO B  33      27.962  16.730   0.247  1.00 14.90           C  
+ANISOU 1792  CB  PRO B  33     1502   2282   1875    193    330    253       C  
+ATOM   1793  CG  PRO B  33      27.137  16.877  -0.959  1.00 13.41           C  
+ANISOU 1793  CG  PRO B  33     1548   2013   1532    116    207     65       C  
+ATOM   1794  CD  PRO B  33      27.802  16.041  -1.960  1.00 12.26           C  
+ANISOU 1794  CD  PRO B  33     1458   1843   1355     47    150    165       C  
+ATOM   1795  N   VAL B  34      31.043  16.386   1.429  1.00 11.62           N  
+ANISOU 1795  N   VAL B  34     1579   1395   1439    182    188      3       N  
+ATOM   1796  CA  VAL B  34      31.845  15.621   2.363  1.00 11.40           C  
+ANISOU 1796  CA  VAL B  34     1502   1465   1362     59    175     64       C  
+ATOM   1797  C   VAL B  34      30.895  14.909   3.319  1.00 10.21           C  
+ANISOU 1797  C   VAL B  34     1323   1351   1205    129    130    127       C  
+ATOM   1798  O   VAL B  34      29.981  15.525   3.897  1.00 11.44           O  
+ANISOU 1798  O   VAL B  34     1406   1594   1345    151    282     96       O  
+ATOM   1799  CB  VAL B  34      32.837  16.509   3.130  1.00 12.39           C  
+ANISOU 1799  CB  VAL B  34     1717   1349   1641     53    132      2       C  
+ATOM   1800  CG1 VAL B  34      33.486  15.746   4.289  1.00 12.29           C  
+ANISOU 1800  CG1 VAL B  34     1698   1356   1615    -43     94     82       C  
+ATOM   1801  CG2 VAL B  34      33.925  17.031   2.197  1.00 14.30           C  
+ANISOU 1801  CG2 VAL B  34     1866   1856   1708   -253    297    -72       C  
+ATOM   1802  N   LYS B  35      31.071  13.603   3.452  1.00 10.35           N  
+ANISOU 1802  N   LYS B  35     1314   1432   1186     95    142    171       N  
+ATOM   1803  CA  LYS B  35      30.276  12.832   4.405  1.00 11.38           C  
+ANISOU 1803  CA  LYS B  35     1393   1569   1362    119    146    242       C  
+ATOM   1804  C   LYS B  35      30.675  13.173   5.832  1.00 10.62           C  
+ANISOU 1804  C   LYS B  35     1262   1494   1278    215     53    202       C  
+ATOM   1805  O   LYS B  35      31.849  13.159   6.201  1.00 11.97           O  
+ANISOU 1805  O   LYS B  35     1247   1876   1424    151     96    184       O  
+ATOM   1806  CB  LYS B  35      30.492  11.353   4.178  1.00 11.93           C  
+ANISOU 1806  CB  LYS B  35     1451   1549   1531     65    165    320       C  
+ATOM   1807  CG  LYS B  35      29.915  10.893   2.879  1.00 13.53           C  
+ANISOU 1807  CG  LYS B  35     1678   1647   1813    -30     57    146       C  
+ATOM   1808  CD  LYS B  35      30.301   9.466   2.474  1.00 15.98           C  
+ANISOU 1808  CD  LYS B  35     2053   1980   2037     -2     94     32       C  
+ATOM   1809  CE  LYS B  35      29.696   9.096   1.114  1.00 19.83           C  
+ANISOU 1809  CE  LYS B  35     2610   2390   2531     52    -31   -236       C  
+ATOM   1810  NZ  LYS B  35      29.733   7.634   0.833  1.00 25.63           N  
+ANISOU 1810  NZ  LYS B  35     3492   2765   3481     88    -50   -154       N  
+ATOM   1811  N   GLY B  36      29.699  13.473   6.665  1.00 10.91           N  
+ANISOU 1811  N   GLY B  36     1278   1573   1293    176     46    209       N  
+ATOM   1812  CA  GLY B  36      29.959  13.688   8.067  1.00 10.99           C  
+ANISOU 1812  CA  GLY B  36     1369   1558   1247    117    -10    112       C  
+ATOM   1813  C   GLY B  36      30.282  12.393   8.764  1.00  9.02           C  
+ANISOU 1813  C   GLY B  36     1076   1323   1026    127     22    104       C  
+ATOM   1814  O   GLY B  36      29.820  11.286   8.340  1.00 10.95           O  
+ANISOU 1814  O   GLY B  36     1364   1596   1198    191    -40    140       O  
+ATOM   1815  N   LEU B  37      31.067  12.476   9.844  1.00  9.62           N  
+ANISOU 1815  N   LEU B  37     1150   1262   1241    -54    100    317       N  
+ATOM   1816  CA  LEU B  37      31.414  11.312  10.673  1.00  8.23           C  
+ANISOU 1816  CA  LEU B  37     1042    997   1085     56    -37    354       C  
+ATOM   1817  C   LEU B  37      30.294  10.894  11.562  1.00  7.29           C  
+ANISOU 1817  C   LEU B  37      918    911    940     48    -41    199       C  
+ATOM   1818  O   LEU B  37      30.276   9.731  11.953  1.00  6.81           O  
+ANISOU 1818  O   LEU B  37      985    858    742    104      4    141       O  
+ATOM   1819  CB  LEU B  37      32.680  11.575  11.527  1.00  9.75           C  
+ANISOU 1819  CB  LEU B  37     1047   1386   1269    -73    -38    358       C  
+ATOM   1820  CG  LEU B  37      33.926  12.066  10.820  1.00 12.72           C  
+ANISOU 1820  CG  LEU B  37     1267   1724   1841    -99      6    271       C  
+ATOM   1821  CD1 LEU B  37      35.014  12.247  11.849  1.00 16.77           C  
+ANISOU 1821  CD1 LEU B  37     1708   2450   2210   -274    -36    249       C  
+ATOM   1822  CD2 LEU B  37      34.246  11.099   9.711  1.00 16.41           C  
+ANISOU 1822  CD2 LEU B  37     1866   1903   2465   -129    394    156       C  
+ATOM   1823  N   CYS B  38      29.392  11.794  11.939  1.00  6.33           N  
+ANISOU 1823  N   CYS B  38      885    565    955    -45    -38    255       N  
+ATOM   1824  CA  CYS B  38      28.274  11.405  12.774  1.00  6.42           C  
+ANISOU 1824  CA  CYS B  38      804    768    865    -18    -36    175       C  
+ATOM   1825  C   CYS B  38      27.385  10.409  12.045  1.00  5.95           C  
+ANISOU 1825  C   CYS B  38      686    817    757     81    -73    128       C  
+ATOM   1826  O   CYS B  38      27.425  10.305  10.829  1.00  6.52           O  
+ANISOU 1826  O   CYS B  38     1043    734    698    -34   -141    127       O  
+ATOM   1827  CB  CYS B  38      27.465  12.632  13.246  1.00  6.72           C  
+ANISOU 1827  CB  CYS B  38      835    658   1060     47   -108    143       C  
+ATOM   1828  SG  CYS B  38      26.127  13.256  12.174  1.00  9.45           S  
+ANISOU 1828  SG  CYS B  38     1155   1145   1289     64     11    234       S  
+ATOM   1829  N   LYS B  39      26.554   9.720  12.815  1.00  6.56           N  
+ANISOU 1829  N   LYS B  39      851    763    877    -58    -16    141       N  
+ATOM   1830  CA  LYS B  39      25.711   8.662  12.275  1.00  5.93           C  
+ANISOU 1830  CA  LYS B  39      804    602    845     13      3     92       C  
+ATOM   1831  C   LYS B  39      24.217   8.997  12.213  1.00  6.32           C  
+ANISOU 1831  C   LYS B  39      798    858    744    123    -35     90       C  
+ATOM   1832  O   LYS B  39      23.363   8.107  12.240  1.00  6.13           O  
+ANISOU 1832  O   LYS B  39      789    677    861     34   -145     75       O  
+ATOM   1833  CB  LYS B  39      26.022   7.326  12.936  1.00  6.17           C  
+ANISOU 1833  CB  LYS B  39      796    737    808    -43     23     58       C  
+ATOM   1834  CG  LYS B  39      27.397   6.811  12.532  1.00  6.11           C  
+ANISOU 1834  CG  LYS B  39      735    734    852     26    -14     66       C  
+ATOM   1835  CD  LYS B  39      27.810   5.588  13.267  1.00  6.21           C  
+ANISOU 1835  CD  LYS B  39      804    758    795     53    -29    185       C  
+ATOM   1836  CE  LYS B  39      29.180   5.149  12.831  1.00  5.87           C  
+ANISOU 1836  CE  LYS B  39      823    571    836     39    -38     94       C  
+ATOM   1837  NZ  LYS B  39      29.677   3.982  13.644  1.00  6.21           N  
+ANISOU 1837  NZ  LYS B  39      801    634    924    104     17    222       N  
+ATOM   1838  N   ALA B  40      23.896  10.275  11.995  1.00  6.23           N  
+ANISOU 1838  N   ALA B  40      756    611    999    -45    -36    175       N  
+ATOM   1839  CA  ALA B  40      22.519  10.674  11.672  1.00  6.62           C  
+ANISOU 1839  CA  ALA B  40      706    907    901      9    -35    130       C  
+ATOM   1840  C   ALA B  40      22.236  10.338  10.220  1.00  6.79           C  
+ANISOU 1840  C   ALA B  40      834    779    965     77     33    185       C  
+ATOM   1841  O   ALA B  40      23.148  10.218   9.402  1.00  7.49           O  
+ANISOU 1841  O   ALA B  40      848   1013    985    131     16    205       O  
+ATOM   1842  CB  ALA B  40      22.327  12.175  11.893  1.00  7.75           C  
+ANISOU 1842  CB  ALA B  40     1094    732   1117     79    -36    -63       C  
+ATOM   1843  N   ARG B  41      20.948  10.200   9.890  1.00  6.49           N  
+ANISOU 1843  N   ARG B  41      793    924    746    131    -20    211       N  
+ATOM   1844  CA  ARG B  41      20.502  10.164   8.493  1.00  7.08           C  
+ANISOU 1844  CA  ARG B  41      830    934    924     15     64    162       C  
+ATOM   1845  C   ARG B  41      19.549  11.316   8.247  1.00  6.85           C  
+ANISOU 1845  C   ARG B  41      757    994    851     72    -20    187       C  
+ATOM   1846  O   ARG B  41      18.335  11.146   8.228  1.00  7.74           O  
+ANISOU 1846  O   ARG B  41      813    966   1160    120    -43    297       O  
+ATOM   1847  CB  ARG B  41      19.876   8.802   8.156  1.00  7.48           C  
+ANISOU 1847  CB  ARG B  41     1022    990    829     33     -9    186       C  
+ATOM   1848  CG  ARG B  41      19.643   8.609   6.657  1.00  9.84           C  
+ANISOU 1848  CG  ARG B  41     1637    974   1125    -77   -165    162       C  
+ATOM   1849  CD  ARG B  41      18.418   9.200   6.066  1.00 15.46           C  
+ANISOU 1849  CD  ARG B  41     2037   2057   1777    -99   -179      3       C  
+ATOM   1850  NE  ARG B  41      17.195   8.644   6.659  1.00 16.16           N  
+ANISOU 1850  NE  ARG B  41     2212   2181   1745   -314     30     51       N  
+ATOM   1851  CZ  ARG B  41      16.519   7.578   6.201  1.00 16.83           C  
+ANISOU 1851  CZ  ARG B  41     2097   2139   2158     37   -125    -66       C  
+ATOM   1852  NH1 ARG B  41      16.912   6.890   5.134  1.00 21.00           N  
+ANISOU 1852  NH1 ARG B  41     2686   2904   2386     73     50   -114       N  
+ATOM   1853  NH2 ARG B  41      15.426   7.176   6.818  1.00 15.62           N  
+ANISOU 1853  NH2 ARG B  41     2479   1959   1495   -351    122   -182       N  
+ATOM   1854  N   PHE B  42      20.112  12.501   8.093  1.00  7.00           N  
+ANISOU 1854  N   PHE B  42      818    958    883    147     16     91       N  
+ATOM   1855  CA  PHE B  42      19.348  13.647   7.606  1.00  7.78           C  
+ANISOU 1855  CA  PHE B  42      973    982   1002    124    -54    119       C  
+ATOM   1856  C   PHE B  42      19.173  13.545   6.096  1.00  7.84           C  
+ANISOU 1856  C   PHE B  42      936   1014   1029     85     70    108       C  
+ATOM   1857  O   PHE B  42      20.000  12.961   5.413  1.00  9.80           O  
+ANISOU 1857  O   PHE B  42     1214   1464   1045    327    -87    102       O  
+ATOM   1858  CB  PHE B  42      20.075  14.937   7.928  1.00  7.98           C  
+ANISOU 1858  CB  PHE B  42     1045    999    988     23    -44    146       C  
+ATOM   1859  CG  PHE B  42      20.328  15.159   9.374  1.00  8.54           C  
+ANISOU 1859  CG  PHE B  42     1143   1033   1067     23    -49    182       C  
+ATOM   1860  CD1 PHE B  42      19.272  15.272  10.255  1.00  9.23           C  
+ANISOU 1860  CD1 PHE B  42     1243   1320    942   -220   -110    -40       C  
+ATOM   1861  CD2 PHE B  42      21.608  15.363   9.861  1.00  9.49           C  
+ANISOU 1861  CD2 PHE B  42     1314    943   1348     -3    -12    185       C  
+ATOM   1862  CE1 PHE B  42      19.499  15.505  11.596  1.00  9.74           C  
+ANISOU 1862  CE1 PHE B  42     1313   1310   1078   -187    -64     76       C  
+ATOM   1863  CE2 PHE B  42      21.839  15.591  11.204  1.00 11.22           C  
+ANISOU 1863  CE2 PHE B  42     1459   1249   1555    -59   -162     54       C  
+ATOM   1864  CZ  PHE B  42      20.771  15.669  12.067  1.00 10.53           C  
+ANISOU 1864  CZ  PHE B  42     1624   1357   1017    -64   -287     47       C  
+ATOM   1865  N   THR B  43      18.093  14.139   5.594  1.00  7.74           N  
+ANISOU 1865  N   THR B  43      993   1063    884    147     89    159       N  
+ATOM   1866  CA  THR B  43      17.853  14.263   4.163  1.00  8.22           C  
+ANISOU 1866  CA  THR B  43     1033   1222    866    144     92    123       C  
+ATOM   1867  C   THR B  43      18.147  15.700   3.764  1.00  7.81           C  
+ANISOU 1867  C   THR B  43     1025   1161    781    193      7    237       C  
+ATOM   1868  O   THR B  43      17.496  16.622   4.246  1.00  8.94           O  
+ANISOU 1868  O   THR B  43     1098   1191   1106    224     70    270       O  
+ATOM   1869  CB  THR B  43      16.398  13.899   3.813  1.00  9.65           C  
+ANISOU 1869  CB  THR B  43     1147   1437   1080    104    123     80       C  
+ATOM   1870  OG1 THR B  43      16.173  12.540   4.178  1.00 11.63           O  
+ANISOU 1870  OG1 THR B  43     1456   1492   1469    -90    193     29       O  
+ATOM   1871  CG2 THR B  43      16.129  14.098   2.325  1.00 11.59           C  
+ANISOU 1871  CG2 THR B  43     1420   1912   1071    111    -48    -59       C  
+ATOM   1872  N   ARG B  44      19.152  15.887   2.915  1.00  8.51           N  
+ANISOU 1872  N   ARG B  44     1042   1176   1015    161     56    306       N  
+ATOM   1873  CA  ARG B  44      19.534  17.233   2.454  1.00  8.68           C  
+ANISOU 1873  CA  ARG B  44     1186   1201    909    113     89    219       C  
+ATOM   1874  C   ARG B  44      19.589  17.254   0.949  1.00  9.19           C  
+ANISOU 1874  C   ARG B  44     1338   1247    904    187     71    192       C  
+ATOM   1875  O   ARG B  44      19.882  16.261   0.311  1.00 10.64           O  
+ANISOU 1875  O   ARG B  44     2109   1095    839    303    159    385       O  
+ATOM   1876  CB  ARG B  44      20.918  17.612   2.977  1.00  9.72           C  
+ANISOU 1876  CB  ARG B  44     1198   1494    999     61     38    291       C  
+ATOM   1877  CG  ARG B  44      21.104  17.456   4.450  1.00 12.29           C  
+ANISOU 1877  CG  ARG B  44     1575   1845   1247     61    -90    247       C  
+ATOM   1878  CD  ARG B  44      20.227  18.343   5.238  1.00 12.79           C  
+ANISOU 1878  CD  ARG B  44     1736   1711   1410    -64     13    105       C  
+ATOM   1879  NE  ARG B  44      20.556  19.741   5.023  1.00 12.28           N  
+ANISOU 1879  NE  ARG B  44     1917   1544   1202     23    117     96       N  
+ATOM   1880  CZ  ARG B  44      19.952  20.742   5.621  1.00 12.94           C  
+ANISOU 1880  CZ  ARG B  44     1678   1656   1582      0     -9     33       C  
+ATOM   1881  NH1 ARG B  44      18.943  20.508   6.430  1.00 14.30           N  
+ANISOU 1881  NH1 ARG B  44     1903   2001   1528     46    211    270       N  
+ATOM   1882  NH2 ARG B  44      20.346  21.988   5.383  1.00 14.69           N  
+ANISOU 1882  NH2 ARG B  44     2031   1856   1692    -65    233    275       N  
+ATOM   1883  N   TYR B  45      19.343  18.422   0.368  1.00  8.27           N  
+ANISOU 1883  N   TYR B  45     1278   1136    726    174     95    185       N  
+ATOM   1884  CA  TYR B  45      19.400  18.605  -1.072  1.00  8.73           C  
+ANISOU 1884  CA  TYR B  45     1189   1285    843    109     61    231       C  
+ATOM   1885  C   TYR B  45      20.553  19.532  -1.391  1.00  8.80           C  
+ANISOU 1885  C   TYR B  45     1212   1239    892     73     63    287       C  
+ATOM   1886  O   TYR B  45      20.635  20.617  -0.850  1.00  9.38           O  
+ANISOU 1886  O   TYR B  45     1294   1345    922    -12     73    244       O  
+ATOM   1887  CB  TYR B  45      18.063  19.180  -1.573  1.00  9.76           C  
+ANISOU 1887  CB  TYR B  45     1169   1452   1086     36    -34    295       C  
+ATOM   1888  CG  TYR B  45      16.893  18.280  -1.252  1.00 11.09           C  
+ANISOU 1888  CG  TYR B  45     1049   1688   1475    -31    -94    316       C  
+ATOM   1889  CD1 TYR B  45      16.573  17.225  -2.074  1.00 13.34           C  
+ANISOU 1889  CD1 TYR B  45     1391   1743   1931    -89     42    251       C  
+ATOM   1890  CD2 TYR B  45      16.157  18.458  -0.096  1.00 11.15           C  
+ANISOU 1890  CD2 TYR B  45     1190   1329   1714    149    -32    497       C  
+ATOM   1891  CE1 TYR B  45      15.522  16.370  -1.766  1.00 15.10           C  
+ANISOU 1891  CE1 TYR B  45     1781   1669   2285   -203    -63    121       C  
+ATOM   1892  CE2 TYR B  45      15.103  17.640   0.188  1.00 12.11           C  
+ANISOU 1892  CE2 TYR B  45     1288   1090   2222    131     63    342       C  
+ATOM   1893  CZ  TYR B  45      14.816  16.576  -0.640  1.00 14.42           C  
+ANISOU 1893  CZ  TYR B  45     1393   1700   2384    -66      9     67       C  
+ATOM   1894  OH  TYR B  45      13.764  15.725  -0.281  1.00 18.45           O  
+ANISOU 1894  OH  TYR B  45     1696   2154   3158   -268    119    507       O  
+ATOM   1895  N   TYR B  46      21.460  19.069  -2.251  1.00  8.43           N  
+ANISOU 1895  N   TYR B  46     1001   1263    938     37    -30    252       N  
+ATOM   1896  CA  TYR B  46      22.638  19.836  -2.637  1.00  8.41           C  
+ANISOU 1896  CA  TYR B  46      957   1292    946     88    -23    243       C  
+ATOM   1897  C   TYR B  46      22.645  20.037  -4.141  1.00  9.40           C  
+ANISOU 1897  C   TYR B  46     1092   1408   1072     90     31    282       C  
+ATOM   1898  O   TYR B  46      22.333  19.139  -4.918  1.00  9.01           O  
+ANISOU 1898  O   TYR B  46     1168   1389    866    167     77    389       O  
+ATOM   1899  CB  TYR B  46      23.911  19.078  -2.267  1.00  9.10           C  
+ANISOU 1899  CB  TYR B  46     1012   1455    992    153     55    307       C  
+ATOM   1900  CG  TYR B  46      24.332  19.062  -0.829  1.00  8.67           C  
+ANISOU 1900  CG  TYR B  46      999   1304    990     83     58    428       C  
+ATOM   1901  CD1 TYR B  46      25.365  19.857  -0.408  1.00  9.86           C  
+ANISOU 1901  CD1 TYR B  46      997   1537   1210    117    -61    397       C  
+ATOM   1902  CD2 TYR B  46      23.778  18.165   0.077  1.00  9.02           C  
+ANISOU 1902  CD2 TYR B  46     1096   1375    954    -15    -16    342       C  
+ATOM   1903  CE1 TYR B  46      25.838  19.799   0.875  1.00 10.97           C  
+ANISOU 1903  CE1 TYR B  46     1301   1532   1332     48   -158    241       C  
+ATOM   1904  CE2 TYR B  46      24.256  18.089   1.373  1.00  8.97           C  
+ANISOU 1904  CE2 TYR B  46     1010   1542    854    -22   -101    534       C  
+ATOM   1905  CZ  TYR B  46      25.265  18.904   1.766  1.00  9.40           C  
+ANISOU 1905  CZ  TYR B  46     1236   1336    996     97    -82    260       C  
+ATOM   1906  OH  TYR B  46      25.745  18.782   3.055  1.00 10.96           O  
+ANISOU 1906  OH  TYR B  46     1348   1582   1233     44   -188    246       O  
+ATOM   1907  N   CYS B  47      23.056  21.219  -4.539  1.00  9.16           N  
+ANISOU 1907  N   CYS B  47     1068   1376   1037     10     -6    293       N  
+ATOM   1908  CA  CYS B  47      23.243  21.516  -5.941  1.00  9.27           C  
+ANISOU 1908  CA  CYS B  47     1082   1425   1014     94    -26    322       C  
+ATOM   1909  C   CYS B  47      24.516  20.895  -6.468  1.00  9.54           C  
+ANISOU 1909  C   CYS B  47     1059   1537   1026     15     31    297       C  
+ATOM   1910  O   CYS B  47      25.623  21.239  -5.993  1.00 11.28           O  
+ANISOU 1910  O   CYS B  47     1062   2008   1214     -8     19    297       O  
+ATOM   1911  CB  CYS B  47      23.325  23.031  -6.102  1.00  9.46           C  
+ANISOU 1911  CB  CYS B  47     1240   1406    948    219    148    382       C  
+ATOM   1912  SG  CYS B  47      23.576  23.547  -7.812  1.00 10.73           S  
+ANISOU 1912  SG  CYS B  47     1256   1656   1162    101     31    605       S  
+ATOM   1913  N   MET B  48      24.361  19.971  -7.409  1.00 10.28           N  
+ANISOU 1913  N   MET B  48     1113   1590   1202    162     -6    210       N  
+ATOM   1914  C   MET B  48      25.506  19.655  -9.497  1.00 11.80           C  
+ANISOU 1914  C   MET B  48     1434   1669   1381    165    -55    140       C  
+ATOM   1915  O   MET B  48      24.881  19.023 -10.329  1.00 14.10           O  
+ANISOU 1915  O   MET B  48     1969   1992   1393     59    -82    213       O  
+ATOM   1916  CA AMET B  48      25.475  19.264  -8.028  0.50 11.56           C  
+ANISOU 1916  CA AMET B  48     1381   1699   1312    130     40    166       C  
+ATOM   1917  CB AMET B  48      25.302  17.744  -7.887  0.50 12.56           C  
+ANISOU 1917  CB AMET B  48     1485   1773   1511    107    123    120       C  
+ATOM   1918  CG AMET B  48      25.064  17.228  -6.471  0.50 15.06           C  
+ANISOU 1918  CG AMET B  48     1886   2021   1813     96    145    271       C  
+ATOM   1919  SD AMET B  48      26.233  17.774  -5.207  0.50 20.56           S  
+ANISOU 1919  SD AMET B  48     2333   2983   2494   -117    243    524       S  
+ATOM   1920  CE AMET B  48      27.804  17.784  -6.029  0.50 19.94           C  
+ANISOU 1920  CE AMET B  48     2388   2738   2447     43     76    286       C  
+ATOM   1921  CA BMET B  48      25.478  19.278  -8.021  0.50 10.94           C  
+ANISOU 1921  CA BMET B  48     1304   1627   1225    135     42    151       C  
+ATOM   1922  CB BMET B  48      25.322  17.772  -7.810  0.50 11.25           C  
+ANISOU 1922  CB BMET B  48     1332   1645   1294    136    152     91       C  
+ATOM   1923  CG BMET B  48      25.507  17.323  -6.360  0.50 11.65           C  
+ANISOU 1923  CG BMET B  48     1436   1609   1378    100    149    130       C  
+ATOM   1924  SD BMET B  48      27.219  17.481  -5.837  0.50 10.62           S  
+ANISOU 1924  SD BMET B  48     1136   2043    853    771    345    475       S  
+ATOM   1925  CE BMET B  48      27.076  18.676  -4.519  0.50 11.31           C  
+ANISOU 1925  CE BMET B  48     1412   1608   1277    281    179    254       C  
+ATOM   1926  N   GLY B  49      26.202  20.730  -9.812  1.00 11.79           N  
+ANISOU 1926  N   GLY B  49     1484   1785   1209    103     -2    229       N  
+ATOM   1927  CA  GLY B  49      26.278  21.220 -11.187  1.00 11.92           C  
+ANISOU 1927  CA  GLY B  49     1380   1836   1311    206     28    312       C  
+ATOM   1928  C   GLY B  49      24.979  21.904 -11.579  1.00 11.76           C  
+ANISOU 1928  C   GLY B  49     1322   1845   1299    202    112    193       C  
+ATOM   1929  O   GLY B  49      24.675  22.988 -11.086  1.00 13.26           O  
+ANISOU 1929  O   GLY B  49     1430   2104   1501    334    111     75       O  
+ATOM   1930  N   ASN B  50      24.192  21.247 -12.405  1.00 11.99           N  
+ANISOU 1930  N   ASN B  50     1424   1902   1227    309     84    369       N  
+ATOM   1931  CA  ASN B  50      22.973  21.827 -12.954  1.00 11.95           C  
+ANISOU 1931  CA  ASN B  50     1345   1945   1251    262    -47    248       C  
+ATOM   1932  C   ASN B  50      21.749  21.598 -12.120  1.00 13.04           C  
+ANISOU 1932  C   ASN B  50     1475   2204   1273    358     -2    285       C  
+ATOM   1933  O   ASN B  50      20.745  22.272 -12.328  1.00 15.39           O  
+ANISOU 1933  O   ASN B  50     1690   2843   1312    561    -84    452       O  
+ATOM   1934  CB  ASN B  50      22.677  21.214 -14.308  1.00 12.14           C  
+ANISOU 1934  CB  ASN B  50     1425   1932   1254    219     25    319       C  
+ATOM   1935  CG  ASN B  50      23.618  21.648 -15.377  1.00 11.91           C  
+ANISOU 1935  CG  ASN B  50     1542   1487   1495    203    187    194       C  
+ATOM   1936  OD1 ASN B  50      24.398  22.569 -15.218  1.00 13.10           O  
+ANISOU 1936  OD1 ASN B  50     1318   1848   1809    277     69    730       O  
+ATOM   1937  ND2 ASN B  50      23.514  20.985 -16.514  1.00 16.06           N  
+ANISOU 1937  ND2 ASN B  50     2059   2293   1749    318    201     64       N  
+ATOM   1938  N   CYS B  51      21.789  20.619 -11.220  1.00 13.22           N  
+ANISOU 1938  N   CYS B  51     1468   2299   1253    202     14    187       N  
+ATOM   1939  CA  CYS B  51      20.599  20.132 -10.543  1.00 14.50           C  
+ANISOU 1939  CA  CYS B  51     1601   2454   1454     71     23     86       C  
+ATOM   1940  C   CYS B  51      20.863  19.719  -9.116  1.00 11.93           C  
+ANISOU 1940  C   CYS B  51     1345   2002   1184    102     12     79       C  
+ATOM   1941  O   CYS B  51      22.008  19.440  -8.748  1.00 11.79           O  
+ANISOU 1941  O   CYS B  51     1301   1861   1316    200    116    190       O  
+ATOM   1942  CB  CYS B  51      20.025  18.928 -11.308  1.00 17.25           C  
+ANISOU 1942  CB  CYS B  51     1983   2836   1732    -64    -84    -24       C  
+ATOM   1943  SG  CYS B  51      21.220  17.532 -11.651  1.00 22.99           S  
+ANISOU 1943  SG  CYS B  51     2317   3934   2483   -405    164   -832       S  
+ATOM   1944  N   CYS B  52      19.802  19.730  -8.312  1.00 11.30           N  
+ANISOU 1944  N   CYS B  52     1315   1880   1097    104    -42    239       N  
+ATOM   1945  CA  CYS B  52      19.866  19.331  -6.933  1.00 10.35           C  
+ANISOU 1945  CA  CYS B  52     1352   1542   1036    -15    -35    220       C  
+ATOM   1946  C   CYS B  52      19.610  17.848  -6.794  1.00 11.77           C  
+ANISOU 1946  C   CYS B  52     1474   1709   1286    -60    -62     66       C  
+ATOM   1947  O   CYS B  52      18.749  17.276  -7.451  1.00 13.13           O  
+ANISOU 1947  O   CYS B  52     1596   1736   1654   -108    -90     32       O  
+ATOM   1948  CB  CYS B  52      18.861  20.131  -6.105  1.00 11.54           C  
+ANISOU 1948  CB  CYS B  52     1494   1522   1366    -19     87    177       C  
+ATOM   1949  SG  CYS B  52      19.350  21.868  -5.951  1.00 11.71           S  
+ANISOU 1949  SG  CYS B  52     1681   1575   1193    -11    207    494       S  
+ATOM   1950  N   LYS B  53      20.430  17.240  -5.943  1.00 10.65           N  
+ANISOU 1950  N   LYS B  53     1553   1470   1021    -63    -53    115       N  
+ATOM   1951  CA  LYS B  53      20.364  15.826  -5.656  1.00 12.32           C  
+ANISOU 1951  CA  LYS B  53     1746   1590   1342    -17      2    173       C  
+ATOM   1952  C   LYS B  53      20.203  15.633  -4.154  1.00 10.51           C  
+ANISOU 1952  C   LYS B  53     1505   1291   1197     -6    -18     94       C  
+ATOM   1953  O   LYS B  53      20.733  16.385  -3.361  1.00 10.22           O  
+ANISOU 1953  O   LYS B  53     1377   1377   1128    -28    -23    164       O  
+ATOM   1954  CB  LYS B  53      21.643  15.124  -6.122  1.00 13.09           C  
+ANISOU 1954  CB  LYS B  53     1956   1694   1323    117     70     84       C  
+ATOM   1955  CG  LYS B  53      21.667  13.616  -5.874  1.00 18.22           C  
+ANISOU 1955  CG  LYS B  53     2596   2165   2161     84    139    216       C  
+ATOM   1956  CD  LYS B  53      22.680  12.887  -6.701  1.00 19.68           C  
+ANISOU 1956  CD  LYS B  53     2657   2478   2341    104     44     34       C  
+ATOM   1957  CE  LYS B  53      22.577  11.402  -6.475  1.00 23.23           C  
+ANISOU 1957  CE  LYS B  53     3183   2828   2814     91     43     48       C  
+ATOM   1958  NZ  LYS B  53      21.362  10.782  -7.090  1.00 27.80           N  
+ANISOU 1958  NZ  LYS B  53     3469   3606   3486    -22     24     34       N  
+ATOM   1959  N   VAL B  54      19.482  14.580  -3.796  1.00 10.53           N  
+ANISOU 1959  N   VAL B  54     1455   1377   1166    -52     40     72       N  
+ATOM   1960  C   VAL B  54      20.482  13.481  -1.856  1.00 11.09           C  
+ANISOU 1960  C   VAL B  54     1518   1393   1301     75    134     24       C  
+ATOM   1961  O   VAL B  54      21.057  12.599  -2.517  1.00 12.54           O  
+ANISOU 1961  O   VAL B  54     1810   1632   1320    216    204    -44       O  
+ATOM   1962  CA AVAL B  54      19.278  14.251  -2.413  0.50 10.85           C  
+ANISOU 1962  CA AVAL B  54     1501   1389   1231     24     62     54       C  
+ATOM   1963  CB AVAL B  54      17.942  13.500  -2.235  0.50 10.75           C  
+ANISOU 1963  CB AVAL B  54     1461   1332   1290    -19     77     50       C  
+ATOM   1964  CG1AVAL B  54      18.059  12.051  -2.681  0.50 12.17           C  
+ANISOU 1964  CG1AVAL B  54     1731   1416   1475   -137    -16      9       C  
+ATOM   1965  CG2AVAL B  54      17.495  13.602  -0.790  0.50 10.70           C  
+ANISOU 1965  CG2AVAL B  54     1519   1416   1131    108    -72    305       C  
+ATOM   1966  CA BVAL B  54      19.279  14.204  -2.412  0.50 11.17           C  
+ANISOU 1966  CA BVAL B  54     1524   1442   1277     27    104     21       C  
+ATOM   1967  CB BVAL B  54      18.102  13.250  -2.260  0.50 11.48           C  
+ANISOU 1967  CB BVAL B  54     1559   1457   1345    -34    145    -15       C  
+ATOM   1968  CG1BVAL B  54      17.914  12.932  -0.803  0.50 12.19           C  
+ANISOU 1968  CG1BVAL B  54     1579   1640   1412    -49    266    -74       C  
+ATOM   1969  CG2BVAL B  54      16.862  13.848  -2.820  0.50 13.53           C  
+ANISOU 1969  CG2BVAL B  54     1739   1677   1724     11    123    -11       C  
+ATOM   1970  N   TYR B  55      20.849  13.843  -0.639  1.00  9.73           N  
+ANISOU 1970  N   TYR B  55     1440   1201   1052    201    190    139       N  
+ATOM   1971  CA  TYR B  55      21.905  13.174   0.118  1.00 10.22           C  
+ANISOU 1971  CA  TYR B  55     1466   1293   1120    166    168    217       C  
+ATOM   1972  C   TYR B  55      21.315  12.779   1.463  1.00 10.21           C  
+ANISOU 1972  C   TYR B  55     1554   1274   1050    198    154    164       C  
+ATOM   1973  O   TYR B  55      20.601  13.549   2.090  1.00 11.83           O  
+ANISOU 1973  O   TYR B  55     1901   1439   1155    417    339    376       O  
+ATOM   1974  CB  TYR B  55      23.122  14.097   0.275  1.00 10.53           C  
+ANISOU 1974  CB  TYR B  55     1490   1381   1127    196     92    273       C  
+ATOM   1975  CG  TYR B  55      23.888  14.161  -1.015  1.00 10.41           C  
+ANISOU 1975  CG  TYR B  55     1241   1550   1162    110     49    285       C  
+ATOM   1976  CD1 TYR B  55      24.885  13.241  -1.291  1.00 12.09           C  
+ANISOU 1976  CD1 TYR B  55     1327   1712   1552     95    226    299       C  
+ATOM   1977  CD2 TYR B  55      23.553  15.075  -2.008  1.00 11.27           C  
+ANISOU 1977  CD2 TYR B  55     1581   1613   1086    159    128    373       C  
+ATOM   1978  CE1 TYR B  55      25.537  13.241  -2.505  1.00 12.84           C  
+ANISOU 1978  CE1 TYR B  55     1291   1905   1679    -14    388     54       C  
+ATOM   1979  CE2 TYR B  55      24.191  15.087  -3.214  1.00 11.92           C  
+ANISOU 1979  CE2 TYR B  55     1550   1868   1110    -14    129    276       C  
+ATOM   1980  CZ  TYR B  55      25.197  14.194  -3.442  1.00 13.40           C  
+ANISOU 1980  CZ  TYR B  55     1575   2133   1382     55    316    145       C  
+ATOM   1981  OH  TYR B  55      25.827  14.208  -4.668  1.00 16.00           O  
+ANISOU 1981  OH  TYR B  55     1943   2611   1524     19    587    173       O  
+ATOM   1982  N   GLU B  56      21.588  11.548   1.873  1.00  9.50           N  
+ANISOU 1982  N   GLU B  56     1410   1197   1002     88     77    224       N  
+ATOM   1983  CA  GLU B  56      21.064  10.987   3.122  1.00  9.70           C  
+ANISOU 1983  CA  GLU B  56     1368   1201   1117     70     93    271       C  
+ATOM   1984  C   GLU B  56      22.235  10.569   3.994  1.00  8.31           C  
+ANISOU 1984  C   GLU B  56     1140   1055    962     59    124    268       C  
+ATOM   1985  O   GLU B  56      23.046   9.715   3.571  1.00  9.42           O  
+ANISOU 1985  O   GLU B  56     1342   1185   1049    234    174    257       O  
+ATOM   1986  CB  GLU B  56      20.220   9.768   2.820  1.00 11.04           C  
+ANISOU 1986  CB  GLU B  56     1527   1460   1207     15     30    209       C  
+ATOM   1987  CG  GLU B  56      18.940  10.022   2.067  1.00 15.37           C  
+ANISOU 1987  CG  GLU B  56     1935   2108   1795   -176    -11    109       C  
+ATOM   1988  CD  GLU B  56      18.309   8.687   1.732  1.00 21.59           C  
+ANISOU 1988  CD  GLU B  56     2683   2851   2667   -415     41   -136       C  
+ATOM   1989  OE1 GLU B  56      17.577   8.177   2.578  1.00 22.83           O  
+ANISOU 1989  OE1 GLU B  56     3173   3091   2410   -407    127    -41       O  
+ATOM   1990  OE2 GLU B  56      18.635   8.084   0.684  1.00 23.78           O  
+ANISOU 1990  OE2 GLU B  56     3287   3227   2519   -449     32   -214       O  
+ATOM   1991  N   GLY B  57      22.356  11.156   5.179  1.00  7.87           N  
+ANISOU 1991  N   GLY B  57     1033    947   1010    199    101    204       N  
+ATOM   1992  CA  GLY B  57      23.490  10.860   6.040  1.00  8.38           C  
+ANISOU 1992  CA  GLY B  57      934   1118   1129    133    107    229       C  
+ATOM   1993  C   GLY B  57      23.761  12.038   6.933  1.00  7.21           C  
+ANISOU 1993  C   GLY B  57      925    925    887     79    111    397       C  
+ATOM   1994  O   GLY B  57      22.867  12.821   7.253  1.00  8.03           O  
+ANISOU 1994  O   GLY B  57      970    972   1108    129    175    246       O  
+ATOM   1995  N   CYS B  58      25.008  12.144   7.394  1.00  8.00           N  
+ANISOU 1995  N   CYS B  58     1072   1095    870     42     -1    382       N  
+ATOM   1996  CA  CYS B  58      25.378  13.191   8.338  1.00  8.64           C  
+ANISOU 1996  CA  CYS B  58     1216   1028   1039    121    -86    331       C  
+ATOM   1997  C   CYS B  58      25.797  14.429   7.590  1.00  9.06           C  
+ANISOU 1997  C   CYS B  58     1108   1137   1195    -16     -9    267       C  
+ATOM   1998  O   CYS B  58      26.977  14.765   7.476  1.00 10.78           O  
+ANISOU 1998  O   CYS B  58     1196   1356   1543    -39    -87    472       O  
+ATOM   1999  CB  CYS B  58      26.543  12.698   9.224  1.00  9.85           C  
+ANISOU 1999  CB  CYS B  58     1376   1182   1184     70   -139    275       C  
+ATOM   2000  SG  CYS B  58      27.040  13.926  10.441  1.00  9.42           S  
+ANISOU 2000  SG  CYS B  58     1431   1071   1077     61    -75    337       S  
+ATOM   2001  N   TYR B  59      24.807  15.095   7.055  1.00  7.94           N  
+ANISOU 2001  N   TYR B  59     1108    900   1007     79     63    342       N  
+ATOM   2002  CA  TYR B  59      25.018  16.262   6.194  1.00  8.58           C  
+ANISOU 2002  CA  TYR B  59     1180   1066   1015     43    -16    264       C  
+ATOM   2003  C   TYR B  59      24.335  17.427   6.841  1.00  9.94           C  
+ANISOU 2003  C   TYR B  59     1331   1260   1184    176    -61    252       C  
+ATOM   2004  O   TYR B  59      23.144  17.332   7.144  1.00 10.34           O  
+ANISOU 2004  O   TYR B  59     1389   1261   1276    252     -6    203       O  
+ATOM   2005  CB  TYR B  59      24.423  16.016   4.808  1.00  9.35           C  
+ANISOU 2005  CB  TYR B  59     1335   1123   1094     77     76    254       C  
+ATOM   2006  CG  TYR B  59      25.070  14.932   4.035  1.00  8.53           C  
+ANISOU 2006  CG  TYR B  59     1255   1051    934    100     93    347       C  
+ATOM   2007  CD1 TYR B  59      26.317  15.111   3.438  1.00 10.15           C  
+ANISOU 2007  CD1 TYR B  59     1356   1296   1205    -24    134    129       C  
+ATOM   2008  CD2 TYR B  59      24.447  13.707   3.890  1.00  8.51           C  
+ANISOU 2008  CD2 TYR B  59     1104   1087   1041     48     78    230       C  
+ATOM   2009  CE1 TYR B  59      26.899  14.093   2.727  1.00  9.78           C  
+ANISOU 2009  CE1 TYR B  59     1169   1446   1098     21     82    166       C  
+ATOM   2010  CE2 TYR B  59      25.020  12.705   3.153  1.00  9.62           C  
+ANISOU 2010  CE2 TYR B  59     1417   1284    951     62    110    266       C  
+ATOM   2011  CZ  TYR B  59      26.241  12.910   2.554  1.00  9.73           C  
+ANISOU 2011  CZ  TYR B  59     1220   1235   1243    171     -5    220       C  
+ATOM   2012  OH  TYR B  59      26.803  11.908   1.806  1.00 11.42           O  
+ANISOU 2012  OH  TYR B  59     1483   1445   1408    222    155    186       O  
+ATOM   2013  N   THR B  60      25.086  18.526   6.989  1.00 11.20           N  
+ANISOU 2013  N   THR B  60     1507   1409   1339    167    -77    118       N  
+ATOM   2014  CA  THR B  60      24.594  19.781   7.544  1.00 13.00           C  
+ANISOU 2014  CA  THR B  60     1859   1569   1510     97    -59     60       C  
+ATOM   2015  C   THR B  60      24.475  20.869   6.483  1.00 12.31           C  
+ANISOU 2015  C   THR B  60     1646   1348   1684     58    -20     69       C  
+ATOM   2016  O   THR B  60      23.827  21.894   6.734  1.00 14.76           O  
+ANISOU 2016  O   THR B  60     2054   1559   1995    207    146    -62       O  
+ATOM   2017  CB  THR B  60      25.537  20.327   8.667  1.00 14.85           C  
+ANISOU 2017  CB  THR B  60     2148   1864   1628     42     -9    -58       C  
+ATOM   2018  OG1 THR B  60      26.849  20.511   8.143  1.00 19.37           O  
+ANISOU 2018  OG1 THR B  60     2347   2586   2424     13   -180    -37       O  
+ATOM   2019  CG2 THR B  60      25.609  19.382   9.842  1.00 16.22           C  
+ANISOU 2019  CG2 THR B  60     2367   2064   1728    164    -85    -56       C  
+ATOM   2020  N   GLY B  61      25.080  20.678   5.325  1.00 11.32           N  
+ANISOU 2020  N   GLY B  61     1594   1191   1515     -7   -245     97       N  
+ATOM   2021  CA  GLY B  61      25.009  21.655   4.248  1.00 10.96           C  
+ANISOU 2021  CA  GLY B  61     1506   1120   1534    -56   -177    132       C  
+ATOM   2022  C   GLY B  61      23.787  21.462   3.383  1.00  9.87           C  
+ANISOU 2022  C   GLY B  61     1310   1097   1340    -37    -89     77       C  
+ATOM   2023  O   GLY B  61      22.830  20.760   3.725  1.00  9.68           O  
+ANISOU 2023  O   GLY B  61     1284   1103   1289      9     82    192       O  
+ATOM   2024  N   GLY B  62      23.815  22.058   2.216  1.00 10.75           N  
+ANISOU 2024  N   GLY B  62     1362   1346   1376    -81     46    174       N  
+ATOM   2025  CA  GLY B  62      22.677  22.025   1.334  1.00 11.00           C  
+ANISOU 2025  CA  GLY B  62     1334   1478   1368     -2     13    167       C  
+ATOM   2026  C   GLY B  62      21.452  22.628   1.976  1.00  9.69           C  
+ANISOU 2026  C   GLY B  62     1327   1315   1037     68    -22    187       C  
+ATOM   2027  O   GLY B  62      21.540  23.472   2.862  1.00 11.20           O  
+ANISOU 2027  O   GLY B  62     1309   1418   1525    174   -173     62       O  
+ATOM   2028  N   TYR B  63      20.309  22.105   1.562  1.00  9.95           N  
+ANISOU 2028  N   TYR B  63     1296   1434   1048     68    -81    134       N  
+ATOM   2029  C   TYR B  63      18.120  21.548   2.449  1.00  9.55           C  
+ANISOU 2029  C   TYR B  63     1283   1381    964    160    -39    124       C  
+ATOM   2030  O   TYR B  63      18.192  20.399   1.999  1.00 10.38           O  
+ANISOU 2030  O   TYR B  63     1536   1281   1125    249    305    256       O  
+ATOM   2031  CA ATYR B  63      19.023  22.663   1.951  0.50  9.54           C  
+ANISOU 2031  CA ATYR B  63     1254   1348   1021    139    -69    135       C  
+ATOM   2032  CB ATYR B  63      18.359  23.426   0.779  0.50  9.61           C  
+ANISOU 2032  CB ATYR B  63     1304   1283   1062    101    -62    203       C  
+ATOM   2033  CG ATYR B  63      19.072  24.686   0.337  0.50  9.17           C  
+ANISOU 2033  CG ATYR B  63     1090   1254   1141     -5    -41     41       C  
+ATOM   2034  CD1ATYR B  63      18.654  25.935   0.764  0.50 10.23           C  
+ANISOU 2034  CD1ATYR B  63     1088   1466   1331     82    127     18       C  
+ATOM   2035  CD2ATYR B  63      20.154  24.613  -0.518  0.50  9.83           C  
+ANISOU 2035  CD2ATYR B  63     1051   1344   1340    136   -117     58       C  
+ATOM   2036  CE1ATYR B  63      19.293  27.079   0.353  0.50 10.17           C  
+ANISOU 2036  CE1ATYR B  63     1169   1343   1349     44    156   -136       C  
+ATOM   2037  CE2ATYR B  63      20.820  25.767  -0.933  0.50  9.23           C  
+ANISOU 2037  CE2ATYR B  63     1164   1291   1049      4    -48    132       C  
+ATOM   2038  CZ ATYR B  63      20.376  27.000  -0.494  0.50  9.57           C  
+ANISOU 2038  CZ ATYR B  63     1096   1376   1163     22     34     89       C  
+ATOM   2039  OH ATYR B  63      21.012  28.162  -0.908  0.50 10.68           O  
+ANISOU 2039  OH ATYR B  63     1276   1288   1492    -58    102    -19       O  
+ATOM   2040  CA BTYR B  63      18.999  22.642   1.861  0.50  9.34           C  
+ANISOU 2040  CA BTYR B  63     1263   1342    944    133    -74    130       C  
+ATOM   2041  CB BTYR B  63      18.398  23.162   0.539  0.50  9.05           C  
+ANISOU 2041  CB BTYR B  63     1303   1247    889     78   -124    165       C  
+ATOM   2042  CG BTYR B  63      19.269  24.206  -0.098  0.50  9.48           C  
+ANISOU 2042  CG BTYR B  63     1213   1345   1042    -41    -80     94       C  
+ATOM   2043  CD1BTYR B  63      19.034  25.541   0.140  0.50  9.10           C  
+ANISOU 2043  CD1BTYR B  63     1101   1316   1039    -10    -74    -85       C  
+ATOM   2044  CD2BTYR B  63      20.348  23.854  -0.892  0.50  8.69           C  
+ANISOU 2044  CD2BTYR B  63     1144   1089   1066    -45   -218     47       C  
+ATOM   2045  CE1BTYR B  63      19.850  26.519  -0.404  0.50  9.41           C  
+ANISOU 2045  CE1BTYR B  63     1287   1262   1027    -15    -38     43       C  
+ATOM   2046  CE2BTYR B  63      21.172  24.823  -1.450  0.50  9.03           C  
+ANISOU 2046  CE2BTYR B  63     1195   1203   1033    -30    -88    193       C  
+ATOM   2047  CZ BTYR B  63      20.916  26.153  -1.198  0.50  9.27           C  
+ANISOU 2047  CZ BTYR B  63     1177   1204   1139      2    -89     29       C  
+ATOM   2048  OH BTYR B  63      21.710  27.120  -1.758  0.50  9.40           O  
+ANISOU 2048  OH BTYR B  63     1504   1221    847    -91   -151     89       O  
+ATOM   2049  N   SER B  64      17.240  21.867   3.388  1.00  9.94           N  
+ANISOU 2049  N   SER B  64     1291   1482   1003    152     13    -54       N  
+ATOM   2050  CA  SER B  64      16.279  20.831   3.809  1.00 10.19           C  
+ANISOU 2050  CA  SER B  64     1257   1525   1088    161     -9     32       C  
+ATOM   2051  C   SER B  64      15.124  20.704   2.860  1.00  9.98           C  
+ANISOU 2051  C   SER B  64     1218   1344   1227     71    -55    136       C  
+ATOM   2052  O   SER B  64      14.458  19.674   2.894  1.00 10.78           O  
+ANISOU 2052  O   SER B  64     1230   1414   1452     62     -5    458       O  
+ATOM   2053  CB  SER B  64      15.751  21.026   5.220  1.00 12.21           C  
+ANISOU 2053  CB  SER B  64     1566   1791   1281     81     11   -106       C  
+ATOM   2054  OG  SER B  64      15.111  22.253   5.334  1.00 15.22           O  
+ANISOU 2054  OG  SER B  64     2109   1831   1842     71     95     14       O  
+ATOM   2055  N   ARG B  65      14.854  21.728   2.039  1.00  9.23           N  
+ANISOU 2055  N   ARG B  65     1172   1153   1182     17   -124    276       N  
+ATOM   2056  CA  ARG B  65      13.766  21.675   1.075  1.00  8.66           C  
+ANISOU 2056  CA  ARG B  65     1122   1117   1051    -29    -85    190       C  
+ATOM   2057  C   ARG B  65      14.357  21.657  -0.330  1.00  8.43           C  
+ANISOU 2057  C   ARG B  65     1093    957   1151     15    -83    229       C  
+ATOM   2058  O   ARG B  65      15.209  22.473  -0.671  1.00  8.62           O  
+ANISOU 2058  O   ARG B  65     1128   1043   1102    -33   -207    250       O  
+ATOM   2059  CB  ARG B  65      12.828  22.873   1.231  1.00  9.09           C  
+ANISOU 2059  CB  ARG B  65     1324   1117   1010     21    -14    105       C  
+ATOM   2060  CG  ARG B  65      11.744  22.697   2.296  1.00 12.54           C  
+ANISOU 2060  CG  ARG B  65     1881   1582   1298   -112    119    167       C  
+ATOM   2061  CD  ARG B  65      12.196  22.905   3.727  1.00 16.21           C  
+ANISOU 2061  CD  ARG B  65     1969   2192   1995    -62      6    -81       C  
+ATOM   2062  NE  ARG B  65      12.759  24.251   3.885  1.00 17.81           N  
+ANISOU 2062  NE  ARG B  65     2272   2084   2410     37    -85   -331       N  
+ATOM   2063  CZ  ARG B  65      12.085  25.349   4.237  1.00 20.58           C  
+ANISOU 2063  CZ  ARG B  65     2524   2469   2825      0   -164   -167       C  
+ATOM   2064  NH1 ARG B  65      10.793  25.303   4.544  1.00 20.15           N  
+ANISOU 2064  NH1 ARG B  65     2595   2626   2435    214    -36   -283       N  
+ATOM   2065  NH2 ARG B  65      12.742  26.506   4.292  1.00 22.17           N  
+ANISOU 2065  NH2 ARG B  65     3014   2505   2903    -80   -110   -379       N  
+ATOM   2066  N   MET B  66      13.891  20.728  -1.154  1.00  8.52           N  
+ANISOU 2066  N   MET B  66     1147   1045   1042    -76    -14    232       N  
+ATOM   2067  CA  MET B  66      14.305  20.628  -2.536  1.00  9.03           C  
+ANISOU 2067  CA  MET B  66     1114   1104   1210    -48   -110     70       C  
+ATOM   2068  C   MET B  66      14.119  21.937  -3.291  1.00  8.90           C  
+ANISOU 2068  C   MET B  66     1019   1189   1172   -128   -184    169       C  
+ATOM   2069  O   MET B  66      15.010  22.352  -4.048  1.00  9.05           O  
+ANISOU 2069  O   MET B  66     1050   1209   1179   -211    -25    179       O  
+ATOM   2070  CB  MET B  66      13.548  19.495  -3.225  1.00 10.15           C  
+ANISOU 2070  CB  MET B  66     1384   1144   1326   -124   -111    187       C  
+ATOM   2071  CG  MET B  66      13.826  19.391  -4.694  1.00 12.51           C  
+ANISOU 2071  CG  MET B  66     1581   1580   1589   -111     -4   -120       C  
+ATOM   2072  SD  MET B  66      15.526  19.073  -5.135  1.00 17.59           S  
+ANISOU 2072  SD  MET B  66     2104   2811   1767   -255    230   -254       S  
+ATOM   2073  CE  MET B  66      15.580  17.312  -5.351  1.00 22.28           C  
+ANISOU 2073  CE  MET B  66     2820   2881   2764   -135    -40   -339       C  
+ATOM   2074  N   GLY B  67      12.995  22.613  -3.093  1.00  8.80           N  
+ANISOU 2074  N   GLY B  67     1163   1162   1016    -39   -142    274       N  
+ATOM   2075  CA  GLY B  67      12.734  23.822  -3.860  1.00  9.04           C  
+ANISOU 2075  CA  GLY B  67     1202   1078   1152    -87   -235    326       C  
+ATOM   2076  C   GLY B  67      13.666  24.946  -3.511  1.00  9.20           C  
+ANISOU 2076  C   GLY B  67     1061   1176   1256    -65   -218    224       C  
+ATOM   2077  O   GLY B  67      13.974  25.794  -4.357  1.00  9.68           O  
+ANISOU 2077  O   GLY B  67     1198   1199   1280   -129   -308    323       O  
+ATOM   2078  N   GLU B  68      14.135  24.988  -2.266  1.00  8.97           N  
+ANISOU 2078  N   GLU B  68     1064   1100   1244     18   -180    334       N  
+ATOM   2079  CA  GLU B  68      15.094  26.006  -1.876  1.00  9.43           C  
+ANISOU 2079  CA  GLU B  68     1223   1181   1178    -44   -222    245       C  
+ATOM   2080  C   GLU B  68      16.448  25.707  -2.525  1.00  8.89           C  
+ANISOU 2080  C   GLU B  68     1086   1080   1212     20   -249    273       C  
+ATOM   2081  O   GLU B  68      17.145  26.634  -2.927  1.00  9.57           O  
+ANISOU 2081  O   GLU B  68     1201   1154   1279   -126   -245    393       O  
+ATOM   2082  CB  GLU B  68      15.181  26.120  -0.355  1.00 10.80           C  
+ANISOU 2082  CB  GLU B  68     1382   1328   1391     -7   -278    168       C  
+ATOM   2083  CG  GLU B  68      13.885  26.638   0.240  1.00 14.84           C  
+ANISOU 2083  CG  GLU B  68     1920   1895   1823     24   -119     14       C  
+ATOM   2084  CD  GLU B  68      13.562  28.046  -0.243  1.00 17.33           C  
+ANISOU 2084  CD  GLU B  68     2456   1821   2305     73   -117    -88       C  
+ATOM   2085  OE1 GLU B  68      14.203  29.013   0.231  1.00 23.28           O  
+ANISOU 2085  OE1 GLU B  68     3219   2524   3102     41   -226    -51       O  
+ATOM   2086  OE2 GLU B  68      12.717  28.173  -1.155  1.00 22.25           O  
+ANISOU 2086  OE2 GLU B  68     2921   2745   2785    195   -105   -157       O  
+ATOM   2087  N   CYS B  69      16.852  24.437  -2.606  1.00  8.76           N  
+ANISOU 2087  N   CYS B  69     1096   1133   1096    -17    -71    372       N  
+ATOM   2088  CA  CYS B  69      18.048  24.094  -3.360  1.00  8.60           C  
+ANISOU 2088  CA  CYS B  69      994   1170   1101     53   -133    398       C  
+ATOM   2089  C   CYS B  69      17.887  24.471  -4.826  1.00  8.65           C  
+ANISOU 2089  C   CYS B  69      910   1193   1183     84    -26    368       C  
+ATOM   2090  O   CYS B  69      18.769  25.094  -5.414  1.00  9.29           O  
+ANISOU 2090  O   CYS B  69     1115   1246   1166    -26   -115    464       O  
+ATOM   2091  CB  CYS B  69      18.317  22.590  -3.207  1.00  8.73           C  
+ANISOU 2091  CB  CYS B  69     1064   1244   1006     89    -91    363       C  
+ATOM   2092  SG  CYS B  69      19.855  22.061  -3.980  1.00  9.90           S  
+ANISOU 2092  SG  CYS B  69     1122   1445   1191     78     72    499       S  
+ATOM   2093  N   ALA B  70      16.756  24.088  -5.414  1.00  8.78           N  
+ANISOU 2093  N   ALA B  70     1091   1228   1014    -57    -72    377       N  
+ATOM   2094  CA  ALA B  70      16.596  24.241  -6.857  1.00  9.09           C  
+ANISOU 2094  CA  ALA B  70     1111   1223   1120    -48   -139    384       C  
+ATOM   2095  C   ALA B  70      16.677  25.694  -7.317  1.00  9.19           C  
+ANISOU 2095  C   ALA B  70     1101   1297   1092    -94   -170    424       C  
+ATOM   2096  O   ALA B  70      17.311  25.994  -8.332  1.00 10.01           O  
+ANISOU 2096  O   ALA B  70     1226   1578    996   -164   -175    472       O  
+ATOM   2097  CB  ALA B  70      15.283  23.610  -7.310  1.00 10.09           C  
+ANISOU 2097  CB  ALA B  70     1235   1334   1263   -207   -153    312       C  
+ATOM   2098  N   ARG B  71      16.131  26.606  -6.534  1.00  9.24           N  
+ANISOU 2098  N   ARG B  71     1177   1216   1117   -119   -232    516       N  
+ATOM   2099  CA  ARG B  71      16.179  27.999  -6.940  1.00 10.96           C  
+ANISOU 2099  CA  ARG B  71     1485   1303   1376   -107   -227    446       C  
+ATOM   2100  C   ARG B  71      17.566  28.597  -6.763  1.00 10.17           C  
+ANISOU 2100  C   ARG B  71     1436   1164   1263   -127   -166    503       C  
+ATOM   2101  O   ARG B  71      17.839  29.674  -7.284  1.00 11.81           O  
+ANISOU 2101  O   ARG B  71     1572   1297   1618   -108   -149    636       O  
+ATOM   2102  CB  ARG B  71      15.119  28.808  -6.246  1.00 11.82           C  
+ANISOU 2102  CB  ARG B  71     1591   1398   1502   -180   -181    385       C  
+ATOM   2103  CG  ARG B  71      15.342  29.063  -4.808  1.00 11.77           C  
+ANISOU 2103  CG  ARG B  71     1627   1330   1514   -121   -154    350       C  
+ATOM   2104  CD  ARG B  71      14.116  29.780  -4.260  1.00 14.44           C  
+ANISOU 2104  CD  ARG B  71     2078   1766   1641    134    -54    203       C  
+ATOM   2105  NE  ARG B  71      14.277  30.153  -2.862  1.00 16.55           N  
+ANISOU 2105  NE  ARG B  71     2495   1755   2039    175   -298     -3       N  
+ATOM   2106  CZ  ARG B  71      14.849  31.270  -2.459  1.00 20.90           C  
+ANISOU 2106  CZ  ARG B  71     2889   2539   2510    -13   -189    -21       C  
+ATOM   2107  NH1 ARG B  71      15.353  32.142  -3.327  1.00 23.33           N  
+ANISOU 2107  NH1 ARG B  71     3281   2603   2980   -159   -145    -67       N  
+ATOM   2108  NH2 ARG B  71      14.941  31.496  -1.162  1.00 23.60           N  
+ANISOU 2108  NH2 ARG B  71     3322   2907   2736    -35   -199   -298       N  
+ATOM   2109  N   ASN B  72      18.454  27.857  -6.089  1.00 10.11           N  
+ANISOU 2109  N   ASN B  72     1308   1318   1215   -183   -212    465       N  
+ATOM   2110  CA  ASN B  72      19.843  28.215  -5.869  1.00  9.88           C  
+ANISOU 2110  CA  ASN B  72     1331   1251   1171   -219   -227    385       C  
+ATOM   2111  C   ASN B  72      20.800  27.336  -6.655  1.00  9.91           C  
+ANISOU 2111  C   ASN B  72     1194   1325   1245   -166   -146    398       C  
+ATOM   2112  O   ASN B  72      21.960  27.181  -6.262  1.00 11.75           O  
+ANISOU 2112  O   ASN B  72     1203   1824   1436    -61   -257    439       O  
+ATOM   2113  CB  ASN B  72      20.144  28.145  -4.351  1.00 10.99           C  
+ANISOU 2113  CB  ASN B  72     1413   1500   1260   -283   -153    371       C  
+ATOM   2114  CG  ASN B  72      19.567  29.330  -3.608  1.00 12.08           C  
+ANISOU 2114  CG  ASN B  72     1739   1673   1175   -461   -143    105       C  
+ATOM   2115  OD1 ASN B  72      20.032  30.477  -3.796  1.00 15.57           O  
+ANISOU 2115  OD1 ASN B  72     2608   1611   1695   -723    -60     37       O  
+ATOM   2116  ND2 ASN B  72      18.541  29.101  -2.797  1.00 13.25           N  
+ANISOU 2116  ND2 ASN B  72     1768   2082   1183   -391   -202    474       N  
+ATOM   2117  N   CYS B  73      20.352  26.754  -7.773  1.00  9.77           N  
+ANISOU 2117  N   CYS B  73     1216   1325   1169   -109   -201    542       N  
+ATOM   2118  CA  CYS B  73      21.146  25.777  -8.510  1.00 10.24           C  
+ANISOU 2118  CA  CYS B  73     1197   1392   1300   -151   -184    483       C  
+ATOM   2119  C   CYS B  73      20.935  26.027  -9.998  1.00 11.00           C  
+ANISOU 2119  C   CYS B  73     1291   1578   1308   -186   -116    480       C  
+ATOM   2120  O   CYS B  73      19.794  26.024 -10.450  1.00 10.84           O  
+ANISOU 2120  O   CYS B  73     1363   1321   1434   -219   -350    634       O  
+ATOM   2121  CB  CYS B  73      20.718  24.362  -8.133  1.00  9.59           C  
+ANISOU 2121  CB  CYS B  73     1192   1302   1150    -85    -79    522       C  
+ATOM   2122  SG  CYS B  73      21.810  23.096  -8.750  1.00 10.63           S  
+ANISOU 2122  SG  CYS B  73     1337   1621   1079    -17    -32    569       S  
+ATOM   2123  N   PRO B  74      22.020  26.207 -10.778  1.00 11.93           N  
+ANISOU 2123  N   PRO B  74     1395   1747   1391   -241   -122    526       N  
+ATOM   2124  CA  PRO B  74      23.417  26.178 -10.404  1.00 13.76           C  
+ANISOU 2124  CA  PRO B  74     1574   1977   1677   -265    -19    509       C  
+ATOM   2125  C   PRO B  74      23.810  27.303  -9.508  1.00 16.01           C  
+ANISOU 2125  C   PRO B  74     1778   2208   2097   -181   -145    409       C  
+ATOM   2126  O   PRO B  74      23.076  28.298  -9.270  1.00 13.88           O  
+ANISOU 2126  O   PRO B  74     1464   1900   1907   -611   -244    440       O  
+ATOM   2127  CB  PRO B  74      24.161  26.255 -11.769  1.00 15.35           C  
+ANISOU 2127  CB  PRO B  74     1713   2120   1996   -192     95    453       C  
+ATOM   2128  CG  PRO B  74      23.220  26.785 -12.693  1.00 14.67           C  
+ANISOU 2128  CG  PRO B  74     1808   2132   1633   -328    -83     50       C  
+ATOM   2129  CD  PRO B  74      21.856  26.437 -12.223  1.00 12.15           C  
+ANISOU 2129  CD  PRO B  74     1664   1665   1285   -257   -121    323       C  
+ATOM   2130  N   ALA B  75      24.989  27.103  -8.929  1.00 18.57           N  
+ANISOU 2130  N   ALA B  75     2125   2370   2560    -79   -294    306       N  
+ATOM   2131  CA  ALA B  75      25.694  28.186  -8.304  1.00 19.48           C  
+ANISOU 2131  CA  ALA B  75     2419   2555   2425     37   -126    114       C  
+ATOM   2132  C   ALA B  75      27.198  27.897  -8.260  1.00 19.56           C  
+ANISOU 2132  C   ALA B  75     2376   2595   2460    123     41     76       C  
+ATOM   2133  O   ALA B  75      27.713  27.051  -9.025  1.00 19.66           O  
+ANISOU 2133  O   ALA B  75     2318   2694   2457     58    220   -208       O  
+ATOM   2134  CB  ALA B  75      25.111  28.443  -6.932  1.00 20.56           C  
+ANISOU 2134  CB  ALA B  75     2661   2653   2495     32    -22     25       C  
+TER    2135      ALA B  75                                                      
+HETATM 2136 CA    CA A1244       5.636   0.256  12.384  1.00 10.99          CA  
+ANISOU 2136 CA    CA A1244     1245   1327   1602   -132   -368    148      CA  
+HETATM 2137 CL    CL B1076      10.166  21.671  -1.907  1.00 12.31          CL  
+ANISOU 2137 CL    CL B1076     1291   1450   1935   -209   -105    187      CL  
+HETATM 2138  O   HOH A2001      22.970  -5.511   9.157  1.00 10.94           O  
+ANISOU 2138  O   HOH A2001     1038    865   2250    -43    -73    125       O  
+HETATM 2139  O   HOH A2002      27.336  -9.889  13.418  1.00 14.22           O  
+ANISOU 2139  O   HOH A2002     2766   1184   1450    637     11     53       O  
+HETATM 2140  O   HOH A2003      28.141 -10.188   9.633  1.00  9.33           O  
+ANISOU 2140  O   HOH A2003     1259    820   1464    119    159    247       O  
+HETATM 2141  O   HOH A2004      24.670  -8.915   8.078  1.00  8.78           O  
+ANISOU 2141  O   HOH A2004     1256    854   1224    -44   -143    137       O  
+HETATM 2142  O   HOH A2005      19.298  -9.798  19.660  1.00 14.56           O  
+ANISOU 2142  O   HOH A2005     1921   1569   2042   -352     52   -145       O  
+HETATM 2143  O   HOH A2006      10.075 -11.311  15.235  1.00 13.61           O  
+ANISOU 2143  O   HOH A2006      974   1680   2516    371     65   -556       O  
+HETATM 2144  O   HOH A2007       8.402 -10.551  18.981  1.00 24.13           O  
+ANISOU 2144  O   HOH A2007     3197   2318   3653    -46    221    -24       O  
+HETATM 2145  O   HOH A2008       9.514  -6.921  24.425  1.00 31.89           O  
+ANISOU 2145  O   HOH A2008     4511   3678   3925    112    337    261       O  
+HETATM 2146  O   HOH A2009       5.529  -7.792  19.505  1.00 19.48           O  
+ANISOU 2146  O   HOH A2009     2308   1897   3196   -543    101    347       O  
+HETATM 2147  O   HOH A2010       5.045  -4.623  16.639  1.00 14.24           O  
+ANISOU 2147  O   HOH A2010     1640   1355   2412    -19   -118    198       O  
+HETATM 2148  O   HOH A2011      24.164  -7.795   5.542  1.00 15.08           O  
+ANISOU 2148  O   HOH A2011     2695   1331   1703   -514   -363    282       O  
+HETATM 2149  O   HOH A2012      17.052  -8.285  20.466  1.00 16.67           O  
+ANISOU 2149  O   HOH A2012     1981   2330   2021    281    -20    101       O  
+HETATM 2150  O   HOH A2013      17.130  -7.268  23.126  1.00 14.84           O  
+ANISOU 2150  O   HOH A2013     1564   2094   1979     69    141    133       O  
+HETATM 2151  O   HOH A2014      13.678  -8.376  24.975  1.00 23.88           O  
+ANISOU 2151  O   HOH A2014     3270   3290   2513    -58    278    719       O  
+HETATM 2152  O   HOH A2015      20.157 -10.749  22.031  1.00 22.11           O  
+ANISOU 2152  O   HOH A2015     2948   3143   2309    152   -136    576       O  
+HETATM 2153  O   HOH A2016      12.435  -3.661  19.535  1.00  8.20           O  
+ANISOU 2153  O   HOH A2016     1081    892   1140   -118     11    127       O  
+HETATM 2154  O   HOH A2017       5.927 -10.099  17.997  1.00 32.77           O  
+ANISOU 2154  O   HOH A2017     4252   3953   4245    -31    108     55       O  
+HETATM 2155  O   HOH A2018      10.041   1.555  21.940  1.00  8.42           O  
+ANISOU 2155  O   HOH A2018      756   1373   1067    108     -4    127       O  
+HETATM 2156  O   HOH A2019      10.978  -9.695  23.883  1.00 45.96           O  
+ANISOU 2156  O   HOH A2019     5829   5859   5772     20     32     63       O  
+HETATM 2157  O   HOH A2020      11.489  -8.048  26.210  1.00 36.58           O  
+ANISOU 2157  O   HOH A2020     4876   4452   4568    173     75     54       O  
+HETATM 2158  O   HOH A2021      13.215 -11.076  23.922  1.00 30.90           O  
+ANISOU 2158  O   HOH A2021     4000   3902   3836     84    284     77       O  
+HETATM 2159  O   HOH A2022      26.131  -8.892   4.066  1.00 19.94           O  
+ANISOU 2159  O   HOH A2022     3269   1910   2396   -185   -126   -469       O  
+HETATM 2160  O   HOH A2023      20.283  -2.181  22.046  1.00  7.92           O  
+ANISOU 2160  O   HOH A2023      950   1147    909     79     25    411       O  
+HETATM 2161  O   HOH A2024      18.596  -5.661  24.955  1.00 13.95           O  
+ANISOU 2161  O   HOH A2024     2043   1694   1562    -85    194    383       O  
+HETATM 2162  O   HOH A2025      17.801  -5.515  27.717  1.00 43.15           O  
+ANISOU 2162  O   HOH A2025     5759   5328   5307     82    266    178       O  
+HETATM 2163  O   HOH A2026      20.842  -7.170  25.407  1.00 21.49           O  
+ANISOU 2163  O   HOH A2026     2519   2650   2996    152   -243    385       O  
+HETATM 2164  O   HOH A2027      10.257   6.558  11.871  1.00  8.08           O  
+ANISOU 2164  O   HOH A2027      954   1084   1029    116    -19    240       O  
+HETATM 2165  O   HOH A2028       8.225   8.323   7.975  1.00 15.68           O  
+ANISOU 2165  O   HOH A2028     2124   2311   1522   -265   -334   -130       O  
+HETATM 2166  O   HOH A2029       6.487  10.658   9.084  1.00 14.06           O  
+ANISOU 2166  O   HOH A2029     1732   1821   1787   -116   -536    106       O  
+HETATM 2167  O   HOH A2030      11.991  -8.937   7.885  1.00 27.18           O  
+ANISOU 2167  O   HOH A2030     3826   3207   3291     21    -30    -84       O  
+HETATM 2168  O   HOH A2031      16.743   7.250  34.587  1.00 34.42           O  
+ANISOU 2168  O   HOH A2031     4385   4296   4394    -96     79    -24       O  
+HETATM 2169  O   HOH A2032      12.546   6.272  36.469  1.00 32.77           O  
+ANISOU 2169  O   HOH A2032     4742   4267   3442    -78   -112    395       O  
+HETATM 2170  O   HOH A2033      15.689  10.496  37.340  1.00 28.30           O  
+ANISOU 2170  O   HOH A2033     3958   3097   3697    -34    398   -149       O  
+HETATM 2171  O   HOH A2034       6.461   4.863  35.013  1.00 25.84           O  
+ANISOU 2171  O   HOH A2034     2723   3879   3215   -393    670    126       O  
+HETATM 2172  O   HOH A2035       9.884   6.844  36.240  1.00 31.03           O  
+ANISOU 2172  O   HOH A2035     4323   4198   3269     69     38    -66       O  
+HETATM 2173  O   HOH A2036       4.558 -11.184  13.175  1.00 56.66           O  
+ANISOU 2173  O   HOH A2036     7169   7095   7261    -21      2    -17       O  
+HETATM 2174  O   HOH A2037       6.463  11.983   5.496  1.00 24.97           O  
+ANISOU 2174  O   HOH A2037     3175   3350   2961     73   -255   -118       O  
+HETATM 2175  O   HOH A2038       9.062   8.785   5.362  1.00 31.25           O  
+ANISOU 2175  O   HOH A2038     3793   4280   3797   -222   -134   -238       O  
+HETATM 2176  O   HOH A2039       3.125  15.177  34.526  1.00 34.48           O  
+ANISOU 2176  O   HOH A2039     4244   4426   4429    123     80   -181       O  
+HETATM 2177  O   HOH A2040      15.174  17.342   7.075  1.00 10.82           O  
+ANISOU 2177  O   HOH A2040     1611   1221   1277    434     50    128       O  
+HETATM 2178  O   HOH A2041      36.264  22.848  27.933  1.00 28.99           O  
+ANISOU 2178  O   HOH A2041     4362   3427   3226    218   -262    325       O  
+HETATM 2179  O   HOH A2042      39.720  20.150  21.199  1.00 41.20           O  
+ANISOU 2179  O   HOH A2042     5214   5082   5357    -34   -103     28       O  
+HETATM 2180  O   HOH A2043      11.970   6.817   7.162  1.00 20.05           O  
+ANISOU 2180  O   HOH A2043     2477   2696   2444   -219   -498   -985       O  
+HETATM 2181  O   HOH A2044      41.148  20.400  23.939  1.00 41.86           O  
+ANISOU 2181  O   HOH A2044     5262   5434   5206     12    -72    -31       O  
+HETATM 2182  O   HOH A2045       6.217  19.749  17.757  1.00 25.53           O  
+ANISOU 2182  O   HOH A2045     4026   2451   3221    119   -136   -193       O  
+HETATM 2183  O   HOH A2046      20.638   6.038  23.302  1.00  9.72           O  
+ANISOU 2183  O   HOH A2046     1438   1480    773   -400    171     -3       O  
+HETATM 2184  O   HOH A2047      11.168  -9.520  10.537  1.00 15.11           O  
+ANISOU 2184  O   HOH A2047     1926   1295   2517    266   -456   -308       O  
+HETATM 2185  O   HOH A2048       8.283  -8.711  10.191  1.00 39.75           O  
+ANISOU 2185  O   HOH A2048     4635   5235   5230   -126    -61   -141       O  
+HETATM 2186  O   HOH A2049      16.167   4.325  33.082  1.00 18.47           O  
+ANISOU 2186  O   HOH A2049     2922   2656   1439   1056   -193   -122       O  
+HETATM 2187  O   HOH A2050      10.459  11.521  34.526  1.00 29.06           O  
+ANISOU 2187  O   HOH A2050     3986   4073   2982   -342    499    -40       O  
+HETATM 2188  O   HOH A2051      14.291   8.075  35.254  1.00 26.00           O  
+ANISOU 2188  O   HOH A2051     3361   3451   3065   -135   -332    108       O  
+HETATM 2189  O   HOH A2052       1.260  -6.027  10.151  1.00 72.53           O  
+ANISOU 2189  O   HOH A2052     9157   9191   9210     -4    -50     -8       O  
+HETATM 2190  O   HOH A2053       7.240  -9.463  12.500  1.00 33.48           O  
+ANISOU 2190  O   HOH A2053     4465   3586   4667     11   -166   -188       O  
+HETATM 2191  O   HOH A2054      -2.589  -4.481  18.123  1.00 21.78           O  
+ANISOU 2191  O   HOH A2054     2071   2664   3538    -16    259     94       O  
+HETATM 2192  O   HOH A2055       8.835   5.617  34.002  1.00 16.15           O  
+ANISOU 2192  O   HOH A2055     2131   2460   1543   -320    548    552       O  
+HETATM 2193  O   HOH A2056       4.093   8.317  33.465  1.00 25.57           O  
+ANISOU 2193  O   HOH A2056     1974   4724   3016    175    693     13       O  
+HETATM 2194  O   HOH A2057       8.266   9.509  34.107  1.00 26.29           O  
+ANISOU 2194  O   HOH A2057     3283   3658   3046   -421    388   -139       O  
+HETATM 2195  O   HOH A2058       5.161  14.711  29.425  1.00 26.44           O  
+ANISOU 2195  O   HOH A2058     3815   3138   3091   -113    370     91       O  
+HETATM 2196  O   HOH A2059       3.427  11.917  32.992  1.00 37.20           O  
+ANISOU 2196  O   HOH A2059     4636   4826   4670      0     48   -229       O  
+HETATM 2197  O   HOH A2060       6.924  15.296  33.938  1.00 58.18           O  
+ANISOU 2197  O   HOH A2060     7383   7375   7347    -12    126    -26       O  
+HETATM 2198  O   HOH A2061       4.550  20.653  23.542  1.00 26.75           O  
+ANISOU 2198  O   HOH A2061     3199   3211   3754    -78    -73    -10       O  
+HETATM 2199  O   HOH A2062       3.736  20.133  26.165  1.00 35.74           O  
+ANISOU 2199  O   HOH A2062     4501   4226   4852     47    -19   -189       O  
+HETATM 2200  O   HOH A2063       6.257  21.780  27.789  1.00 44.26           O  
+ANISOU 2200  O   HOH A2063     5600   5554   5661    -28      8    -43       O  
+HETATM 2201  O   HOH A2064      19.986  22.660  29.398  1.00 16.66           O  
+ANISOU 2201  O   HOH A2064     2788   1927   1613   -190     22   -662       O  
+HETATM 2202  O   HOH A2065      30.289  18.758  31.745  1.00 23.73           O  
+ANISOU 2202  O   HOH A2065     2629   3025   3361    -78   -244   -289       O  
+HETATM 2203  O   HOH A2066      18.243  -6.972  31.931  1.00 47.99           O  
+ANISOU 2203  O   HOH A2066     6154   5912   6165     26     28     21       O  
+HETATM 2204  O   HOH A2067      33.264  22.204  27.609  1.00 34.02           O  
+ANISOU 2204  O   HOH A2067     4221   4374   4329   -195   -173    -88       O  
+HETATM 2205  O   HOH A2068      25.937  20.915  32.080  1.00 33.88           O  
+ANISOU 2205  O   HOH A2068     4514   3990   4368   -119     56    -35       O  
+HETATM 2206  O   HOH A2069      25.340  24.572  32.130  1.00 57.74           O  
+ANISOU 2206  O   HOH A2069     7431   7219   7287    -50    -25     11       O  
+HETATM 2207  O   HOH A2070      32.307  18.629  11.934  1.00 33.79           O  
+ANISOU 2207  O   HOH A2070     4431   4047   4361     26    -64     -9       O  
+HETATM 2208  O   HOH A2071      37.941  15.693  17.195  1.00 24.64           O  
+ANISOU 2208  O   HOH A2071     2637   2639   4083    122    338    408       O  
+HETATM 2209  O   HOH A2072      35.010  13.179  15.603  1.00 15.68           O  
+ANISOU 2209  O   HOH A2072     2432   1205   2318    176   -169    207       O  
+HETATM 2210  O   HOH A2073      39.822  19.682  18.547  1.00 49.52           O  
+ANISOU 2210  O   HOH A2073     6121   6303   6391   -141    -39     13       O  
+HETATM 2211  O   HOH A2074      38.424  17.625  22.674  1.00 40.52           O  
+ANISOU 2211  O   HOH A2074     4971   5285   5140    -29   -150     53       O  
+HETATM 2212  O   HOH A2075      23.139  19.656  17.181  1.00 12.13           O  
+ANISOU 2212  O   HOH A2075     1319   1442   1846     37      4    414       O  
+HETATM 2213  O   HOH A2076      36.433  18.974  27.984  1.00 67.60           O  
+ANISOU 2213  O   HOH A2076     8547   8527   8611      5    -67    -28       O  
+HETATM 2214  O   HOH A2077      24.344  17.523  13.227  1.00 15.97           O  
+ANISOU 2214  O   HOH A2077     2700   1574   1792   -405    149    199       O  
+HETATM 2215  O   HOH A2078      21.975  18.868  14.868  1.00 12.49           O  
+ANISOU 2215  O   HOH A2078     1471   1710   1562     50     52    195       O  
+HETATM 2216  O   HOH A2079      19.704  19.668  12.476  1.00 14.56           O  
+ANISOU 2216  O   HOH A2079     1692   2480   1359   -324   -239     95       O  
+HETATM 2217  O   HOH A2080       5.145  19.190  21.382  1.00 24.66           O  
+ANISOU 2217  O   HOH A2080     2986   2529   3854    433     80   -464       O  
+HETATM 2218  O   HOH A2081       3.453  19.428  16.804  1.00 60.37           O  
+ANISOU 2218  O   HOH A2081     7515   7709   7714     21     -6    -23       O  
+HETATM 2219  O   HOH A2082      -2.229  12.617  23.085  1.00 26.33           O  
+ANISOU 2219  O   HOH A2082     2888   3741   3372    280   -264   -407       O  
+HETATM 2220  O   HOH A2083      -0.739  15.914  24.947  1.00 37.85           O  
+ANISOU 2220  O   HOH A2083     4806   4826   4747     43   -181    -46       O  
+HETATM 2221  O   HOH A2084      15.027  21.447  11.455  1.00 12.10           O  
+ANISOU 2221  O   HOH A2084     1618    754   2223    -76   -209   -263       O  
+HETATM 2222  O   HOH A2085      14.514  19.757   8.534  1.00 14.10           O  
+ANISOU 2222  O   HOH A2085     2088   1770   1498     96   -112     85       O  
+HETATM 2223  O   HOH A2086      -1.214   6.508  28.977  1.00 34.63           O  
+ANISOU 2223  O   HOH A2086     4580   4127   4449    -82     43   -119       O  
+HETATM 2224  O   HOH A2087      11.158  24.457  16.332  1.00 12.50           O  
+ANISOU 2224  O   HOH A2087     2034   1132   1581   -358   -220   -229       O  
+HETATM 2225  O   HOH A2088      11.500  -4.000  31.725  1.00 37.40           O  
+ANISOU 2225  O   HOH A2088     5032   4623   4554   -147   -201    182       O  
+HETATM 2226  O   HOH A2089      12.037  -4.653  29.240  1.00 26.34           O  
+ANISOU 2226  O   HOH A2089     3570   2979   3457   -140   -100    474       O  
+HETATM 2227  O   HOH A2090       9.820  21.279  17.531  1.00 20.91           O  
+ANISOU 2227  O   HOH A2090     3025   2301   2618    -29    137   -287       O  
+HETATM 2228  O   HOH A2091       7.327  17.774  16.777  1.00 17.78           O  
+ANISOU 2228  O   HOH A2091     2187   1991   2576    599   -281     40       O  
+HETATM 2229  O   HOH A2092      10.519  18.799  18.270  1.00 16.60           O  
+ANISOU 2229  O   HOH A2092     2106   2067   2132    561   -701   -844       O  
+HETATM 2230  O   HOH A2093      14.578  -4.512  27.485  1.00 26.83           O  
+ANISOU 2230  O   HOH A2093     3859   3287   3048     67     73    707       O  
+HETATM 2231  O   HOH A2094      15.936  -4.036  29.832  1.00 47.83           O  
+ANISOU 2231  O   HOH A2094     6033   5940   6200    -41     51    146       O  
+HETATM 2232  O   HOH A2095       9.112   0.897  34.021  1.00 22.88           O  
+ANISOU 2232  O   HOH A2095     3305   3207   2182    207    179    -77       O  
+HETATM 2233  O   HOH A2096      18.093   6.106  36.978  1.00 24.08           O  
+ANISOU 2233  O   HOH A2096     3574   3164   2411    176   -371     40       O  
+HETATM 2234  O   HOH A2097      20.089   4.778  38.350  1.00 23.97           O  
+ANISOU 2234  O   HOH A2097     3069   3444   2592     30    164   -113       O  
+HETATM 2235  O   HOH A2098      10.332   2.307  18.376  1.00  6.96           O  
+ANISOU 2235  O   HOH A2098      715    892   1037    -98     70    131       O  
+HETATM 2236  O   HOH A2099      33.104   3.539  39.305  1.00 37.13           O  
+ANISOU 2236  O   HOH A2099     4745   4773   4586     27    -61    159       O  
+HETATM 2237  O   HOH A2100      35.082   3.738  35.212  1.00 54.49           O  
+ANISOU 2237  O   HOH A2100     6735   7131   6837    -71    -30      1       O  
+HETATM 2238  O   HOH A2101      32.578   2.175  27.901  1.00 21.52           O  
+ANISOU 2238  O   HOH A2101     2840   3255   2081    468    183    585       O  
+HETATM 2239  O   HOH A2102      40.159  -3.562  31.360  1.00 44.77           O  
+ANISOU 2239  O   HOH A2102     5771   5565   5672     -9    -87     -6       O  
+HETATM 2240  O   HOH A2103      41.679  -4.552  27.363  1.00 27.40           O  
+ANISOU 2240  O   HOH A2103     3570   2985   3854     30   -120    297       O  
+HETATM 2241  O   HOH A2104       4.705  -1.931  16.031  1.00 10.91           O  
+ANISOU 2241  O   HOH A2104     1329   1377   1436   -224   -275    103       O  
+HETATM 2242  O   HOH A2105      21.786  -9.584  23.678  1.00 38.51           O  
+ANISOU 2242  O   HOH A2105     5108   4773   4750     85   -233    138       O  
+HETATM 2243  O   HOH A2106       7.980   4.946  11.686  1.00  9.01           O  
+ANISOU 2243  O   HOH A2106     1041    966   1416      2   -165     26       O  
+HETATM 2244  O   HOH A2107      11.452  -0.775  19.251  1.00  8.33           O  
+ANISOU 2244  O   HOH A2107     1161   1001   1003    194   -101    190       O  
+HETATM 2245  O   HOH A2108       5.289   2.227  11.694  1.00 10.31           O  
+ANISOU 2245  O   HOH A2108     1182   1438   1295    110   -224    432       O  
+HETATM 2246  O   HOH A2109      11.573  -8.172  12.814  1.00 10.97           O  
+ANISOU 2246  O   HOH A2109      977   1085   2106    -21    -99   -395       O  
+HETATM 2247  O   HOH A2110      11.338  -3.910  16.988  1.00  8.10           O  
+ANISOU 2247  O   HOH A2110     1005   1024   1049   -133   -149    182       O  
+HETATM 2248  O   HOH A2111      21.880  -7.363   4.283  1.00 21.39           O  
+ANISOU 2248  O   HOH A2111     2974   2571   2580    -67   -209    508       O  
+HETATM 2249  O   HOH A2112      27.493  -6.710   5.052  1.00 26.63           O  
+ANISOU 2249  O   HOH A2112     3423   2675   4017    -99   -352   -232       O  
+HETATM 2250  O   HOH A2113      30.561   5.802   4.261  1.00 24.38           O  
+ANISOU 2250  O   HOH A2113     3677   3402   2184    930     58   -173       O  
+HETATM 2251  O   HOH A2114       7.558  -6.306   8.697  1.00 19.54           O  
+ANISOU 2251  O   HOH A2114     2945   1535   2943   -434    -48    117       O  
+HETATM 2252  O   HOH A2115      34.133   4.882   4.404  1.00 23.74           O  
+ANISOU 2252  O   HOH A2115     3426   3506   2088    413    575    322       O  
+HETATM 2253  O   HOH A2116       4.978   3.277   9.224  1.00 23.07           O  
+ANISOU 2253  O   HOH A2116     3857   2554   2352    556   -214    187       O  
+HETATM 2254  O   HOH A2117       9.907   5.979   8.838  1.00 24.21           O  
+ANISOU 2254  O   HOH A2117     3292   2563   3340    321    297    260       O  
+HETATM 2255  O   HOH A2118      17.958  -5.179   5.492  1.00 21.46           O  
+ANISOU 2255  O   HOH A2118     3162   2208   2785    -59     54    185       O  
+HETATM 2256  O   HOH A2119      14.047  -4.470   3.502  1.00 31.68           O  
+ANISOU 2256  O   HOH A2119     4138   4423   3476    -65    -32    -11       O  
+HETATM 2257  O   HOH A2120       2.670   0.056   4.263  1.00 30.22           O  
+ANISOU 2257  O   HOH A2120     3958   3427   4097    139    -29    278       O  
+HETATM 2258  O   HOH A2121      12.799   3.320   4.609  1.00 27.19           O  
+ANISOU 2258  O   HOH A2121     3520   3735   3075    239   -136   -172       O  
+HETATM 2259  O   HOH A2122      10.979   4.989   3.514  1.00 43.03           O  
+ANISOU 2259  O   HOH A2122     5503   5586   5260     39   -117    156       O  
+HETATM 2260  O   HOH A2123       6.399  -5.643   4.727  1.00 36.69           O  
+ANISOU 2260  O   HOH A2123     4847   4629   4462    -41    -91    -49       O  
+HETATM 2261  O   HOH A2124      12.051  -6.876   6.103  1.00 27.34           O  
+ANISOU 2261  O   HOH A2124     3288   3510   3588   -349   -189      2       O  
+HETATM 2262  O   HOH A2125      -0.667  -1.709   8.400  1.00 21.97           O  
+ANISOU 2262  O   HOH A2125     1959   4072   2314     11   -189   -335       O  
+HETATM 2263  O   HOH A2126       0.926   0.848   7.420  1.00 20.63           O  
+ANISOU 2263  O   HOH A2126     2147   3183   2506    741   -752     75       O  
+HETATM 2264  O   HOH A2127      -1.331  -3.725  11.246  1.00 30.36           O  
+ANISOU 2264  O   HOH A2127     3445   4012   4078   -144     -5     99       O  
+HETATM 2265  O   HOH A2128      24.780 -12.034  16.131  1.00 21.69           O  
+ANISOU 2265  O   HOH A2128     3110   1556   3574    -60   -470    330       O  
+HETATM 2266  O   HOH A2129       3.576  -7.247  10.713  1.00 25.61           O  
+ANISOU 2266  O   HOH A2129     2936   3210   3584   -290   -390   -308       O  
+HETATM 2267  O   HOH A2130      -2.716  -4.238  14.355  1.00 26.60           O  
+ANISOU 2267  O   HOH A2130     2678   3173   4255   -339     83   -181       O  
+HETATM 2268  O   HOH A2131       5.045  -6.767  14.891  1.00 19.66           O  
+ANISOU 2268  O   HOH A2131     3090   2113   2264    139   -353   -155       O  
+HETATM 2269  O   HOH A2132       7.670  -6.854  11.944  1.00 19.02           O  
+ANISOU 2269  O   HOH A2132     1650   2001   3573    -68   -753  -1041       O  
+HETATM 2270  O   HOH A2133       6.020  -1.542  13.564  1.00  9.81           O  
+ANISOU 2270  O   HOH A2133      880   1140   1707    -88   -358    162       O  
+HETATM 2271  O   HOH A2134      -2.941  -1.884  18.606  1.00 16.23           O  
+ANISOU 2271  O   HOH A2134     1594   1970   2600     56    321   -268       O  
+HETATM 2272  O   HOH A2135      42.069  -4.840  25.096  1.00 26.31           O  
+ANISOU 2272  O   HOH A2135     3164   3028   3802    322   -521    300       O  
+HETATM 2273  O   HOH A2136      46.314   5.436  24.643  1.00 22.69           O  
+ANISOU 2273  O   HOH A2136     3098   2562   2958    -41   -293    -65       O  
+HETATM 2274  O   HOH A2137      41.586  -2.469  28.906  1.00 36.38           O  
+ANISOU 2274  O   HOH A2137     4739   4633   4448   -312    -81    197       O  
+HETATM 2275  O   HOH A2138      -0.842  -5.192  20.184  1.00 28.81           O  
+ANISOU 2275  O   HOH A2138     3455   3540   3949   -209    -65    137       O  
+HETATM 2276  O   HOH A2139       2.518   0.114  22.588  1.00 11.47           O  
+ANISOU 2276  O   HOH A2139     1439   1378   1541   -267     98    104       O  
+HETATM 2277  O   HOH A2140       1.670  -2.578  22.663  1.00 30.46           O  
+ANISOU 2277  O   HOH A2140     4293   3546   3732   -113     59    230       O  
+HETATM 2278  O   HOH A2141      43.923  -1.485  28.201  1.00 45.41           O  
+ANISOU 2278  O   HOH A2141     5695   5706   5850     70   -155     84       O  
+HETATM 2279  O   HOH A2142      42.262  -5.868  19.287  1.00 22.67           O  
+ANISOU 2279  O   HOH A2142     2692   2357   3562     68    127    361       O  
+HETATM 2280  O   HOH A2143      44.199  12.055  25.644  1.00 31.27           O  
+ANISOU 2280  O   HOH A2143     3576   4241   4064     -6     98    122       O  
+HETATM 2281  O   HOH A2144      41.153  14.663  13.770  1.00 34.80           O  
+ANISOU 2281  O   HOH A2144     4186   4594   4441   -216     49    249       O  
+HETATM 2282  O   HOH A2145       1.511   6.926  24.841  1.00 26.00           O  
+ANISOU 2282  O   HOH A2145     3359   2804   3715    -11    602   -168       O  
+HETATM 2283  O   HOH A2146      38.565  15.909  20.616  1.00 30.19           O  
+ANISOU 2283  O   HOH A2146     3829   3476   4164    278   -186    -43       O  
+HETATM 2284  O   HOH A2147      37.484  14.355  11.586  1.00 31.02           O  
+ANISOU 2284  O   HOH A2147     3990   3858   3937     15    305    202       O  
+HETATM 2285  O   HOH A2148      40.606  14.710  26.253  1.00 40.62           O  
+ANISOU 2285  O   HOH A2148     5021   5207   5205    -98   -185    -22       O  
+HETATM 2286  O   HOH A2149       0.174   9.045  21.317  1.00 12.79           O  
+ANISOU 2286  O   HOH A2149     1330   1680   1849   -224     30   -352       O  
+HETATM 2287  O   HOH A2150       1.121  12.371  19.118  1.00 18.22           O  
+ANISOU 2287  O   HOH A2150     2510   2309   2103    383   -260     -5       O  
+HETATM 2288  O   HOH A2151      33.385  11.964  34.102  1.00 25.17           O  
+ANISOU 2288  O   HOH A2151     2997   3205   3360   -317     72    -81       O  
+HETATM 2289  O   HOH A2152       1.982  13.786  21.666  1.00 19.13           O  
+ANISOU 2289  O   HOH A2152     1178   2427   3660    260   -215  -1423       O  
+HETATM 2290  O   HOH A2153       5.351  15.835  16.056  1.00 29.96           O  
+ANISOU 2290  O   HOH A2153     3905   3681   3795     -4     -8   -177       O  
+HETATM 2291  O   HOH A2154       2.993  13.579  17.492  1.00 24.30           O  
+ANISOU 2291  O   HOH A2154     3109   2911   3211   -361   -136   -602       O  
+HETATM 2292  O   HOH A2155       9.342  20.184  20.101  1.00 26.30           O  
+ANISOU 2292  O   HOH A2155     2800   3536   3654     94    -54   -147       O  
+HETATM 2293  O   HOH A2156       6.995  22.323  23.767  1.00 25.16           O  
+ANISOU 2293  O   HOH A2156     2974   2401   4182     24      1    275       O  
+HETATM 2294  O   HOH A2157       6.478  19.195  28.216  1.00 26.52           O  
+ANISOU 2294  O   HOH A2157     3130   3604   3339    542    265   -226       O  
+HETATM 2295  O   HOH A2158      10.865  22.897  23.574  1.00 21.09           O  
+ANISOU 2295  O   HOH A2158     2438   1718   3858     70    -41    332       O  
+HETATM 2296  O   HOH A2159      41.320  -7.431  15.240  1.00 38.22           O  
+ANISOU 2296  O   HOH A2159     5251   4296   4975   -177    -35     49       O  
+HETATM 2297  O   HOH A2160      40.529 -10.091   8.585  1.00 32.50           O  
+ANISOU 2297  O   HOH A2160     4056   3829   4460    -47    233    -41       O  
+HETATM 2298  O   HOH A2161      34.011  -8.544   6.283  1.00 34.22           O  
+ANISOU 2298  O   HOH A2161     4156   4466   4381     45    235   -351       O  
+HETATM 2299  O   HOH A2162      32.884 -10.910   7.750  1.00 31.64           O  
+ANISOU 2299  O   HOH A2162     3931   4030   4059   -194    -71    129       O  
+HETATM 2300  O   HOH A2163      31.263  -8.699   6.346  1.00 27.85           O  
+ANISOU 2300  O   HOH A2163     3735   3442   3405     67    122     44       O  
+HETATM 2301  O   HOH A2164      12.334  23.596  30.387  1.00 25.21           O  
+ANISOU 2301  O   HOH A2164     3423   2744   3409     14   -140     68       O  
+HETATM 2302  O   HOH A2165       7.933  22.732  31.533  1.00 33.93           O  
+ANISOU 2302  O   HOH A2165     3940   4532   4418    144    171    150       O  
+HETATM 2303  O   HOH A2166      18.773  21.841  22.849  1.00  8.21           O  
+ANISOU 2303  O   HOH A2166     1092    856   1169     10    -75      3       O  
+HETATM 2304  O   HOH A2167      13.351  21.967  19.613  1.00 13.91           O  
+ANISOU 2304  O   HOH A2167     1613   1494   2176    324    -89   -287       O  
+HETATM 2305  O   HOH A2168      13.124  19.437  18.714  1.00 14.33           O  
+ANISOU 2305  O   HOH A2168     1564   2394   1488    585    -89   -527       O  
+HETATM 2306  O   HOH A2169      11.503  20.497  21.715  1.00 19.93           O  
+ANISOU 2306  O   HOH A2169     2190   3084   2299    305    277    425       O  
+HETATM 2307  O   HOH A2170      20.691  22.712  26.634  1.00  9.17           O  
+ANISOU 2307  O   HOH A2170     1130   1000   1354    -50    -24   -138       O  
+HETATM 2308  O   HOH A2171      27.883  16.906  32.364  1.00 18.71           O  
+ANISOU 2308  O   HOH A2171     2435   2996   1677    128   -437     15       O  
+HETATM 2309  O   HOH A2172      21.118  -8.246  32.340  1.00 46.95           O  
+ANISOU 2309  O   HOH A2172     5788   5992   6057     39    157    -14       O  
+HETATM 2310  O   HOH A2173      25.951  26.456  26.064  1.00 11.59           O  
+ANISOU 2310  O   HOH A2173     1452   1217   1734    -57     32   -160       O  
+HETATM 2311  O   HOH A2174      32.047  22.487  25.217  1.00 15.17           O  
+ANISOU 2311  O   HOH A2174     1772   1932   2058   -284   -200   -167       O  
+HETATM 2312  O   HOH A2175      32.564  21.310  29.842  1.00 34.02           O  
+ANISOU 2312  O   HOH A2175     4261   4275   4389     36   -181   -231       O  
+HETATM 2313  O   HOH A2176      27.815  22.384  30.682  1.00 24.73           O  
+ANISOU 2313  O   HOH A2176     3731   3168   2496    309     34   -291       O  
+HETATM 2314  O   HOH A2177      25.575  19.274  15.456  1.00 14.21           O  
+ANISOU 2314  O   HOH A2177     1485   1448   2465   -200   -277    464       O  
+HETATM 2315  O   HOH A2178      34.508  21.876  23.903  1.00 15.29           O  
+ANISOU 2315  O   HOH A2178     1984   1787   2039   -449   -176   -100       O  
+HETATM 2316  O   HOH A2179      33.306   7.432   4.027  1.00 24.37           O  
+ANISOU 2316  O   HOH A2179     3135   2519   3605      4    259   -389       O  
+HETATM 2317  O   HOH A2180      28.424  18.986  13.450  1.00 23.79           O  
+ANISOU 2317  O   HOH A2180     2625   3165   3246    321    -20   -204       O  
+HETATM 2318  O   HOH A2181      30.931  22.655  14.062  1.00 25.28           O  
+ANISOU 2318  O   HOH A2181     3048   3151   3404    173    394    430       O  
+HETATM 2319  O   HOH A2182      31.553  16.814  13.764  1.00 19.69           O  
+ANISOU 2319  O   HOH A2182     2459   2198   2823   -157     38   -171       O  
+HETATM 2320  O   HOH A2183      37.172  17.606  14.635  1.00 31.26           O  
+ANISOU 2320  O   HOH A2183     3713   3900   4263    136    316   -185       O  
+HETATM 2321  O   HOH A2184      32.735  21.258  12.598  1.00 21.56           O  
+ANISOU 2321  O   HOH A2184     2905   2745   2540   -437   -181   -230       O  
+HETATM 2322  O   HOH A2185      33.925  15.346  14.465  1.00 19.01           O  
+ANISOU 2322  O   HOH A2185     3091   1755   2378    292   -125    -30       O  
+HETATM 2323  O   HOH A2186      39.208  19.528  14.595  1.00 42.89           O  
+ANISOU 2323  O   HOH A2186     5310   5403   5580     69     12   -100       O  
+HETATM 2324  O   HOH A2187      38.053  22.143  13.154  1.00 61.85           O  
+ANISOU 2324  O   HOH A2187     7928   7784   7786     -2     25    -16       O  
+HETATM 2325  O   HOH A2188      37.749  21.403  17.283  1.00 26.52           O  
+ANISOU 2325  O   HOH A2188     3342   3021   3713    -59    298    164       O  
+HETATM 2326  O   HOH A2189      41.841  -6.731   9.678  1.00 64.04           O  
+ANISOU 2326  O   HOH A2189     8047   8082   8200     53     -3      3       O  
+HETATM 2327  O   HOH A2190      42.272  -6.283  13.049  1.00 35.34           O  
+ANISOU 2327  O   HOH A2190     4330   4305   4792     69    217     -1       O  
+HETATM 2328  O   HOH A2191      36.024  18.750  22.812  1.00 19.59           O  
+ANISOU 2328  O   HOH A2191     2602   2477   2364  -1115   -436    308       O  
+HETATM 2329  O   HOH A2192      36.356  13.823  18.004  1.00 15.04           O  
+ANISOU 2329  O   HOH A2192     1753   1768   2191    354    358    325       O  
+HETATM 2330  O   HOH A2193      30.956  11.461  20.947  1.00  9.78           O  
+ANISOU 2330  O   HOH A2193     1097   1323   1295    347   -282   -173       O  
+HETATM 2331  O   HOH A2194      38.132   5.449  32.884  1.00 36.88           O  
+ANISOU 2331  O   HOH A2194     4581   4833   4598    -16    183     68       O  
+HETATM 2332  O   HOH A2195      36.283  16.344  27.782  1.00 20.76           O  
+ANISOU 2332  O   HOH A2195     2453   3117   2315    -46  -1082     11       O  
+HETATM 2333  O   HOH A2196      35.189  19.730  25.030  1.00 29.94           O  
+ANISOU 2333  O   HOH A2196     3730   3405   4240   -235   -174   -109       O  
+HETATM 2334  O   HOH A2197      31.394  16.814  30.301  1.00 19.68           O  
+ANISOU 2334  O   HOH A2197     3138   2648   1690    270   -458   -407       O  
+HETATM 2335  O   HOH A2198      33.253  19.399  28.134  1.00 19.95           O  
+ANISOU 2335  O   HOH A2198     1885   2772   2922   -300   -872   -535       O  
+HETATM 2336  O   HOH A2199      17.705   9.444  35.778  1.00 72.97           O  
+ANISOU 2336  O   HOH A2199     9299   9255   9170     50     -2    -39       O  
+HETATM 2337  O   HOH A2200      27.687  16.397  36.214  1.00 32.98           O  
+ANISOU 2337  O   HOH A2200     4305   4012   4213    190    250   -356       O  
+HETATM 2338  O   HOH A2201      13.075  13.809  38.482  1.00 22.41           O  
+ANISOU 2338  O   HOH A2201     2229   3033   3252    -10    259    -65       O  
+HETATM 2339  O   HOH A2202      16.788  13.873  40.749  1.00 33.98           O  
+ANISOU 2339  O   HOH A2202     4440   4514   3956    -84   -107    -27       O  
+HETATM 2340  O   HOH A2203       7.582  18.184  34.247  1.00 66.05           O  
+ANISOU 2340  O   HOH A2203     8328   8440   8326     24     58     42       O  
+HETATM 2341  O   HOH A2204       6.384  20.229  30.312  1.00 27.93           O  
+ANISOU 2341  O   HOH A2204     3304   4123   3182    243    -46   -169       O  
+HETATM 2342  O   HOH A2205       1.293  16.630  19.572  1.00 31.84           O  
+ANISOU 2342  O   HOH A2205     3934   4017   4147    330   -168    119       O  
+HETATM 2343  O   HOH A2206       3.292  18.286  27.919  1.00 24.99           O  
+ANISOU 2343  O   HOH A2206     3725   2704   3066    266    430   -353       O  
+HETATM 2344  O   HOH A2207       2.951  19.248  19.816  1.00 46.40           O  
+ANISOU 2344  O   HOH A2207     5754   6087   5787     19     27     95       O  
+HETATM 2345  O   HOH A2208       0.842  13.956  23.398  1.00 23.87           O  
+ANISOU 2345  O   HOH A2208     3035   3172   2861    -10    361     21       O  
+HETATM 2346  O   HOH A2209       0.920   9.485  25.734  1.00 24.28           O  
+ANISOU 2346  O   HOH A2209     2982   3299   2944   -114   -217     47       O  
+HETATM 2347  O   HOH A2210       0.084   8.858  28.237  1.00 25.54           O  
+ANISOU 2347  O   HOH A2210     2457   3612   3634      0   -134   -247       O  
+HETATM 2348  O   HOH A2211       2.601   6.145  31.540  1.00 27.16           O  
+ANISOU 2348  O   HOH A2211     3671   3873   2776    -71    461     18       O  
+HETATM 2349  O   HOH A2212      -2.413   3.123  28.797  1.00 23.04           O  
+ANISOU 2349  O   HOH A2212     3085   2874   2795   -281   -383     48       O  
+HETATM 2350  O   HOH A2213       1.309  -1.906  30.965  1.00 39.18           O  
+ANISOU 2350  O   HOH A2213     5006   4956   4924    -48     10     98       O  
+HETATM 2351  O   HOH A2214       5.349  -1.532  32.334  1.00 28.08           O  
+ANISOU 2351  O   HOH A2214     3003   3741   3923    195    409    223       O  
+HETATM 2352  O   HOH A2215       7.501  -1.740  30.595  1.00 16.76           O  
+ANISOU 2352  O   HOH A2215     1492   2354   2519   -313     80    145       O  
+HETATM 2353  O   HOH A2216       8.315  -4.270  30.814  1.00 30.60           O  
+ANISOU 2353  O   HOH A2216     4099   3504   4022    126     39    338       O  
+HETATM 2354  O   HOH A2217       1.852  -4.471  24.377  1.00 33.92           O  
+ANISOU 2354  O   HOH A2217     4540   3851   4494   -293     83   -148       O  
+HETATM 2355  O   HOH A2218       9.735  -5.698  28.215  1.00 29.52           O  
+ANISOU 2355  O   HOH A2218     3336   3799   4081   -166    -68    468       O  
+HETATM 2356  O   HOH A2219       2.328  -5.531  28.215  1.00 22.40           O  
+ANISOU 2356  O   HOH A2219     2569   2541   3400   -329    476    414       O  
+HETATM 2357  O   HOH A2220       6.715  -8.662  22.085  1.00 36.68           O  
+ANISOU 2357  O   HOH A2220     4862   4490   4584     82      5    177       O  
+HETATM 2358  O   HOH A2221       9.484  -2.080  20.719  1.00 11.08           O  
+ANISOU 2358  O   HOH A2221     1225   1542   1442    -50     91    280       O  
+HETATM 2359  O   HOH A2222       0.155  -7.772  19.683  1.00 91.94           O  
+ANISOU 2359  O   HOH A2222    11624  11631  11676     18    -19     -5       O  
+HETATM 2360  O   HOH A2223      10.595   3.495  33.810  1.00 17.24           O  
+ANISOU 2360  O   HOH A2223     2145   2680   1725    179    567    150       O  
+HETATM 2361  O   HOH A2224      11.955  -1.330  31.945  1.00 18.21           O  
+ANISOU 2361  O   HOH A2224     2025   2644   2249   -140    165    708       O  
+HETATM 2362  O   HOH A2225      14.291   1.296  33.272  1.00 25.82           O  
+ANISOU 2362  O   HOH A2225     2664   4272   2872    -25     98    319       O  
+HETATM 2363  O   HOH A2226      13.902  -2.717  28.740  1.00 21.57           O  
+ANISOU 2363  O   HOH A2226     2639   2594   2959   -186    537    -41       O  
+HETATM 2364  O   HOH A2227       9.528  -0.149  31.513  1.00 14.43           O  
+ANISOU 2364  O   HOH A2227     1457   2328   1696   -339    257    675       O  
+HETATM 2365  O   HOH A2228      16.256  -2.306  36.845  1.00 81.96           O  
+ANISOU 2365  O   HOH A2228    10433  10388  10320     23     14    -10       O  
+HETATM 2366  O   HOH A2229      14.255  -1.063  33.651  1.00 40.71           O  
+ANISOU 2366  O   HOH A2229     5152   5143   5172    -82     62     -4       O  
+HETATM 2367  O   HOH A2230      16.823   1.951  37.059  1.00 37.65           O  
+ANISOU 2367  O   HOH A2230     4988   4968   4348     57    255    195       O  
+HETATM 2368  O   HOH A2231      17.929  -0.384  37.687  1.00 87.70           O  
+ANISOU 2368  O   HOH A2231    11096  11140  11085     -7     26     -1       O  
+HETATM 2369  O   HOH A2232      16.951  -2.138  31.956  1.00 22.72           O  
+ANISOU 2369  O   HOH A2232     4179   2236   2218    -96    -14    714       O  
+HETATM 2370  O   HOH A2233      17.530   4.022  35.345  1.00 18.60           O  
+ANISOU 2370  O   HOH A2233     2748   2613   1705   -161    418   -198       O  
+HETATM 2371  O   HOH A2234      22.132   1.002  37.103  1.00 52.81           O  
+ANISOU 2371  O   HOH A2234     6648   6778   6638     32    -26     25       O  
+HETATM 2372  O   HOH A2235      20.117   2.149  37.487  1.00 17.51           O  
+ANISOU 2372  O   HOH A2235     2238   2388   2026    198     21    109       O  
+HETATM 2373  O   HOH A2236      22.394   5.878  37.591  1.00 21.70           O  
+ANISOU 2373  O   HOH A2236     3094   2842   2309   -306    241    -45       O  
+HETATM 2374  O   HOH A2237      25.835  -0.137  36.140  1.00 19.34           O  
+ANISOU 2374  O   HOH A2237     3051   2283   2014   -182  -1026    495       O  
+HETATM 2375  O   HOH A2238      28.484  -1.009  39.484  1.00 31.70           O  
+ANISOU 2375  O   HOH A2238     3843   3985   4215   -113     81    381       O  
+HETATM 2376  O   HOH A2239      34.484   0.064  34.482  1.00 55.79           O  
+ANISOU 2376  O   HOH A2239     7002   7094   7100     43    -73     11       O  
+HETATM 2377  O   HOH A2240      32.520   3.912  36.956  1.00 19.88           O  
+ANISOU 2377  O   HOH A2240     2161   3024   2367   -545   -359   -242       O  
+HETATM 2378  O   HOH A2241      35.025   1.469  28.692  1.00 26.65           O  
+ANISOU 2378  O   HOH A2241     3375   3502   3247    233    -92   -535       O  
+HETATM 2379  O   HOH A2242      31.044   2.446  29.963  1.00 16.75           O  
+ANISOU 2379  O   HOH A2242     2081   2861   1421    582   -141    772       O  
+HETATM 2380  O   HOH A2243      36.875  -6.159  32.818  1.00 37.32           O  
+ANISOU 2380  O   HOH A2243     4699   4467   5011    204   -107     11       O  
+HETATM 2381  O   HOH A2244      38.515  -5.567  30.798  1.00 23.11           O  
+ANISOU 2381  O   HOH A2244     2794   3398   2588    332   -435    472       O  
+HETATM 2382  O   HOH A2245      38.129  -1.503  31.037  1.00 24.17           O  
+ANISOU 2382  O   HOH A2245     3350   2986   2847   -103   -368   -288       O  
+HETATM 2383  O   HOH A2246      39.484  -6.924  28.380  1.00 35.97           O  
+ANISOU 2383  O   HOH A2246     4477   4796   4392    156   -140     15       O  
+HETATM 2384  O   HOH A2247      33.187  -9.919  23.344  1.00 27.03           O  
+ANISOU 2384  O   HOH A2247     3251   3250   3768    -93    -95     31       O  
+HETATM 2385  O   HOH A2248      38.890  -7.276  25.851  1.00 16.83           O  
+ANISOU 2385  O   HOH A2248     2123   1636   2634     15   -426    300       O  
+HETATM 2386  O   HOH A2249      26.718 -10.381  25.093  1.00 25.96           O  
+ANISOU 2386  O   HOH A2249     3218   2786   3859   -339    128    112       O  
+HETATM 2387  O   HOH A2250      30.957  -9.744  19.822  1.00 23.15           O  
+ANISOU 2387  O   HOH A2250     3024   3009   2762    171   -288   -178       O  
+HETATM 2388  O   HOH A2251      29.989 -12.816  25.128  1.00 18.37           O  
+ANISOU 2388  O   HOH A2251     2389   2045   2544    -32   -215    561       O  
+HETATM 2389  O   HOH A2252      25.148  -8.718  23.496  1.00 25.58           O  
+ANISOU 2389  O   HOH A2252     3617   2570   3529   -360    -64    494       O  
+HETATM 2390  O   HOH A2253      19.616   3.424  16.674  1.00  5.52           O  
+ANISOU 2390  O   HOH A2253      803    702    590    -41     39     35       O  
+HETATM 2391  O   HOH A2254      15.516   2.536   7.794  1.00 11.32           O  
+ANISOU 2391  O   HOH A2254     1402   1723   1175     94   -237    212       O  
+HETATM 2392  O   HOH A2255      18.151   5.269   8.642  1.00 20.80           O  
+ANISOU 2392  O   HOH A2255     2934   2570   2398     50    -61    -27       O  
+HETATM 2393  O   HOH A2256      20.095  -1.047  10.586  1.00  6.31           O  
+ANISOU 2393  O   HOH A2256      827    687    881    -74    -53     74       O  
+HETATM 2394  O   HOH A2257      22.389  -4.841   3.165  1.00 23.07           O  
+ANISOU 2394  O   HOH A2257     3854   2577   2333     37    296   -238       O  
+HETATM 2395  O   HOH A2258      26.136  -4.774   3.532  1.00 22.04           O  
+ANISOU 2395  O   HOH A2258     3107   2480   2786    234    534    255       O  
+HETATM 2396  O   HOH A2259      24.613  -5.462   6.651  1.00 13.23           O  
+ANISOU 2396  O   HOH A2259     2545   1263   1217    -68   -353   -165       O  
+HETATM 2397  O   HOH A2260      23.490  -5.103  -3.352  1.00 41.24           O  
+ANISOU 2397  O   HOH A2260     5368   5322   4978     48    -60    -61       O  
+HETATM 2398  O   HOH A2261      20.373  -3.463  -2.733  1.00 27.95           O  
+ANISOU 2398  O   HOH A2261     3275   4314   3030    164   -545    191       O  
+HETATM 2399  O   HOH A2262      27.661   3.685   4.236  1.00 23.94           O  
+ANISOU 2399  O   HOH A2262     3160   2539   3394   -452    510    -56       O  
+HETATM 2400  O   HOH A2263      31.759   3.627   5.151  1.00 16.97           O  
+ANISOU 2400  O   HOH A2263     3849   1453   1145    149    214    221       O  
+HETATM 2401  O   HOH A2264      30.947  -4.120   4.907  1.00 33.99           O  
+ANISOU 2401  O   HOH A2264     4264   4522   4125    214    195    136       O  
+HETATM 2402  O   HOH A2265      28.314  -3.285   3.107  1.00 22.54           O  
+ANISOU 2402  O   HOH A2265     2683   2890   2992    237    213   -486       O  
+HETATM 2403  O   HOH A2266      26.309  -0.952  -2.733  1.00 67.06           O  
+ANISOU 2403  O   HOH A2266     8497   8517   8464     48     -3    -22       O  
+HETATM 2404  O   HOH A2267      32.084   4.098   0.599  1.00 38.61           O  
+ANISOU 2404  O   HOH A2267     4972   4729   4969     -1   -139    -23       O  
+HETATM 2405  O   HOH A2268      28.556  -1.896   0.552  1.00 32.33           O  
+ANISOU 2405  O   HOH A2268     4371   4233   3679    -32    177    -85       O  
+HETATM 2406  O   HOH A2269      24.204   0.642  -2.704  1.00 40.88           O  
+ANISOU 2406  O   HOH A2269     5272   5338   4920   -129    -61    -62       O  
+HETATM 2407  O   HOH A2270      20.229   2.833  -2.325  1.00 40.87           O  
+ANISOU 2407  O   HOH A2270     5174   5126   5227   -120      1      9       O  
+HETATM 2408  O   HOH A2271      20.720  -0.633  -1.848  1.00 29.25           O  
+ANISOU 2408  O   HOH A2271     4080   3822   3212    -12   -422    230       O  
+HETATM 2409  O   HOH A2272      21.150  -5.043   0.881  1.00 29.64           O  
+ANISOU 2409  O   HOH A2272     4142   4012   3106     93   -193   -187       O  
+HETATM 2410  O   HOH A2273      18.266  -1.750  -0.424  1.00 28.03           O  
+ANISOU 2410  O   HOH A2273     3766   4098   2785   -335   -356    -35       O  
+HETATM 2411  O   HOH A2274      18.571  -2.718   4.358  1.00 19.52           O  
+ANISOU 2411  O   HOH A2274     2316   2585   2514    167    143     86       O  
+HETATM 2412  O   HOH A2275      19.164  -3.867  -0.580  1.00 34.64           O  
+ANISOU 2412  O   HOH A2275     4743   4565   3853     10     59    128       O  
+HETATM 2413  O   HOH A2276      16.173  -0.896   1.254  1.00 35.82           O  
+ANISOU 2413  O   HOH A2276     4290   4615   4706    -21   -115   -124       O  
+HETATM 2414  O   HOH A2277      23.194   7.076   3.652  1.00 26.85           O  
+ANISOU 2414  O   HOH A2277     3474   2383   4342   -241    530    189       O  
+HETATM 2415  O   HOH A2278      15.869  -2.807   2.702  1.00 33.32           O  
+ANISOU 2415  O   HOH A2278     4136   4817   3707   -134    -49   -101       O  
+HETATM 2416  O   HOH A2279      13.439   0.649   3.925  1.00 21.55           O  
+ANISOU 2416  O   HOH A2279     2660   3061   2467     29   -448    144       O  
+HETATM 2417  O   HOH A2280      17.300   2.023   1.073  1.00 19.18           O  
+ANISOU 2417  O   HOH A2280     2592   2731   1963    379   -606    166       O  
+HETATM 2418  O   HOH A2281      14.538  -5.112   6.604  1.00  9.78           O  
+ANISOU 2418  O   HOH A2281     2083    884    749   -483   -124    -35       O  
+HETATM 2419  O   HOH A2282      10.940  -3.537   1.375  1.00 29.54           O  
+ANISOU 2419  O   HOH A2282     3605   4142   3476    -18   -202      1       O  
+HETATM 2420  O   HOH A2283       7.843  -3.226   4.647  1.00 18.09           O  
+ANISOU 2420  O   HOH A2283     2425   3092   1354    -52   -422    -28       O  
+HETATM 2421  O   HOH A2284       9.640   0.034   2.751  1.00 27.73           O  
+ANISOU 2421  O   HOH A2284     3406   3745   3384    -14   -386    309       O  
+HETATM 2422  O   HOH A2285      13.613  -6.660  14.162  1.00  8.25           O  
+ANISOU 2422  O   HOH A2285      863    761   1508    -79    -14    139       O  
+HETATM 2423  O   HOH A2286      16.653  -8.554   6.507  1.00 25.74           O  
+ANISOU 2423  O   HOH A2286     3893   3229   2657   -308   -475    -71       O  
+HETATM 2424  O   HOH A2287      19.890  -7.133   5.935  1.00 17.86           O  
+ANISOU 2424  O   HOH A2287     2754   2202   1830     69   -518    -49       O  
+HETATM 2425  O   HOH A2288      23.820 -11.366  23.517  1.00 25.23           O  
+ANISOU 2425  O   HOH A2288     3633   3540   2413     96    250   -197       O  
+HETATM 2426  O   HOH A2289      26.173  -9.654  15.864  1.00 12.04           O  
+ANISOU 2426  O   HOH A2289     1974    973   1625   -238    107   -142       O  
+HETATM 2427  O   HOH A2290      20.733 -13.180  21.079  1.00 22.60           O  
+ANISOU 2427  O   HOH A2290     2645   3383   2556   -584     -8     12       O  
+HETATM 2428  O   HOH A2291      24.589 -14.745  22.895  1.00 15.63           O  
+ANISOU 2428  O   HOH A2291     2283   1782   1871     -7    131   -163       O  
+HETATM 2429  O   HOH A2292      38.044  -5.355  24.025  1.00 13.01           O  
+ANISOU 2429  O   HOH A2292     1615   1115   2211    183    127    280       O  
+HETATM 2430  O   HOH A2293      37.161   0.528  27.327  1.00 18.33           O  
+ANISOU 2430  O   HOH A2293     2272   2594   2099   -113   -305      1       O  
+HETATM 2431  O   HOH A2294      40.225  -3.845  23.204  1.00 13.51           O  
+ANISOU 2431  O   HOH A2294     1395   1182   2556    203   -326     30       O  
+HETATM 2432  O   HOH A2295      44.281  -2.821  24.548  1.00 23.31           O  
+ANISOU 2432  O   HOH A2295     2427   2288   4140    750    -66    356       O  
+HETATM 2433  O   HOH A2296      37.491   5.005  25.495  1.00 14.15           O  
+ANISOU 2433  O   HOH A2296     1874   1519   1981     58   -667    -88       O  
+HETATM 2434  O   HOH A2297      39.909   0.632  28.712  1.00 14.70           O  
+ANISOU 2434  O   HOH A2297     2334   1803   1447   -360   -308     14       O  
+HETATM 2435  O   HOH A2298      44.582   5.089  26.898  1.00 23.05           O  
+ANISOU 2435  O   HOH A2298     2794   2924   3038     54   -489    107       O  
+HETATM 2436  O   HOH A2299      38.942   8.322  26.803  1.00 18.34           O  
+ANISOU 2436  O   HOH A2299     3122   1832   2014    210    247   -372       O  
+HETATM 2437  O   HOH A2300      43.303   1.159  27.524  1.00 15.85           O  
+ANISOU 2437  O   HOH A2300     2012   2133   1875   -220   -565    417       O  
+HETATM 2438  O   HOH A2301      46.931  -0.042  26.965  1.00 17.75           O  
+ANISOU 2438  O   HOH A2301     2037   2320   2387    642   -207    267       O  
+HETATM 2439  O   HOH A2302      46.567   4.687  21.863  1.00 12.96           O  
+ANISOU 2439  O   HOH A2302      965   1750   2209    -13   -106    242       O  
+HETATM 2440  O   HOH A2303      41.003  -3.786  20.572  1.00 22.60           O  
+ANISOU 2440  O   HOH A2303     3158   2158   3270   -416    685    470       O  
+HETATM 2441  O   HOH A2304      42.776   0.174  17.279  1.00 17.87           O  
+ANISOU 2441  O   HOH A2304     2194   1801   2793     17   -170   -517       O  
+HETATM 2442  O   HOH A2305      47.140   6.726  19.853  1.00 10.63           O  
+ANISOU 2442  O   HOH A2305     1096   1280   1660   -114      5    -22       O  
+HETATM 2443  O   HOH A2306      40.658  10.352  27.268  1.00 25.03           O  
+ANISOU 2443  O   HOH A2306     2416   3005   4089    141    -11   -351       O  
+HETATM 2444  O   HOH A2307      45.286   9.802  26.035  1.00 22.88           O  
+ANISOU 2444  O   HOH A2307     2253   3112   3325   -245    -17   -221       O  
+HETATM 2445  O   HOH A2308      46.568   1.378  15.297  1.00 38.94           O  
+ANISOU 2445  O   HOH A2308     4908   4848   5036     22     95   -142       O  
+HETATM 2446  O   HOH A2309      46.787   0.521  21.796  1.00 22.94           O  
+ANISOU 2446  O   HOH A2309     1636   3142   3936    431   -220   -129       O  
+HETATM 2447  O   HOH A2310      44.982   3.709  13.417  1.00 17.94           O  
+ANISOU 2447  O   HOH A2310     3049   2199   1567    135    833     36       O  
+HETATM 2448  O   HOH A2311      42.154   9.878  20.702  1.00 16.11           O  
+ANISOU 2448  O   HOH A2311     1843   2118   2158    -57     68    -97       O  
+HETATM 2449  O   HOH A2312      43.306  14.080  15.185  1.00 24.09           O  
+ANISOU 2449  O   HOH A2312     2529   3036   3585     97    292    205       O  
+HETATM 2450  O   HOH A2313      44.880  10.489  21.521  1.00 13.51           O  
+ANISOU 2450  O   HOH A2313      833   1877   2421    -26    -10   -605       O  
+HETATM 2451  O   HOH A2314      39.813  16.592  18.910  1.00 31.72           O  
+ANISOU 2451  O   HOH A2314     3579   3909   4563    128     91   -245       O  
+HETATM 2452  O   HOH A2315      37.385  13.244  14.234  1.00 21.23           O  
+ANISOU 2452  O   HOH A2315     2494   2688   2883    -95   -401    -80       O  
+HETATM 2453  O   HOH A2316      38.490  10.515  11.733  1.00 32.50           O  
+ANISOU 2453  O   HOH A2316     4267   4238   3843    247    140    271       O  
+HETATM 2454  O   HOH A2317      42.141  11.588  22.028  1.00 26.30           O  
+ANISOU 2454  O   HOH A2317     2332   4290   3370    -36    -41     19       O  
+HETATM 2455  O   HOH A2318      41.349  12.098  25.702  1.00 27.09           O  
+ANISOU 2455  O   HOH A2318     3066   3859   3367    241   -374   -166       O  
+HETATM 2456  O   HOH A2319      36.910   7.620  29.320  1.00 28.98           O  
+ANISOU 2456  O   HOH A2319     3368   3500   4140    -54   -247    132       O  
+HETATM 2457  O   HOH A2320      34.575  12.664  31.619  1.00 25.84           O  
+ANISOU 2457  O   HOH A2320     2946   3852   3019   -196   -118   -182       O  
+HETATM 2458  O   HOH A2321      38.541  14.460  27.668  1.00 18.50           O  
+ANISOU 2458  O   HOH A2321     2465   2048   2516   -174   -768   -757       O  
+HETATM 2459  O   HOH A2322      30.821  12.365  23.792  1.00  9.24           O  
+ANISOU 2459  O   HOH A2322      944   1058   1508    132     31     52       O  
+HETATM 2460  O   HOH A2323      31.678  14.356  31.373  1.00 19.12           O  
+ANISOU 2460  O   HOH A2323     3368   2407   1489    438   -104   -237       O  
+HETATM 2461  O   HOH A2324      37.121   2.662  23.942  1.00  8.00           O  
+ANISOU 2461  O   HOH A2324      822   1131   1084     90   -137     67       O  
+HETATM 2462  O   HOH A2325      36.559  -6.699  18.230  1.00 12.53           O  
+ANISOU 2462  O   HOH A2325     1379   1322   2058    232   -126    250       O  
+HETATM 2463  O   HOH A2326      36.392  -2.583  11.459  1.00 13.80           O  
+ANISOU 2463  O   HOH A2326     1597   1469   2175    104     54     39       O  
+HETATM 2464  O   HOH A2327      39.367 -11.095  13.507  1.00 38.64           O  
+ANISOU 2464  O   HOH A2327     4811   4722   5146    -34   -151     51       O  
+HETATM 2465  O   HOH A2328      37.246  -9.418   8.021  1.00 29.22           O  
+ANISOU 2465  O   HOH A2328     3839   3856   3405    -22     12    222       O  
+HETATM 2466  O   HOH A2329      35.750 -10.614  15.683  1.00 17.06           O  
+ANISOU 2466  O   HOH A2329     2657   1410   2415    615   -392   -317       O  
+HETATM 2467  O   HOH A2330      38.319  -6.575  16.258  1.00 17.12           O  
+ANISOU 2467  O   HOH A2330     1861   1502   3140    352    145    628       O  
+HETATM 2468  O   HOH A2331      35.116  -9.603   8.855  1.00 30.39           O  
+ANISOU 2468  O   HOH A2331     4169   4025   3351    -60    -26     -4       O  
+HETATM 2469  O   HOH A2332      34.013  -8.077  11.719  1.00 21.55           O  
+ANISOU 2469  O   HOH A2332     2579   2889   2719    -93    -70    181       O  
+HETATM 2470  O   HOH A2333      29.659  -6.664   6.341  1.00 19.01           O  
+ANISOU 2470  O   HOH A2333     2530   3020   1670    329    257   -814       O  
+HETATM 2471  O   HOH A2334      33.729 -11.991  12.252  1.00 16.55           O  
+ANISOU 2471  O   HOH A2334     2416   1474   2397     95    -98   -185       O  
+HETATM 2472  O   HOH A2335      33.793  -3.584  11.402  1.00 13.29           O  
+ANISOU 2472  O   HOH A2335     1565   1529   1954     17    223    137       O  
+HETATM 2473  O   HOH A2336      33.420 -11.557  10.233  1.00 18.72           O  
+ANISOU 2473  O   HOH A2336     2424   1476   3212    110    127    152       O  
+HETATM 2474  O   HOH A2337      33.074  -1.655  14.376  1.00  9.59           O  
+ANISOU 2474  O   HOH A2337     1278    822   1542    -13   -327    362       O  
+HETATM 2475  O   HOH A2338      30.718  -9.845   8.659  1.00 21.63           O  
+ANISOU 2475  O   HOH A2338     2325   2720   3172   -410    201    -69       O  
+HETATM 2476  O   HOH A2339      32.224   3.809  12.450  1.00  6.92           O  
+ANISOU 2476  O   HOH A2339      845    757   1025    -48    124     43       O  
+HETATM 2477  O   HOH A2340      33.982  -0.531  12.075  1.00 11.18           O  
+ANISOU 2477  O   HOH A2340     1813   1094   1338   -302   -229    256       O  
+HETATM 2478  O   HOH A2341      27.712   8.937   4.914  1.00 15.92           O  
+ANISOU 2478  O   HOH A2341     2599   1491   1958     86    222    189       O  
+HETATM 2479  O   HOH A2342      29.466   7.128   6.215  1.00 13.14           O  
+ANISOU 2479  O   HOH A2342     1401   2073   1518   -100    303    206       O  
+HETATM 2480  O   HOH A2343      25.829   5.745   5.158  1.00 14.64           O  
+ANISOU 2480  O   HOH A2343     2411   2017   1132   -592    -81    204       O  
+HETATM 2481  O   HOH A2344      17.995   3.929  14.428  1.00  5.60           O  
+ANISOU 2481  O   HOH A2344      665    556    903     29    -50     34       O  
+HETATM 2482  O   HOH A2345      23.380  -6.626  25.695  1.00 23.68           O  
+ANISOU 2482  O   HOH A2345     3443   2994   2558   -558    -10   1098       O  
+HETATM 2483  O   HOH A2346      26.883  -2.433  31.978  1.00 15.92           O  
+ANISOU 2483  O   HOH A2346     2290   1956   1800    429   -305    264       O  
+HETATM 2484  O   HOH A2347      21.805  -6.542  34.750  1.00 25.95           O  
+ANISOU 2484  O   HOH A2347     3410   3319   3130   -151    -62    152       O  
+HETATM 2485  O   HOH A2348      28.736  -4.295  32.429  1.00 22.84           O  
+ANISOU 2485  O   HOH A2348     2492   2557   3628    420   -200    162       O  
+HETATM 2486  O   HOH A2349      26.844  -8.708  30.400  1.00 21.42           O  
+ANISOU 2486  O   HOH A2349     3099   2293   2745    268     97    218       O  
+HETATM 2487  O   HOH A2350      25.809  -7.402  27.835  1.00 23.74           O  
+ANISOU 2487  O   HOH A2350     3323   2357   3340    142    422    -35       O  
+HETATM 2488  O   HOH A2351      21.933  -6.509  28.224  1.00 25.61           O  
+ANISOU 2488  O   HOH A2351     4182   2657   2889    -82   -109    186       O  
+HETATM 2489  O   HOH A2352      22.290  -4.017  38.341  1.00 21.11           O  
+ANISOU 2489  O   HOH A2352     3460   2718   1840    229   -198    213       O  
+HETATM 2490  O   HOH A2353      28.874   4.297  29.747  1.00 10.15           O  
+ANISOU 2490  O   HOH A2353     1180   1832    842    264   -256     52       O  
+HETATM 2491  O   HOH A2354      35.807   7.659   6.566  1.00 16.07           O  
+ANISOU 2491  O   HOH A2354     1369   2901   1835    155    294    953       O  
+HETATM 2492  O   HOH A2355      30.143   7.312  10.227  1.00  8.12           O  
+ANISOU 2492  O   HOH A2355      965   1267    852    135    -22     33       O  
+HETATM 2493  O   HOH A2356      33.468   9.242   6.006  1.00 13.56           O  
+ANISOU 2493  O   HOH A2356     1405   1766   1980    -49    367    247       O  
+HETATM 2494  O   HOH A2357      34.762  -3.011   5.338  1.00 26.82           O  
+ANISOU 2494  O   HOH A2357     3897   3223   3070    109    543   -414       O  
+HETATM 2495  O   HOH A2358      35.213   1.385   1.928  1.00 28.67           O  
+ANISOU 2495  O   HOH A2358     3908   3290   3694    -69    237   -112       O  
+HETATM 2496  O   HOH A2359      37.912  -0.919   5.306  1.00 17.57           O  
+ANISOU 2496  O   HOH A2359     2364   2435   1875    519    878    -92       O  
+HETATM 2497  O   HOH A2360      43.781  -6.932   4.260  1.00 33.91           O  
+ANISOU 2497  O   HOH A2360     4043   4579   4261   -147     34    183       O  
+HETATM 2498  O   HOH A2361      42.696  -9.242   4.245  1.00 35.17           O  
+ANISOU 2498  O   HOH A2361     4673   4770   3919   -125    -75     49       O  
+HETATM 2499  O   HOH A2362      47.660  -5.292   7.515  1.00 35.48           O  
+ANISOU 2499  O   HOH A2362     4691   4419   4370    105   -122     67       O  
+HETATM 2500  O   HOH A2363      39.786  -6.273   2.308  1.00 25.43           O  
+ANISOU 2500  O   HOH A2363     4196   3105   2358    252    201   -241       O  
+HETATM 2501  O   HOH A2364      46.364  -6.558   5.266  1.00 23.95           O  
+ANISOU 2501  O   HOH A2364     3228   3135   2737    -39   -294      1       O  
+HETATM 2502  O   HOH A2365      39.932   1.812   6.806  1.00 18.03           O  
+ANISOU 2502  O   HOH A2365     2120   2135   2592   -177    246    594       O  
+HETATM 2503  O   HOH A2366      43.024   0.808  14.497  1.00 31.53           O  
+ANISOU 2503  O   HOH A2366     3950   4044   3985    194    201   -401       O  
+HETATM 2504  O   HOH A2367      42.867  -4.411  11.249  1.00 47.36           O  
+ANISOU 2504  O   HOH A2367     6107   5865   6023    117     35    -39       O  
+HETATM 2505  O   HOH A2368      43.286  -1.775  13.607  1.00 20.93           O  
+ANISOU 2505  O   HOH A2368     2335   2483   3133    -92    460   -496       O  
+HETATM 2506  O   HOH A2369      40.002   8.269  11.002  1.00 21.81           O  
+ANISOU 2506  O   HOH A2369     3799   2461   2025   -236   -173    375       O  
+HETATM 2507  O   HOH A2370      34.187   2.504  10.093  1.00  7.46           O  
+ANISOU 2507  O   HOH A2370      875    925   1034    -77    145     43       O  
+HETATM 2508  O   HOH A2371      29.284   4.754  16.335  1.00  6.54           O  
+ANISOU 2508  O   HOH A2371      758    837    890    -36   -114    155       O  
+HETATM 2509  O   HOH A2372      30.404  -0.448  16.310  1.00  6.69           O  
+ANISOU 2509  O   HOH A2372      879    646   1017     56    149     28       O  
+HETATM 2510  O   HOH A2373      35.323   5.301  32.972  1.00 63.25           O  
+ANISOU 2510  O   HOH A2373     7970   8051   8011      9     -7     53       O  
+HETATM 2511  O   HOH A2374      36.710   4.001  28.005  1.00 23.79           O  
+ANISOU 2511  O   HOH A2374     2957   3346   2735    288   -159    220       O  
+HETATM 2512  O   HOH A2375      29.037   9.657  36.529  1.00 27.63           O  
+ANISOU 2512  O   HOH A2375     3899   3515   3083    -28    227   -478       O  
+HETATM 2513  O   HOH A2376      28.080   6.132  36.268  1.00 22.93           O  
+ANISOU 2513  O   HOH A2376     3950   2854   1908    188    143    220       O  
+HETATM 2514  O   HOH A2377      31.950   8.395  35.268  1.00 25.53           O  
+ANISOU 2514  O   HOH A2377     3438   3401   2859     30   -211    319       O  
+HETATM 2515  O   HOH A2378      31.129  12.802  35.183  1.00 22.95           O  
+ANISOU 2515  O   HOH A2378     2868   3166   2684     -4   -127    241       O  
+HETATM 2516  O   HOH A2379      34.884   7.881  32.185  1.00 21.26           O  
+ANISOU 2516  O   HOH A2379     2122   2934   3021    252   -376   -180       O  
+HETATM 2517  O   HOH A2380      29.478  14.892  32.887  1.00 19.90           O  
+ANISOU 2517  O   HOH A2380     3200   2148   2212     60   -779    -80       O  
+HETATM 2518  O   HOH A2381      20.836   9.543  35.809  1.00 34.27           O  
+ANISOU 2518  O   HOH A2381     4466   4489   4064   -119    -59    -37       O  
+HETATM 2519  O   HOH A2382      23.959  11.245  40.138  1.00 45.84           O  
+ANISOU 2519  O   HOH A2382     5953   5822   5642     23    -60     68       O  
+HETATM 2520  O   HOH A2383      21.624  14.975  39.433  1.00 26.37           O  
+ANISOU 2520  O   HOH A2383     3472   3584   2964    208     -2   -194       O  
+HETATM 2521  O   HOH A2384      27.712  11.996  36.509  1.00 20.00           O  
+ANISOU 2521  O   HOH A2384     1946   3674   1979    222    259    192       O  
+HETATM 2522  O   HOH A2385      21.883  21.332  31.104  1.00 19.30           O  
+ANISOU 2522  O   HOH A2385     2667   2589   2074     29    479    -57       O  
+HETATM 2523  O   HOH A2386      26.931  14.202  34.689  1.00 15.53           O  
+ANISOU 2523  O   HOH A2386     1603   2448   1850   -184    235   -474       O  
+HETATM 2524  O   HOH A2387      20.111   5.796  40.743  1.00 27.41           O  
+ANISOU 2524  O   HOH A2387     4014   3529   2868     31    185    247       O  
+HETATM 2525  O   HOH A2388      15.817  13.182  38.191  1.00 15.88           O  
+ANISOU 2525  O   HOH A2388     1990   2401   1642     38    592    -48       O  
+HETATM 2526  O   HOH A2389      23.714  17.953  41.350  1.00 74.90           O  
+ANISOU 2526  O   HOH A2389     9380   9476   9602     -7      1      2       O  
+HETATM 2527  O   HOH A2390      23.944  18.654  35.780  1.00 25.60           O  
+ANISOU 2527  O   HOH A2390     3521   3474   2731   -193   -441   -494       O  
+HETATM 2528  O   HOH A2391      22.705  20.583  35.177  1.00 36.14           O  
+ANISOU 2528  O   HOH A2391     4815   4592   4323     22    101     75       O  
+HETATM 2529  O   HOH A2392      21.371  19.681  41.747  1.00 31.86           O  
+ANISOU 2529  O   HOH A2392     3819   4351   3933    170    -53     72       O  
+HETATM 2530  O   HOH A2393      19.288  15.895  40.405  1.00 27.20           O  
+ANISOU 2530  O   HOH A2393     3288   4207   2836     30    391    -36       O  
+HETATM 2531  O   HOH A2394      24.863  21.287  38.801  1.00 25.99           O  
+ANISOU 2531  O   HOH A2394     3582   3427   2863   -450   -708   -136       O  
+HETATM 2532  O   HOH A2395      20.388  20.252  33.183  1.00 20.64           O  
+ANISOU 2532  O   HOH A2395     2987   2750   2105      0    757   -354       O  
+HETATM 2533  O   HOH A2396      10.623  15.762  33.954  1.00 21.88           O  
+ANISOU 2533  O   HOH A2396     2958   3034   2319     55    495   -394       O  
+HETATM 2534  O   HOH A2397      10.989  17.669  39.105  1.00 20.49           O  
+ANISOU 2534  O   HOH A2397     3249   2167   2369    512    619   -566       O  
+HETATM 2535  O   HOH A2398      18.366  21.983  33.256  1.00 25.95           O  
+ANISOU 2535  O   HOH A2398     2760   3424   3675     35    260   -158       O  
+HETATM 2536  O   HOH A2399      17.211  22.997  29.730  1.00 29.09           O  
+ANISOU 2536  O   HOH A2399     3720   3533   3799   -231    331    -95       O  
+HETATM 2537  O   HOH B2001      18.202  15.598 -14.034  1.00 38.40           O  
+ANISOU 2537  O   HOH B2001     4782   5029   4780    -38    -73     -8       O  
+HETATM 2538  O   HOH B2002      23.882  16.960 -14.762  1.00 37.25           O  
+ANISOU 2538  O   HOH B2002     4565   4558   5030     47     -6    -54       O  
+HETATM 2539  O   HOH B2003      28.901  10.594  -9.420  1.00 31.63           O  
+ANISOU 2539  O   HOH B2003     4064   3989   3965     71    161    -13       O  
+HETATM 2540  O   HOH B2004      24.085  10.537  -9.249  1.00 31.99           O  
+ANISOU 2540  O   HOH B2004     3714   3829   4609   -137    215    -73       O  
+HETATM 2541  O   HOH B2005      29.815   9.876 -15.600  1.00 17.71           O  
+ANISOU 2541  O   HOH B2005     2666   1896   2167   -223   -255   -170       O  
+HETATM 2542  O   HOH B2006      32.684  11.271 -15.673  1.00 17.23           O  
+ANISOU 2542  O   HOH B2006     2474   2416   1657    610    -72   -255       O  
+HETATM 2543  O   HOH B2007      32.749   9.810  -8.596  1.00 14.13           O  
+ANISOU 2543  O   HOH B2007     2815    887   1666   -264    169    175       O  
+HETATM 2544  O   HOH B2008      33.955  11.894  -6.965  1.00 31.45           O  
+ANISOU 2544  O   HOH B2008     4023   4073   3853     32    271     99       O  
+HETATM 2545  O   HOH B2009      28.445  21.063  -7.629  1.00 18.88           O  
+ANISOU 2545  O   HOH B2009     1666   2020   3485     11    227   -779       O  
+HETATM 2546  O   HOH B2010      36.010  16.662  -8.512  1.00 10.08           O  
+ANISOU 2546  O   HOH B2010     1245   1368   1214    123    101    144       O  
+HETATM 2547  O   HOH B2011      35.929  14.873  -6.232  1.00 28.57           O  
+ANISOU 2547  O   HOH B2011     3404   3686   3763     54    -81     92       O  
+HETATM 2548  O   HOH B2012      30.562  19.630  -3.863  1.00 22.76           O  
+ANISOU 2548  O   HOH B2012     2713   2727   3204    296    483   -120       O  
+HETATM 2549  O   HOH B2013      36.515  18.045  -3.258  1.00 22.70           O  
+ANISOU 2549  O   HOH B2013     1763   3413   3448     10   -302   -403       O  
+HETATM 2550  O   HOH B2014      29.000   7.794  -9.725  1.00 28.05           O  
+ANISOU 2550  O   HOH B2014     3187   3522   3948    342      9    -22       O  
+HETATM 2551  O   HOH B2015      32.955  18.409  -1.265  1.00 36.44           O  
+ANISOU 2551  O   HOH B2015     4692   4528   4624     46    242     14       O  
+HETATM 2552  O   HOH B2016      28.497  10.874  -2.246  1.00 22.81           O  
+ANISOU 2552  O   HOH B2016     3138   2511   3017    250    231   -400       O  
+HETATM 2553  O   HOH B2017      34.101  16.308  -1.676  1.00 18.37           O  
+ANISOU 2553  O   HOH B2017     2213   2636   2130   -262    -59    307       O  
+HETATM 2554  O   HOH B2018      29.083   8.675  -5.370  1.00 36.40           O  
+ANISOU 2554  O   HOH B2018     4564   4510   4756    102    143   -138       O  
+HETATM 2555  O   HOH B2019      25.633   9.974  -3.820  1.00 36.44           O  
+ANISOU 2555  O   HOH B2019     5036   4234   4572    -15    143    -99       O  
+HETATM 2556  O   HOH B2020      33.028  13.527  -3.547  1.00 14.83           O  
+ANISOU 2556  O   HOH B2020     1866   1731   2037    231     42    259       O  
+HETATM 2557  O   HOH B2021      30.759  11.717  -7.999  1.00 24.24           O  
+ANISOU 2557  O   HOH B2021     3214   2548   3445    143   1171    253       O  
+HETATM 2558  O   HOH B2022      32.240  11.093  -4.539  1.00 21.08           O  
+ANISOU 2558  O   HOH B2022     2709   3218   2084   -202   -222    101       O  
+HETATM 2559  O   HOH B2023      30.738  11.696 -17.159  1.00 35.33           O  
+ANISOU 2559  O   HOH B2023     4449   4391   4584     -2    -67   -187       O  
+HETATM 2560  O   HOH B2024      29.635   7.308 -16.943  1.00 20.05           O  
+ANISOU 2560  O   HOH B2024     2347   1944   3324    155   -195   -181       O  
+HETATM 2561  O   HOH B2025      32.157  13.069  -0.872  1.00 17.55           O  
+ANISOU 2561  O   HOH B2025     2297   2626   1744    673     73    -95       O  
+HETATM 2562  O   HOH B2026      28.529  20.065  -2.068  1.00 22.50           O  
+ANISOU 2562  O   HOH B2026     2563   3038   2946    316    319    225       O  
+HETATM 2563  O   HOH B2027      27.743   7.059 -12.316  1.00 33.18           O  
+ANISOU 2563  O   HOH B2027     4123   4060   4422     10    170    173       O  
+HETATM 2564  O   HOH B2028      31.344  19.330   1.368  1.00 26.93           O  
+ANISOU 2564  O   HOH B2028     4455   2347   3427     97   -340   -124       O  
+HETATM 2565  O   HOH B2029      29.558  17.893   4.883  1.00 25.10           O  
+ANISOU 2565  O   HOH B2029     3131   2463   3941    150     90     14       O  
+HETATM 2566  O   HOH B2030      31.223  10.356  -2.155  1.00 24.35           O  
+ANISOU 2566  O   HOH B2030     2851   3515   2883     23    243    183       O  
+HETATM 2567  O   HOH B2031      26.756   8.895  -1.571  1.00 29.46           O  
+ANISOU 2567  O   HOH B2031     3571   3779   3841    -42    250   -412       O  
+HETATM 2568  O   HOH B2032      31.851  19.130   5.817  1.00 28.29           O  
+ANISOU 2568  O   HOH B2032     3277   3586   3883     96      2   -259       O  
+HETATM 2569  O   HOH B2033      29.425  20.617   0.293  1.00 29.42           O  
+ANISOU 2569  O   HOH B2033     3390   3342   4447     91     24    -74       O  
+HETATM 2570  O   HOH B2034      33.971  20.061   4.619  1.00 61.30           O  
+ANISOU 2570  O   HOH B2034     7806   7713   7769    -11     62    -54       O  
+HETATM 2571  O   HOH B2035      33.992  11.892   5.261  1.00 14.50           O  
+ANISOU 2571  O   HOH B2035     1573   1750   2186    128    398    293       O  
+HETATM 2572  O   HOH B2036      28.950   7.390  -1.962  1.00 72.84           O  
+ANISOU 2572  O   HOH B2036     9194   9246   9235      2    -34     -6       O  
+HETATM 2573  O   HOH B2037      33.642  14.681   7.812  1.00 29.79           O  
+ANISOU 2573  O   HOH B2037     4103   3871   3342   -344   -104   -158       O  
+HETATM 2574  O   HOH B2038      36.055  12.671   7.344  1.00 31.28           O  
+ANISOU 2574  O   HOH B2038     3424   4350   4111     39    165    307       O  
+HETATM 2575  O   HOH B2039      33.578  17.611   7.516  1.00 38.97           O  
+ANISOU 2575  O   HOH B2039     4780   5067   4958   -139    -77    -70       O  
+HETATM 2576  O   HOH B2040      27.289  17.072  12.268  1.00 24.12           O  
+ANISOU 2576  O   HOH B2040     2744   3557   2861   -400   -436    286       O  
+HETATM 2577  O   HOH B2041      31.172   8.900   7.498  1.00 10.87           O  
+ANISOU 2577  O   HOH B2041     1521   1069   1538    226    493    298       O  
+HETATM 2578  O   HOH B2042      32.095  15.054  10.447  1.00 22.92           O  
+ANISOU 2578  O   HOH B2042     3897   1537   3273   -206   -357   -134       O  
+HETATM 2579  O   HOH B2043      11.148   7.586   4.929  1.00 28.27           O  
+ANISOU 2579  O   HOH B2043     3795   3679   3265    -88     23    -19       O  
+HETATM 2580  O   HOH B2044      14.597  11.035   0.372  1.00 43.39           O  
+ANISOU 2580  O   HOH B2044     5586   5302   5596   -149     16    -14       O  
+HETATM 2581  O   HOH B2045      11.364   9.135   0.892  1.00 40.06           O  
+ANISOU 2581  O   HOH B2045     5020   5127   5073    -70   -104     -7       O  
+HETATM 2582  O   HOH B2046      29.683  15.061  12.396  1.00 20.41           O  
+ANISOU 2582  O   HOH B2046     3029   1827   2896   -344     -3    614       O  
+HETATM 2583  O   HOH B2047      18.865  18.867   9.955  1.00 15.67           O  
+ANISOU 2583  O   HOH B2047     2336   1922   1695    238   -100     48       O  
+HETATM 2584  O   HOH B2048      10.433  13.355   0.117  1.00 41.69           O  
+ANISOU 2584  O   HOH B2048     5181   5404   5253   -101     -4    123       O  
+HETATM 2585  O   HOH B2049      27.764  18.230 -13.561  1.00 21.56           O  
+ANISOU 2585  O   HOH B2049     2126   2383   3682   -116   -551   -792       O  
+HETATM 2586  O   HOH B2050      14.610  21.315  -9.710  1.00 25.82           O  
+ANISOU 2586  O   HOH B2050     3194   3372   3242     13   -774      1       O  
+HETATM 2587  O   HOH B2051      16.376  18.321 -11.843  1.00 41.07           O  
+ANISOU 2587  O   HOH B2051     5113   5277   5214    -47    140    -43       O  
+HETATM 2588  O   HOH B2052      14.914   5.267   3.483  1.00 31.00           O  
+ANISOU 2588  O   HOH B2052     4002   3745   4031    113    -61   -176       O  
+HETATM 2589  O   HOH B2053      13.373   8.171   4.184  1.00 32.05           O  
+ANISOU 2589  O   HOH B2053     3865   4367   3945    136     -3   -118       O  
+HETATM 2590  O   HOH B2054      14.080   4.601   6.729  1.00 14.85           O  
+ANISOU 2590  O   HOH B2054     2346   1632   1662    214   -308    357       O  
+HETATM 2591  O   HOH B2055      15.186  13.500  -4.754  1.00 37.22           O  
+ANISOU 2591  O   HOH B2055     4543   4846   4751    -57     29    -53       O  
+HETATM 2592  O   HOH B2056      14.917  17.408   4.336  1.00 10.47           O  
+ANISOU 2592  O   HOH B2056     1403   1294   1281    139     65    377       O  
+HETATM 2593  O   HOH B2057      13.631  11.938   3.453  1.00 37.42           O  
+ANISOU 2593  O   HOH B2057     4485   5193   4539   -226   -120    -58       O  
+HETATM 2594  O   HOH B2058      26.403   7.406   2.897  1.00 25.91           O  
+ANISOU 2594  O   HOH B2058     3673   3006   3164   -119   -136    316       O  
+HETATM 2595  O   HOH B2059      28.571  21.292  12.230  1.00 44.98           O  
+ANISOU 2595  O   HOH B2059     5772   5594   5723     29   -100    -46       O  
+HETATM 2596  O   HOH B2060      17.965  17.957   7.588  1.00 15.53           O  
+ANISOU 2596  O   HOH B2060     2018   1934   1949   -103    -15     72       O  
+HETATM 2597  O   HOH B2061      12.074  15.771   1.086  1.00 25.15           O  
+ANISOU 2597  O   HOH B2061     2250   3640   3665   -147    -48    283       O  
+HETATM 2598  O   HOH B2062      28.211  19.830   3.337  1.00 16.68           O  
+ANISOU 2598  O   HOH B2062     2090   1825   2420   -123   -590     52       O  
+HETATM 2599  O   HOH B2063      24.077  23.097  -2.271  1.00 14.28           O  
+ANISOU 2599  O   HOH B2063     2467   1565   1392   -972    428     50       O  
+HETATM 2600  O   HOH B2064      26.640  21.756  -3.422  1.00 19.03           O  
+ANISOU 2600  O   HOH B2064     2187   3326   1717   -278   -121    233       O  
+HETATM 2601  O   HOH B2065      26.660  24.156  -6.820  1.00 23.18           O  
+ANISOU 2601  O   HOH B2065     2551   3452   2803     25   -313     -5       O  
+HETATM 2602  O   HOH B2066      10.498  24.672  -1.239  1.00 32.98           O  
+ANISOU 2602  O   HOH B2066     4063   4088   4379   -134      3     -2       O  
+HETATM 2603  O   HOH B2067      25.390  16.836 -11.754  1.00 24.22           O  
+ANISOU 2603  O   HOH B2067     3543   2534   3125    491     26    103       O  
+HETATM 2604  O   HOH B2068      27.452  22.741  -8.270  1.00 26.36           O  
+ANISOU 2604  O   HOH B2068     3502   3585   2926     46     38     90       O  
+HETATM 2605  O   HOH B2069      26.325  24.544  -9.695  1.00 17.25           O  
+ANISOU 2605  O   HOH B2069     1360   2881   2313   -196    116    328       O  
+HETATM 2606  O   HOH B2070      25.210  18.979 -13.916  1.00 28.37           O  
+ANISOU 2606  O   HOH B2070     3623   3245   3911    488    -24   -397       O  
+HETATM 2607  O   HOH B2071      21.913  18.262 -16.116  1.00 28.95           O  
+ANISOU 2607  O   HOH B2071     3279   3403   4315    295     36   -136       O  
+HETATM 2608  O   HOH B2072      19.122  24.122 -12.604  1.00 24.94           O  
+ANISOU 2608  O   HOH B2072     3186   2712   3578   -277   -404   -306       O  
+HETATM 2609  O   HOH B2073      16.898  17.609  -9.397  1.00 26.03           O  
+ANISOU 2609  O   HOH B2073     2833   3736   3318    -87   -213    237       O  
+HETATM 2610  O   HOH B2074      17.032  15.070  -7.769  1.00 34.62           O  
+ANISOU 2610  O   HOH B2074     4111   4464   4577    -36    -31     67       O  
+HETATM 2611  O   HOH B2075      17.377  21.206  -9.131  1.00 17.27           O  
+ANISOU 2611  O   HOH B2075     1824   2751   1985    596    -64    217       O  
+HETATM 2612  O   HOH B2076      19.684   9.273  -5.068  1.00 43.95           O  
+ANISOU 2612  O   HOH B2076     5667   5458   5574    116    -68    -47       O  
+HETATM 2613  O   HOH B2077      17.781  13.276  -5.919  1.00 22.00           O  
+ANISOU 2613  O   HOH B2077     2996   2633   2730   -886   -408   -284       O  
+HETATM 2614  O   HOH B2078      22.966  10.611  -2.535  1.00 21.22           O  
+ANISOU 2614  O   HOH B2078     3537   2622   1904    657   -107   -204       O  
+HETATM 2615  O   HOH B2079      21.358   7.566  -0.095  1.00 34.45           O  
+ANISOU 2615  O   HOH B2079     4326   4040   4724   -202    141   -180       O  
+HETATM 2616  O   HOH B2080      23.058   9.743   0.148  1.00 13.91           O  
+ANISOU 2616  O   HOH B2080     2117   1628   1537    270    231     -1       O  
+HETATM 2617  O   HOH B2081      15.476   9.815   3.165  1.00 42.54           O  
+ANISOU 2617  O   HOH B2081     5630   5260   5273   -146     -1   -123       O  
+HETATM 2618  O   HOH B2082      28.099  17.169   7.664  1.00 24.57           O  
+ANISOU 2618  O   HOH B2082     3255   2799   3278   -122    720    -68       O  
+HETATM 2619  O   HOH B2083      27.396  10.966   6.563  1.00 11.82           O  
+ANISOU 2619  O   HOH B2083     1247   1645   1598    281    -23    234       O  
+HETATM 2620  O   HOH B2084      28.407  12.661  -0.245  1.00 15.16           O  
+ANISOU 2620  O   HOH B2084     1931   1966   1863    -13    291     83       O  
+HETATM 2621  O   HOH B2085      21.392  18.772   8.928  1.00 14.11           O  
+ANISOU 2621  O   HOH B2085     1837   1808   1715    160    -27    123       O  
+HETATM 2622  O   HOH B2086      25.579   9.575   1.116  1.00 17.91           O  
+ANISOU 2622  O   HOH B2086     1975   1992   2836    170    174   -102       O  
+HETATM 2623  O   HOH B2087      28.592  21.463   5.402  1.00 83.06           O  
+ANISOU 2623  O   HOH B2087    10501  10480  10576     -3     16    -21       O  
+HETATM 2624  O   HOH B2088      28.960  20.557   9.596  1.00 34.42           O  
+ANISOU 2624  O   HOH B2088     4262   4584   4232    129    -43     -6       O  
+HETATM 2625  O   HOH B2089      21.873  21.504   8.538  1.00 17.56           O  
+ANISOU 2625  O   HOH B2089     2434   2398   1840    446    184    328       O  
+HETATM 2626  O   HOH B2090      27.674  18.719   6.018  1.00 19.77           O  
+ANISOU 2626  O   HOH B2090     2350   2409   2751    106    129     69       O  
+HETATM 2627  O   HOH B2091      26.155  23.332   1.085  1.00 23.62           O  
+ANISOU 2627  O   HOH B2091     2829   2606   3539   -483    969    453       O  
+HETATM 2628  O   HOH B2092      23.574  24.985   3.055  1.00 27.33           O  
+ANISOU 2628  O   HOH B2092     3425   2873   4087    179     74   -226       O  
+HETATM 2629  O   HOH B2093      23.459  27.927  -2.202  1.00 24.09           O  
+ANISOU 2629  O   HOH B2093     2961   3317   2872   -111   -108   -196       O  
+HETATM 2630  O   HOH B2094      20.295  30.902  -0.047  1.00 22.10           O  
+ANISOU 2630  O   HOH B2094     3131   3413   1851    302   -296   -545       O  
+HETATM 2631  O   HOH B2095      22.176  29.504  -0.528  1.00 21.13           O  
+ANISOU 2631  O   HOH B2095     3249   2919   1858   -370    -28    282       O  
+HETATM 2632  O   HOH B2096      13.042  21.431   7.130  1.00 23.00           O  
+ANISOU 2632  O   HOH B2096     2987   3186   2563    669    489    669       O  
+HETATM 2633  O   HOH B2097      17.638  24.247   4.705  1.00 24.26           O  
+ANISOU 2633  O   HOH B2097     2765   2982   3469   -265    303    149       O  
+HETATM 2634  O   HOH B2098      11.948  19.277   4.069  1.00 18.58           O  
+ANISOU 2634  O   HOH B2098     2081   1914   3061    -49    609    926       O  
+HETATM 2635  O   HOH B2099      17.033  23.326   7.456  1.00 13.27           O  
+ANISOU 2635  O   HOH B2099     2297   1352   1390   -318    -59   -546       O  
+HETATM 2636  O   HOH B2100      15.846  25.047   3.073  1.00  8.78           O  
+ANISOU 2636  O   HOH B2100     1382   1002    949    191    125    202       O  
+HETATM 2637  O   HOH B2101      11.677  19.291  -0.049  1.00 12.63           O  
+ANISOU 2637  O   HOH B2101     1461   1461   1874   -278    111    157       O  
+HETATM 2638  O   HOH B2102      10.930  30.038  -1.658  1.00 31.05           O  
+ANISOU 2638  O   HOH B2102     3916   3974   3907    212   -138    110       O  
+HETATM 2639  O   HOH B2103      15.668  29.509   2.305  1.00 23.27           O  
+ANISOU 2639  O   HOH B2103     2780   2638   3421   -631   -550   -384       O  
+HETATM 2640  O   HOH B2104      11.053  26.492  -2.207  1.00 29.93           O  
+ANISOU 2640  O   HOH B2104     3246   3937   4189    143    -23   -233       O  
+HETATM 2641  O   HOH B2105      17.763  23.770 -10.201  1.00 25.97           O  
+ANISOU 2641  O   HOH B2105     3243   3516   3107   -801   -510     15       O  
+HETATM 2642  O   HOH B2106      19.981  30.971  -8.659  1.00 16.35           O  
+ANISOU 2642  O   HOH B2106     2253   1920   2035   -109   -231    641       O  
+HETATM 2643  O   HOH B2107      17.511  30.475  -0.389  1.00 36.15           O  
+ANISOU 2643  O   HOH B2107     4551   4799   4384    -77    -95    -29       O  
+HETATM 2644  O   HOH B2108      23.323  25.985  -4.089  1.00 18.68           O  
+ANISOU 2644  O   HOH B2108     2576   2516   2004    -78   -262    274       O  
+HETATM 2645  O   HOH B2109      22.539  30.955  -4.917  1.00 19.14           O  
+ANISOU 2645  O   HOH B2109     2445   2835   1992   -571     27     38       O  
+HETATM 2646  O   HOH B2110      22.619  30.605  -7.605  1.00 16.60           O  
+ANISOU 2646  O   HOH B2110     2162   2614   1530   -541   -181    210       O  
+HETATM 2647  O   HOH B2111      20.813  29.312 -10.690  1.00 14.69           O  
+ANISOU 2647  O   HOH B2111     1701   1859   2018   -354   -685    522       O  
+CONECT   48 1038                                                                
+CONECT  189  308                                                                
+CONECT  308  189                                                                
+CONECT  399 2136                                                                
+CONECT  412 2136                                                                
+CONECT  436 2136                                                                
+CONECT  476 2136                                                                
+CONECT  842 1591                                                                
+CONECT  884 1373                                                                
+CONECT 1038   48                                                                
+CONECT 1118 1230                                                                
+CONECT 1230 1118                                                                
+CONECT 1311 1480                                                                
+CONECT 1373  884                                                                
+CONECT 1480 1311                                                                
+CONECT 1591  842                                                                
+CONECT 1722 1943                                                                
+CONECT 1828 2000                                                                
+CONECT 1912 2122                                                                
+CONECT 1943 1722                                                                
+CONECT 1949 2092                                                                
+CONECT 2000 1828                                                                
+CONECT 2092 1949                                                                
+CONECT 2122 1912                                                                
+CONECT 2136  399  412  436  476                                                 
+CONECT 2136 2245 2270                                                           
+CONECT 2245 2136                                                                
+CONECT 2270 2136                                                                
+MASTER     1199    0    2    4   16    0    3    6 2645    2   28   22          
+END                                                                             

--- a/test/2uuy/golden/2uuy_prediction.txt
+++ b/test/2uuy/golden/2uuy_prediction.txt
@@ -1,0 +1,31 @@
+[+] Parsed structure file 2uuy (2 chains, 275 residues)
+[+] No. of intermolecular contacts: 58
+[+] No. of charged-charged contacts: 4
+[+] No. of charged-polar contacts: 6
+[+] No. of charged-apolar contacts: 21
+[+] No. of polar-polar contacts: 0
+[+] No. of apolar-polar contacts: 13
+[+] No. of apolar-apolar contacts: 14
+[+] ALA: 7
+[+] CYS: 13
+[+] GLU: 2
+[+] ASP: 2
+[+] GLY: 11
+[+] PHE: 10
+[+] ILE: 0
+[+] HIS: 5
+[+] LYS: 19
+[+] MET: 0
+[+] LEU: 8
+[+] ASN: 0
+[+] GLN: 9
+[+] PRO: 0
+[+] SER: 8
+[+] ARG: 7
+[+] THR: 2
+[+] TRP: 3
+[+] VAL: 2
+[+] TYR: 8
+[+] Link density: 0.1818
+[+] Class: BIO
+

--- a/test/2uuy/test_2uuy.py
+++ b/test/2uuy/test_2uuy.py
@@ -1,0 +1,25 @@
+"""Regression tests for 2uuy complex"""
+
+import shutil
+import os
+import filecmp
+from test.regression import RegressionTest
+
+
+class TestRegression1ppe(RegressionTest):
+
+    def setup(self):
+        self.path = os.path.dirname(os.path.realpath(__file__))
+        self.test_path = self.path + '/scratch_2uuy/'
+        self.ini_test_path()
+        self.golden_data_path = os.path.join(os.path.normpath(os.path.dirname(os.path.realpath(__file__))), 'golden')
+
+    def teardown(self):
+        self.clean_test_path()
+
+    def test_1ppe(self):
+        os.chdir(self.test_path)
+        command = "python ../../../interface_classifier.py {} | tail -n +2 > prediction".format(os.path.join(self.golden_data_path, '2uuy.pdb'))
+        os.system(command)
+
+        assert filecmp.cmp(os.path.join(self.golden_data_path, '2uuy_prediction.txt'), os.path.join(self.test_path, 'prediction'))

--- a/test/regression.py
+++ b/test/regression.py
@@ -1,0 +1,23 @@
+import shutil
+import os
+
+
+class RegressionTest(object):
+    def __init__(self):
+        self.path = ''
+        self.test_path = ''
+        self.golden_data_path = ''
+
+    def ini_test_path(self):
+        try:
+            if self.test_path:
+                shutil.rmtree(self.test_path)
+        except OSError:
+            pass
+        os.mkdir(self.test_path)
+
+    def clean_test_path(self):
+        try:
+            shutil.rmtree(self.test_path)
+        except OSError:
+            pass


### PR DESCRIPTION
New:
- Tests with and without selection of chains for 1ppe and 2uuy.
- Tested with Python 2.7 and Python 3.7.
- FreeSASA 1.0, 1.1 and 2.x series supported.
- Minor changes in importing.