### PR TITLE
Add specific scikit-learn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tar -xzvf freesasa-1.0.tar.gz
 cd freesasa-1.0
 ./configure && make && make install
 
-pip3 install scikit-learn
+pip3 install scikit-learn==0.22
 
 git clone http://github.com/haddocking/interface-classifier
 


### PR DESCRIPTION
The classifier binary looks for the module `sklearn.ensemble.forest` but the name of this module was changed to `sklearn.ensemble._forest` [in this commit](https://github.com/scikit-learn/scikit-learn/commit/437ca0553ce8d97571cecc3f4df8493e5cf959c5#diff-ea2829791da4e865dd5e80e6bdd9bdb5c5d5b89cd9f620b25f4555946dfee70a) which then breaks prodigy-cryst with a `ModuleNotFoundError: No module named 'sklearn.ensemble.forest'`

The solution is to install an older version `scikit-learn==0.22`, thus I updated the install instructions.